### PR TITLE
Fix long transaction descriptions overlapping the amount

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -40,8 +40,8 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
           <View key={index} style={styles.item}>
             <View style={styles.itemLeft}>
               <Text style={styles.itemIcon}>{isIncoming ? '↓' : '↑'}</Text>
-              <View>
-                <Text style={styles.itemDescription}>
+              <View style={styles.itemDescriptionContainer}>
+                <Text style={styles.itemDescription} numberOfLines={1}>
                   {item.description || (isIncoming ? 'Received' : 'Sent')}
                 </Text>
                 <Text style={styles.itemDate}>{dateStr}</Text>
@@ -92,6 +92,9 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: '700',
     color: colors.brandPink,
+  },
+  itemDescriptionContainer: {
+    flex: 1,
   },
   itemDescription: {
     fontSize: 14,


### PR DESCRIPTION
## Summary
- Constrains transaction description text so it doesn't overflow into the sats amount column
- Adds numberOfLines={1} to truncate long descriptions with ellipsis  
- Adds flex: 1 to the description container to respect the amount column's space

Fixes: https://github.com/BenGWeeks/lightning-piggy-mobile/issues/8

## Test plan
- [ ] View Home screen with transactions that have long descriptions
- [ ] Verify description truncates with ellipsis and does not overlap the amount

Generated with [Claude Code](https://claude.com/claude-code)