### PR TITLE
Add transaction detail bottom sheet with Boltz support DM

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-secure-store": "~55.0.9",
     "expo-status-bar": "~55.0.4",
     "light-bolt11-decoder": "^3.2.0",
+    "lucide-react-native": "^1.7.0",
     "message-port-polyfill": "^0.2.0",
     "nostr-tools": "^2.23.3",
     "react": "19.2.0",

--- a/src/components/FeedbackSheet.tsx
+++ b/src/components/FeedbackSheet.tsx
@@ -25,6 +25,11 @@ interface Props {
   isLoggedIn: boolean;
   signerType: string | null;
   onLoginPress: () => void;
+  title?: string;
+  subtitle?: string;
+  initialMessage?: string;
+  successTitle?: string;
+  successMessage?: string;
 }
 
 const FeedbackSheet: React.FC<Props> = ({
@@ -34,6 +39,11 @@ const FeedbackSheet: React.FC<Props> = ({
   isLoggedIn,
   signerType,
   onLoginPress,
+  title = 'Send Feedback',
+  subtitle = 'Your message will be sent as an encrypted Nostr DM to the Lightning Piggy team.',
+  initialMessage = '',
+  successTitle = 'Message Sent',
+  successMessage = 'Thank you for your feedback!',
 }) => {
   const sheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ['55%'], []);
@@ -42,7 +52,7 @@ const FeedbackSheet: React.FC<Props> = ({
 
   useEffect(() => {
     if (visible) {
-      setMessage('');
+      setMessage(initialMessage);
       setSending(false);
       sheetRef.current?.present();
     } else {
@@ -70,9 +80,7 @@ const FeedbackSheet: React.FC<Props> = ({
 
       const result = await onSend(fullMessage);
       if (result.success) {
-        Alert.alert('Feedback Sent', 'Thank you for your feedback!', [
-          { text: 'OK', onPress: onClose },
-        ]);
+        Alert.alert(successTitle, successMessage, [{ text: 'OK', onPress: onClose }]);
       } else {
         Alert.alert('Error', result.error || 'Failed to send feedback.');
       }
@@ -112,10 +120,8 @@ const FeedbackSheet: React.FC<Props> = ({
       backgroundStyle={styles.sheetBackground}
     >
       <BottomSheetView style={styles.content}>
-        <Text style={styles.title}>Send Feedback</Text>
-        <Text style={styles.subtitle}>
-          Your message will be sent as an encrypted Nostr DM to the Lightning Piggy team.
-        </Text>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.subtitle}>{subtitle}</Text>
 
         {!isLoggedIn ? (
           <View style={styles.loginPrompt}>

--- a/src/components/FeedbackSheet.tsx
+++ b/src/components/FeedbackSheet.tsx
@@ -29,6 +29,7 @@ interface Props {
   title?: string;
   subtitle?: string;
   initialMessage?: string;
+  messagePrefix?: string;
   successTitle?: string;
   successMessage?: string;
 }
@@ -43,6 +44,7 @@ const FeedbackSheet: React.FC<Props> = ({
   title = 'Send Feedback',
   subtitle = 'Your message will be sent as an encrypted Nostr DM to the Lightning Piggy team.',
   initialMessage = '',
+  messagePrefix = '[Feedback]',
   successTitle = 'Message Sent',
   successMessage = 'Thank you for your feedback!',
 }) => {
@@ -77,7 +79,7 @@ const FeedbackSheet: React.FC<Props> = ({
     setSending(true);
     try {
       const deviceInfo = `${Platform.OS} ${Platform.Version}`;
-      const fullMessage = `[Feedback] ${trimmed}\n\n---\nDevice: ${deviceInfo}`;
+      const fullMessage = `${messagePrefix} ${trimmed}\n\n---\nDevice: ${deviceInfo}`;
 
       const result = await onSend(fullMessage);
       if (result.success) {

--- a/src/components/FeedbackSheet.tsx
+++ b/src/components/FeedbackSheet.tsx
@@ -17,13 +17,14 @@ import {
   BottomSheetTextInput,
 } from '@gorhom/bottom-sheet';
 import { colors } from '../styles/theme';
+import type { SignerType } from '../types/nostr';
 
 interface Props {
   visible: boolean;
   onClose: () => void;
   onSend: (message: string) => Promise<{ success: boolean; error?: string }>;
   isLoggedIn: boolean;
-  signerType: string | null;
+  signerType: SignerType | null;
   onLoginPress: () => void;
   title?: string;
   subtitle?: string;
@@ -104,8 +105,6 @@ const FeedbackSheet: React.FC<Props> = ({
     ),
     [],
   );
-
-  if (!visible) return null;
 
   const canSend = isLoggedIn && signerType === 'nsec' && message.trim().length > 0 && !sending;
 

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -11,6 +11,7 @@ import * as Clipboard from 'expo-clipboard';
 import * as nip19 from 'nostr-tools/nip19';
 import CopyIcon from './icons/CopyIcon';
 import FeedbackSheet from './FeedbackSheet';
+import NostrLoginSheet from './NostrLoginSheet';
 import { colors } from '../styles/theme';
 import { satsToFiatString } from '../services/fiatService';
 import { useWallet } from '../contexts/WalletContext';
@@ -72,10 +73,19 @@ const TransactionDetailSheet: React.FC<Props> = ({ visible, onClose, transaction
   const { btcPrice, currency } = useWallet();
   const { isLoggedIn, signerType, sendDirectMessage } = useNostr();
   const [boltzSupportOpen, setBoltzSupportOpen] = useState(false);
+  const [loginSheetOpen, setLoginSheetOpen] = useState(false);
+  const lastTransactionRef = useRef<Nip47Transaction | null>(null);
+
+  // Retain last transaction so the modal stays mounted during dismiss animation
+  if (transaction) {
+    lastTransactionRef.current = transaction;
+  }
+  const displayTransaction = transaction ?? lastTransactionRef.current;
 
   useEffect(() => {
     if (visible) {
       setBoltzSupportOpen(false);
+      setLoginSheetOpen(false);
       sheetRef.current?.present();
     } else {
       sheetRef.current?.dismiss();
@@ -147,14 +157,14 @@ const TransactionDetailSheet: React.FC<Props> = ({ visible, onClose, transaction
     [sendDirectMessage],
   );
 
-  if (!transaction) return null;
+  if (!displayTransaction) return null;
 
-  const isIncoming = transaction.type === 'incoming';
-  const amountSats = Math.abs(transaction.amount);
+  const isIncoming = displayTransaction.type === 'incoming';
+  const amountSats = Math.abs(displayTransaction.amount);
   const fiatStr = satsToFiatString(amountSats, btcPrice, currency);
-  const date = transaction.settled_at || transaction.created_at;
+  const date = displayTransaction.settled_at || displayTransaction.created_at;
   const dateStr = date ? new Date(date * 1000).toLocaleString() : '';
-  const status = formatStatus(transaction.state);
+  const status = formatStatus(displayTransaction.state);
 
   return (
     <>
@@ -205,43 +215,43 @@ const TransactionDetailSheet: React.FC<Props> = ({ visible, onClose, transaction
 
           {/* Details */}
           <View style={styles.detailsSection}>
-            {transaction.description ? (
+            {displayTransaction.description ? (
               <View style={styles.detailRow}>
                 <Text style={styles.detailLabel}>Description</Text>
-                <Text style={styles.detailValueText}>{transaction.description}</Text>
+                <Text style={styles.detailValueText}>{displayTransaction.description}</Text>
               </View>
             ) : null}
 
-            {transaction.payment_hash ? (
+            {displayTransaction.payment_hash ? (
               <CopyableRow
                 label="Payment Hash"
-                value={truncateHash(transaction.payment_hash)}
-                fullValue={transaction.payment_hash}
+                value={truncateHash(displayTransaction.payment_hash)}
+                fullValue={displayTransaction.payment_hash}
               />
             ) : null}
 
-            {transaction.preimage ? (
+            {displayTransaction.preimage ? (
               <CopyableRow
                 label="Preimage"
-                value={truncateHash(transaction.preimage)}
-                fullValue={transaction.preimage}
+                value={truncateHash(displayTransaction.preimage)}
+                fullValue={displayTransaction.preimage}
               />
             ) : null}
 
-            {transaction.fees_paid > 0 ? (
+            {displayTransaction.fees_paid > 0 ? (
               <View style={styles.detailRow}>
                 <Text style={styles.detailLabel}>Fee Paid</Text>
                 <Text style={styles.detailValueText}>
-                  {transaction.fees_paid.toLocaleString()} sats
+                  {displayTransaction.fees_paid.toLocaleString()} sats
                 </Text>
               </View>
             ) : null}
 
-            {transaction.invoice ? (
+            {displayTransaction.invoice ? (
               <CopyableRow
                 label="Invoice"
-                value={truncateHash(transaction.invoice, 12, 8)}
-                fullValue={transaction.invoice}
+                value={truncateHash(displayTransaction.invoice, 12, 8)}
+                fullValue={displayTransaction.invoice}
               />
             ) : null}
           </View>
@@ -268,13 +278,16 @@ const TransactionDetailSheet: React.FC<Props> = ({ visible, onClose, transaction
         signerType={signerType}
         onLoginPress={() => {
           setBoltzSupportOpen(false);
+          setLoginSheetOpen(true);
         }}
         title="Contact Boltz Support"
         subtitle="Send an encrypted Nostr DM to Boltz with your transaction details."
         initialMessage={buildSupportMessage()}
+        messagePrefix="[Boltz Support Request]"
         successTitle="Message Sent"
         successMessage="Your support request has been sent to Boltz."
       />
+      <NostrLoginSheet visible={loginSheetOpen} onClose={() => setLoginSheetOpen(false)} />
     </>
   );
 };

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -1,0 +1,407 @@
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, BackHandler } from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet';
+import { ArrowDown, ArrowUp } from 'lucide-react-native';
+import * as Clipboard from 'expo-clipboard';
+import * as nip19 from 'nostr-tools/nip19';
+import CopyIcon from './icons/CopyIcon';
+import FeedbackSheet from './FeedbackSheet';
+import { colors } from '../styles/theme';
+import { satsToFiatString } from '../services/fiatService';
+import { useWallet } from '../contexts/WalletContext';
+import { useNostr } from '../contexts/NostrContext';
+import type { Nip47Transaction } from '../services/nwcService';
+
+const BOLTZ_SUPPORT_NPUB = 'npub1psm37hke2pmxzdzraqe3cjmqs28dv77da74pdx8mtn5a0vegtlas9q8970';
+
+function truncateHash(value: string, leading = 8, trailing = 8): string {
+  if (value.length <= leading + trailing + 3) return value;
+  return `${value.slice(0, leading)}...${value.slice(-trailing)}`;
+}
+
+function formatStatus(state: string): { label: string; color: string } {
+  switch (state) {
+    case 'settled':
+      return { label: 'Confirmed', color: colors.green };
+    case 'pending':
+      return { label: 'Pending', color: '#FF9800' };
+    case 'failed':
+      return { label: 'Failed', color: colors.red };
+    case 'accepted':
+      return { label: 'Accepted', color: colors.courseTeal };
+    default:
+      return { label: state, color: colors.textSupplementary };
+  }
+}
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  transaction: Nip47Transaction | null;
+}
+
+const CopyableRow: React.FC<{ label: string; value: string; fullValue?: string }> = ({
+  label,
+  value,
+  fullValue,
+}) => (
+  <TouchableOpacity
+    style={styles.detailRow}
+    onPress={() => Clipboard.setStringAsync(fullValue || value)}
+    accessibilityLabel={`Copy ${label}`}
+    testID={`copy-${label.toLowerCase().replace(/\s/g, '-')}`}
+  >
+    <Text style={styles.detailLabel}>{label}</Text>
+    <View style={styles.detailValueRow}>
+      <Text style={styles.detailValue} numberOfLines={1}>
+        {value}
+      </Text>
+      <CopyIcon size={16} color={colors.brandPink} />
+    </View>
+  </TouchableOpacity>
+);
+
+const TransactionDetailSheet: React.FC<Props> = ({ visible, onClose, transaction }) => {
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['75%'], []);
+  const { btcPrice, currency } = useWallet();
+  const { isLoggedIn, signerType, sendDirectMessage } = useNostr();
+  const [boltzSupportOpen, setBoltzSupportOpen] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setBoltzSupportOpen(false);
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handler = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose();
+      return true;
+    });
+    return () => handler.remove();
+  }, [visible, onClose]);
+
+  const handleSheetChange = useCallback(
+    (index: number) => {
+      if (index === -1) onClose();
+    },
+    [onClose],
+  );
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    [],
+  );
+
+  const buildSupportMessage = useCallback(() => {
+    if (!transaction) return '';
+    const isIncoming = transaction.type === 'incoming';
+    const amountSats = Math.abs(transaction.amount);
+    const lines = [
+      `[Boltz Support Request]`,
+      `Type: ${isIncoming ? 'Received' : 'Sent'}`,
+      `Amount: ${amountSats.toLocaleString()} sats`,
+      `Status: ${transaction.state}`,
+    ];
+    if (transaction.payment_hash) {
+      lines.push(`Payment Hash: ${transaction.payment_hash}`);
+    }
+    if (transaction.preimage) {
+      lines.push(`Preimage: ${transaction.preimage}`);
+    }
+    if (transaction.description) {
+      lines.push(`Description: ${transaction.description}`);
+    }
+    const date = transaction.settled_at || transaction.created_at;
+    if (date) {
+      lines.push(`Date: ${new Date(date * 1000).toLocaleString()}`);
+    }
+    lines.push('', '---', 'Additional details:');
+    return lines.join('\n');
+  }, [transaction]);
+
+  const handleBoltzSend = useCallback(
+    async (message: string): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const decoded = nip19.decode(BOLTZ_SUPPORT_NPUB);
+        if (decoded.type !== 'npub') {
+          return { success: false, error: 'Invalid Boltz support npub' };
+        }
+        return sendDirectMessage(decoded.data, message);
+      } catch {
+        return { success: false, error: 'Failed to decode Boltz support npub' };
+      }
+    },
+    [sendDirectMessage],
+  );
+
+  if (!transaction) return null;
+
+  const isIncoming = transaction.type === 'incoming';
+  const amountSats = Math.abs(transaction.amount);
+  const fiatStr = satsToFiatString(amountSats, btcPrice, currency);
+  const date = transaction.settled_at || transaction.created_at;
+  const dateStr = date ? new Date(date * 1000).toLocaleString() : '';
+  const status = formatStatus(transaction.state);
+
+  return (
+    <>
+      <BottomSheetModal
+        ref={sheetRef}
+        snapPoints={snapPoints}
+        onChange={handleSheetChange}
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        handleIndicatorStyle={styles.handleIndicator}
+        backgroundStyle={styles.sheetBackground}
+      >
+        <BottomSheetScrollView style={styles.scrollContent}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View style={styles.typeRow}>
+              {isIncoming ? (
+                <ArrowDown size={24} color={colors.green} />
+              ) : (
+                <ArrowUp size={24} color={colors.red} />
+              )}
+              <Text style={styles.typeLabel}>{isIncoming ? 'Received' : 'Sent'}</Text>
+              <View style={[styles.statusBadge, { backgroundColor: status.color + '20' }]}>
+                <Text style={[styles.statusText, { color: status.color }]}>{status.label}</Text>
+              </View>
+            </View>
+          </View>
+
+          {/* Amount */}
+          <View style={styles.amountSection}>
+            <Text style={[styles.amountSats, isIncoming ? styles.incoming : styles.outgoing]}>
+              {isIncoming ? '+' : '-'}
+              {amountSats.toLocaleString()} sats
+            </Text>
+            {fiatStr ? <Text style={styles.amountFiat}>{fiatStr}</Text> : null}
+          </View>
+
+          {/* Date */}
+          {dateStr ? (
+            <View style={styles.dateRow}>
+              <Text style={styles.detailLabel}>Date</Text>
+              <Text style={styles.dateValue}>{dateStr}</Text>
+            </View>
+          ) : null}
+
+          {/* Divider */}
+          <View style={styles.divider} />
+
+          {/* Details */}
+          <View style={styles.detailsSection}>
+            {transaction.description ? (
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Description</Text>
+                <Text style={styles.detailValueText}>{transaction.description}</Text>
+              </View>
+            ) : null}
+
+            {transaction.payment_hash ? (
+              <CopyableRow
+                label="Payment Hash"
+                value={truncateHash(transaction.payment_hash)}
+                fullValue={transaction.payment_hash}
+              />
+            ) : null}
+
+            {transaction.preimage ? (
+              <CopyableRow
+                label="Preimage"
+                value={truncateHash(transaction.preimage)}
+                fullValue={transaction.preimage}
+              />
+            ) : null}
+
+            {transaction.fees_paid > 0 ? (
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Fee Paid</Text>
+                <Text style={styles.detailValueText}>
+                  {transaction.fees_paid.toLocaleString()} sats
+                </Text>
+              </View>
+            ) : null}
+
+            {transaction.invoice ? (
+              <CopyableRow
+                label="Invoice"
+                value={truncateHash(transaction.invoice, 12, 8)}
+                fullValue={transaction.invoice}
+              />
+            ) : null}
+          </View>
+
+          {/* Boltz Support */}
+          <View style={styles.supportSection}>
+            <TouchableOpacity
+              style={styles.supportButton}
+              onPress={() => setBoltzSupportOpen(true)}
+              accessibilityLabel="Contact Boltz Support"
+              testID="contact-boltz-support"
+            >
+              <Text style={styles.supportButtonText}>Contact Boltz Support</Text>
+            </TouchableOpacity>
+          </View>
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+
+      <FeedbackSheet
+        visible={boltzSupportOpen}
+        onClose={() => setBoltzSupportOpen(false)}
+        onSend={handleBoltzSend}
+        isLoggedIn={isLoggedIn}
+        signerType={signerType}
+        onLoginPress={() => {
+          setBoltzSupportOpen(false);
+        }}
+        title="Contact Boltz Support"
+        subtitle="Send an encrypted Nostr DM to Boltz with your transaction details."
+        initialMessage={buildSupportMessage()}
+        successTitle="Message Sent"
+        successMessage="Your support request has been sent to Boltz."
+      />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+  },
+  handleIndicator: {
+    backgroundColor: colors.divider,
+    width: 40,
+  },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  typeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  typeLabel: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.textHeader,
+  },
+  statusBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  amountSection: {
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  amountSats: {
+    fontSize: 28,
+    fontWeight: '700',
+  },
+  amountFiat: {
+    fontSize: 16,
+    color: colors.textSupplementary,
+    marginTop: 4,
+  },
+  incoming: {
+    color: colors.green,
+  },
+  outgoing: {
+    color: colors.red,
+  },
+  dateRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  dateValue: {
+    fontSize: 14,
+    color: colors.textBody,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.divider,
+    marginVertical: 12,
+  },
+  detailsSection: {
+    gap: 4,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+  },
+  detailLabel: {
+    fontSize: 14,
+    color: colors.textSupplementary,
+    fontWeight: '500',
+  },
+  detailValueRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  detailValue: {
+    fontSize: 13,
+    color: colors.textBody,
+    fontWeight: '500',
+    maxWidth: '70%',
+  },
+  detailValueText: {
+    fontSize: 14,
+    color: colors.textBody,
+    flex: 1,
+    textAlign: 'right',
+  },
+  supportSection: {
+    marginTop: 20,
+    paddingBottom: 20,
+  },
+  supportButton: {
+    height: 48,
+    borderRadius: 12,
+    backgroundColor: colors.white,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: colors.brandPink,
+  },
+  supportButtonText: {
+    color: colors.brandPink,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});
+
+export default TransactionDetailSheet;

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { ArrowDown, ArrowUp } from 'lucide-react-native';
 import { colors } from '../styles/theme';
 import { satsToFiatString } from '../services/fiatService';
 import { useWallet } from '../contexts/WalletContext';
-
-interface Transaction {
-  type: string;
-  amount: number;
-  description?: string;
-  created_at?: number;
-  settled_at?: number;
-}
+import type { Nip47Transaction } from '../services/nwcService';
 
 interface Props {
-  transactions: Transaction[];
+  transactions: Nip47Transaction[];
+  onTransactionPress?: (tx: Nip47Transaction) => void;
 }
 
-const TransactionList: React.FC<Props> = ({ transactions }) => {
+const TransactionList: React.FC<Props> = ({ transactions, onTransactionPress }) => {
   const { btcPrice, currency } = useWallet();
 
   if (transactions.length === 0) {
@@ -37,9 +32,19 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
         const fiatStr = satsToFiatString(amountSats, btcPrice, currency);
 
         return (
-          <View key={index} style={styles.item}>
+          <TouchableOpacity
+            key={index}
+            style={styles.item}
+            onPress={() => onTransactionPress?.(item)}
+            accessibilityLabel={`${isIncoming ? 'Received' : 'Sent'} ${amountSats} sats`}
+            testID={`transaction-row-${index}`}
+          >
             <View style={styles.itemLeft}>
-              <Text style={styles.itemIcon}>{isIncoming ? '↓' : '↑'}</Text>
+              {isIncoming ? (
+                <ArrowDown size={18} color={colors.brandPink} />
+              ) : (
+                <ArrowUp size={18} color={colors.brandPink} />
+              )}
               <View style={styles.itemDescriptionContainer}>
                 <Text style={styles.itemDescription} numberOfLines={1}>
                   {item.description || (isIncoming ? 'Received' : 'Sent')}
@@ -54,7 +59,7 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
               </Text>
               {fiatStr ? <Text style={styles.itemFiat}>{fiatStr}</Text> : null}
             </View>
-          </View>
+          </TouchableOpacity>
         );
       })}
     </View>
@@ -87,11 +92,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 12,
     flex: 1,
-  },
-  itemIcon: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: colors.brandPink,
   },
   itemDescriptionContainer: {
     flex: 1,

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -33,7 +33,7 @@ const TransactionList: React.FC<Props> = ({ transactions, onTransactionPress }) 
 
         return (
           <TouchableOpacity
-            key={index}
+            key={item.payment_hash || `tx-${index}`}
             style={styles.item}
             onPress={() => onTransactionPress?.(item)}
             accessibilityLabel={`${isIncoming ? 'Received' : 'Sent'} ${amountSats} sats`}

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -560,13 +560,17 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       if (signerType !== 'nsec') {
         return { success: false, error: 'Direct messages require nsec login' };
       }
+      const normalizedRecipientPubkey = recipientPubkey.trim();
+      if (!/^[0-9a-f]{64}$/i.test(normalizedRecipientPubkey)) {
+        return { success: false, error: 'Invalid public key format' };
+      }
       try {
         const nsec = await SecureStore.getItemAsync(NSEC_KEY);
         if (!nsec) return { success: false, error: 'Key not found' };
         const { secretKey } = nostrService.decodeNsec(nsec);
         const event = await nostrService.createDirectMessageEvent(
           secretKey,
-          recipientPubkey,
+          normalizedRecipientPubkey,
           plaintext,
         );
         const writeRelays = relays.filter((r) => r.write).map((r) => r.url);

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -35,6 +35,7 @@ import type { MainTabParamList } from '../navigation/types';
 
 // Lightning Piggy team npub — update this if the team key changes
 const TEAM_NPUB = 'npub1y2qcaseaspuwvjtyk4suswdhgselydc42ttlt0t2kzhnykne7s5swvaffq';
+const TEAM_PROFILE_CACHE_KEY = 'team_profile_cache';
 
 const QrIcon: React.FC<{ size?: number; color?: string }> = ({ size = 20, color = '#FFFFFF' }) => (
   <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
@@ -83,7 +84,7 @@ const AccountScreen: React.FC = () => {
       try {
         const decoded = nip19.decode(TEAM_NPUB);
         if (decoded.type !== 'npub') return;
-        const cached = await AsyncStorage.getItem('team_profile_cache');
+        const cached = await AsyncStorage.getItem(TEAM_PROFILE_CACHE_KEY);
         if (cached) {
           const parsed = JSON.parse(cached) as NostrProfile;
           if (!cancelled) {
@@ -94,7 +95,7 @@ const AccountScreen: React.FC = () => {
         const fetched = await fetchProfile(decoded.data, DEFAULT_RELAYS);
         if (!cancelled && fetched) {
           setTeamProfile(fetched);
-          await AsyncStorage.setItem('team_profile_cache', JSON.stringify(fetched));
+          await AsyncStorage.setItem(TEAM_PROFILE_CACHE_KEY, JSON.stringify(fetched));
         }
       } catch (error) {
         console.warn('Failed to fetch team profile:', error);
@@ -467,12 +468,19 @@ const AccountScreen: React.FC = () => {
       <FeedbackSheet
         visible={feedbackSheetOpen}
         onClose={() => setFeedbackSheetOpen(false)}
-        onSend={(msg) => {
-          const decoded = nip19.decode(TEAM_NPUB);
-          if (decoded.type !== 'npub') {
-            return Promise.resolve({ success: false, error: 'Invalid team npub' });
+        onSend={async (msg) => {
+          try {
+            const decoded = nip19.decode(TEAM_NPUB);
+            if (decoded.type !== 'npub') {
+              return { success: false, error: 'Invalid team npub' };
+            }
+            return sendDirectMessage(decoded.data, msg);
+          } catch (error) {
+            return {
+              success: false,
+              error: error instanceof Error ? error.message : 'Invalid team npub',
+            };
           }
-          return sendDirectMessage(decoded.data, msg);
         }}
         isLoggedIn={isLoggedIn}
         signerType={signerType}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -8,11 +8,13 @@ import { useNostr } from '../contexts/NostrContext';
 import ReceiveSheet from '../components/ReceiveSheet';
 import SendSheet from '../components/SendSheet';
 import TransactionList from '../components/TransactionList';
+import TransactionDetailSheet from '../components/TransactionDetailSheet';
 import WalletCarousel from '../components/WalletCarousel';
 import AddWalletWizard from '../components/AddWalletWizard';
 import WalletSettingsSheet from '../components/WalletSettingsSheet';
 import ProfileIcon from '../components/ProfileIcon';
 import * as nwcService from '../services/nwcService';
+import type { Nip47Transaction } from '../services/nwcService';
 import { styles } from '../styles/HomeScreen.styles';
 import type { MainTabParamList } from '../navigation/types';
 
@@ -40,8 +42,9 @@ const HomeScreen: React.FC = () => {
   const [sendToPubkey, setSendToPubkey] = useState<string | undefined>();
   const [wizardOpen, setWizardOpen] = useState(false);
   const [settingsWalletId, setSettingsWalletId] = useState<string | null>(null);
-  const [transactions, setTransactions] = useState<any[]>([]);
+  const [transactions, setTransactions] = useState<Nip47Transaction[]>([]);
   const [refreshing, setRefreshing] = useState(false);
+  const [selectedTx, setSelectedTx] = useState<Nip47Transaction | null>(null);
 
   // Handle sendToAddress from navigation params (e.g., from Friends tab zap)
   useEffect(() => {
@@ -166,7 +169,7 @@ const HomeScreen: React.FC = () => {
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
         >
           {hasWallets ? (
-            <TransactionList transactions={transactions} />
+            <TransactionList transactions={transactions} onTransactionPress={setSelectedTx} />
           ) : (
             <View style={styles.emptyState}>
               <Text style={styles.emptyText}>Add a wallet to get started</Text>
@@ -190,6 +193,11 @@ const HomeScreen: React.FC = () => {
       />
       <AddWalletWizard visible={wizardOpen} onClose={() => setWizardOpen(false)} />
       <WalletSettingsSheet walletId={settingsWalletId} onClose={() => setSettingsWalletId(null)} />
+      <TransactionDetailSheet
+        transaction={selectedTx}
+        visible={!!selectedTx}
+        onClose={() => setSelectedTx(null)}
+      />
     </View>
   );
 };

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -1,5 +1,7 @@
 import { NostrWebLNProvider } from '@getalby/sdk';
-import type { Nip47GetInfoResponse } from '@getalby/sdk';
+import type { Nip47GetInfoResponse, Nip47Transaction } from '@getalby/sdk';
+
+export type { Nip47Transaction };
 
 const providers = new Map<string, NostrWebLNProvider>();
 
@@ -147,7 +149,7 @@ export async function getInfo(walletId: string): Promise<{ alias: string; lud16?
   }
 }
 
-export async function listTransactions(walletId: string): Promise<any[]> {
+export async function listTransactions(walletId: string): Promise<Nip47Transaction[]> {
   const provider = providers.get(walletId);
   if (!provider) return [];
   try {


### PR DESCRIPTION
## Summary
- Tapping a transaction row opens a detail bottom sheet showing: type, status badge, amount (sats + fiat), date/time, description, payment hash, preimage, fee paid, and invoice — all copyable
- Adds a "Contact Boltz Support" button that opens an encrypted Nostr DM (NIP-04) to Boltz's npub, pre-populated with transaction details
- Makes `FeedbackSheet` reusable with customizable `title`, `subtitle`, `initialMessage`, and success message props
- Types `nwcService.listTransactions` return as `Nip47Transaction[]` (was `any[]`)
- Replaces `View` with `TouchableOpacity` in transaction list rows with `accessibilityLabel` and `testID`

## Dependencies
- Built on top of PR #56 (`feature/team-zap-profile`) for FeedbackSheet and `sendDirectMessage` infrastructure

## Note on DM replies
The user receives a success alert when the DM is sent, but there is no inbox/chat UI to see Boltz's reply within the app. Users would see replies in a Nostr client (Primal, Amethyst, etc.).

## Test plan
- [ ] Tap a transaction in the list → detail sheet opens with correct data
- [ ] Verify amount, status badge, date, and all detail fields display correctly
- [ ] Tap a copyable row (payment hash, preimage, invoice) → value copied to clipboard
- [ ] Tap "Contact Boltz Support" → FeedbackSheet opens with transaction details pre-populated
- [ ] Send a DM to Boltz (requires nsec login) → success alert shown
- [ ] Swipe down to dismiss the detail sheet
- [ ] Verify existing feedback DM flow on Account screen still works

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)