### PR TITLE
chore: move bundle ID namespace to com.lightningpiggy.app

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -11,15 +11,15 @@ const getAppName = () => {
 };
 
 const getIosBundleId = () => {
-  if (IS_DEV) return 'com.bengweeks.lightningpiggy.dev';
-  if (IS_PREVIEW) return 'com.bengweeks.lightningpiggy.preview';
-  return 'com.bengweeks.lightningpiggy';
+  if (IS_DEV) return 'com.lightningpiggy.app.dev';
+  if (IS_PREVIEW) return 'com.lightningpiggy.app.preview';
+  return 'com.lightningpiggy.app';
 };
 
 const getAndroidPackage = () => {
-  if (IS_DEV) return 'com.anonymous.lightningpiggyapp.dev';
-  if (IS_PREVIEW) return 'com.anonymous.lightningpiggyapp.preview';
-  return 'com.anonymous.lightningpiggyapp';
+  if (IS_DEV) return 'com.lightningpiggy.app.dev';
+  if (IS_PREVIEW) return 'com.lightningpiggy.app.preview';
+  return 'com.lightningpiggy.app';
 };
 
 export default ({ config }: ConfigContext): ExpoConfig => ({

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -12,18 +12,18 @@ Lightning Piggy supports three build variants, each with distinct identifiers so
 
 | **Development**
 | Lightning Piggy (Dev)
-| `com.bengweeks.lightningpiggy.dev`
-| `com.anonymous.lightningpiggyapp.dev`
+| `com.lightningpiggy.app.dev`
+| `com.lightningpiggy.app.dev`
 
 | **Preview**
 | Lightning Piggy (Preview)
-| `com.bengweeks.lightningpiggy.preview`
-| `com.anonymous.lightningpiggyapp.preview`
+| `com.lightningpiggy.app.preview`
+| `com.lightningpiggy.app.preview`
 
 | **Production**
 | Lightning Piggy
-| `com.bengweeks.lightningpiggy`
-| `com.anonymous.lightningpiggyapp`
+| `com.lightningpiggy.app`
+| `com.lightningpiggy.app`
 
 |===
 
@@ -110,22 +110,59 @@ NOTE: The existing individual developer account can remain separate. The organis
 
 TestFlight is Apple's beta testing platform. EAS integrates directly with it.
 
-==== Build and submit
+==== One-time setup
 
-Use EAS to build the iOS app and submit it to TestFlight:
+. **Create an App Store Connect API key** at https://appstoreconnect.apple.com/access/integrations/api → *Team Keys* → *+*. Name: `EAS Submit`, Access: *App Manager*. Download the `.p8` file (only shown once) and note the Key ID and Issuer ID.
+. **Create the App Store Connect app record** at https://appstoreconnect.apple.com/apps → *+* → *New App*. Pick `com.lightningpiggy.app` from the Bundle ID dropdown (EAS auto-registers it on first iOS build, so build once before creating the record). After creation, open the app → *App Information* and copy the numeric **Apple ID** — this is the `ascAppId`.
+. **Wire credentials into `eas.json`** — keep the `.p8` file *outside the repo* and reference the path. Do not commit the `.p8`.
++
+[source,json]
+----
+"submit": {
+  "production": {
+    "ios": {
+      "ascApiKeyPath": "/absolute/path/to/AuthKey_XXXXXXXXXX.p8",
+      "ascApiKeyId": "XXXXXXXXXX",
+      "ascApiKeyIssuerId": "00000000-0000-0000-0000-000000000000",
+      "ascAppId": "0000000000"
+    }
+  }
+}
+----
+
+==== Build and submit
 
 [source,bash]
 ----
-# 1. Build a production iOS archive
+# 1. Build a production iOS archive (cloud or local — see "Local builds" below)
 eas build --platform ios --profile production
 
 # 2. Submit the latest iOS build to TestFlight
-eas submit --platform ios
+eas submit --platform ios --latest
 ----
 
-These commands walk through Apple ID sign-in, two-factor auth, certificate creation, and App Store Connect API key setup as needed.
+With `ascApiKey*` + `ascAppId` populated in `eas.json`, the submit is headless — no Apple ID sign-in, no 2FA, no Keychain prompt. Uploads in 1–3 minutes; Apple then processes the build for 5–10 minutes before it becomes installable.
 
-NOTE: Expo also ships an experimental `npx testflight` shortcut that chains build + submit in one interactive flow. Useful for first-run exploration; the canonical `eas build` / `eas submit` split above is what CI and repeat flows should use.
+CAUTION: The App Store Connect *app-record creation* step still requires interactive Apple ID login (API keys cannot create new apps). Do the one-time record creation in the browser, not via EAS, and you avoid the Apple ID flow entirely afterwards.
+
+==== Local build on macOS (skip the EAS queue)
+
+The free-tier EAS build queue can be slow (60–180 min). A local build on a macOS machine is usually 10–20 minutes. Requires Xcode, Homebrew CocoaPods, and Fastlane installed; EAS-CLI handles the rest.
+
+[source,bash]
+----
+# One-time prerequisites on the Mac
+brew install cocoapods fastlane
+npm install -g eas-cli eas-cli-local-build-plugin
+
+# Build locally
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+eas build --platform ios --profile production --local \
+  --output /tmp/lightning-piggy.ipa
+
+# Then submit the IPA (uses ASC API key from eas.json)
+eas submit --platform ios --path /tmp/lightning-piggy.ipa
+----
 
 After submission, the build appears in App Store Connect under the TestFlight tab. Add internal testers (up to 100) or create external test groups (up to 10,000 testers).
 

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -114,17 +114,21 @@ TestFlight is Apple's beta testing platform. EAS integrates directly with it.
 
 . **Create an App Store Connect API key** at https://appstoreconnect.apple.com/access/integrations/api → *Team Keys* → *+*. Name: `EAS Submit`, Access: *App Manager*. Download the `.p8` file (only shown once) and note the Key ID and Issuer ID.
 . **Create the App Store Connect app record** at https://appstoreconnect.apple.com/apps → *+* → *New App*. Pick `com.lightningpiggy.app` from the Bundle ID dropdown (EAS auto-registers it on first iOS build, so build once before creating the record). After creation, open the app → *App Information* and copy the numeric **Apple ID** — this is the `ascAppId`.
-. **Wire credentials into `eas.json`** — keep the `.p8` file *outside the repo* and reference the path. Do not commit the `.p8`.
+. **Wire credentials into `eas.json`** — keep the `.p8` file *outside the repo* and reference the path. Do not commit the `.p8`. Add the `submit` block below alongside the existing top-level `cli` / `build` blocks:
 +
 [source,json]
 ----
-"submit": {
-  "production": {
-    "ios": {
-      "ascApiKeyPath": "/absolute/path/to/AuthKey_XXXXXXXXXX.p8",
-      "ascApiKeyId": "XXXXXXXXXX",
-      "ascApiKeyIssuerId": "00000000-0000-0000-0000-000000000000",
-      "ascAppId": "0000000000"
+{
+  "cli": { "...": "..." },
+  "build": { "...": "..." },
+  "submit": {
+    "production": {
+      "ios": {
+        "ascApiKeyPath": "/absolute/path/to/AuthKey_XXXXXXXXXX.p8",
+        "ascApiKeyId": "XXXXXXXXXX",
+        "ascApiKeyIssuerId": "00000000-0000-0000-0000-000000000000",
+        "ascAppId": "0000000000"
+      }
     }
   }
 }

--- a/tests/e2e/test-add-hot-wallet.yaml
+++ b/tests/e2e/test-add-hot-wallet.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Add Hot Wallet Test
 ---
 # Imports a hot wallet via mnemonic seed phrase.

--- a/tests/e2e/test-add-nwc-wallet.yaml
+++ b/tests/e2e/test-add-nwc-wallet.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Add NWC Wallet Test
 ---
 # Tests adding a Lightning wallet via NWC connection string.

--- a/tests/e2e/test-add-onchain-wallet.yaml
+++ b/tests/e2e/test-add-onchain-wallet.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Add On-chain Wallet Test
 ---
 # Tests importing an on-chain Bitcoin wallet via xpub/zpub

--- a/tests/e2e/test-alphabet-m.yaml
+++ b/tests/e2e/test-alphabet-m.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Alphabet Navigation Test
 ---
 # Assumes app is already running via `npm start` + `adb reverse tcp:8081 tcp:8081`

--- a/tests/e2e/test-create-account.yaml
+++ b/tests/e2e/test-create-account.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Create Nostr Account Test
 ---
 # Tests creating a new Nostr identity from scratch

--- a/tests/e2e/test-dev-mode.yaml
+++ b/tests/e2e/test-dev-mode.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Enable Developer Mode Test
 ---
 # Enables developer mode by triple-tapping the version number in Account settings.

--- a/tests/e2e/test-edit-profile.yaml
+++ b/tests/e2e/test-edit-profile.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Edit Profile Test
 ---
 # Tests editing Nostr profile fields

--- a/tests/e2e/test-follow-unfollow.yaml
+++ b/tests/e2e/test-follow-unfollow.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Follow and Unfollow Test
 ---
 # Tests following npubs via the Add Friend sheet

--- a/tests/e2e/test-keyboard-sheet.yaml
+++ b/tests/e2e/test-keyboard-sheet.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Bottom Sheet Keyboard Slide Test
 ---
 # Verifies that the Connect Nostr bottom sheet slides up when keyboard opens

--- a/tests/e2e/test-login-perf.yaml
+++ b/tests/e2e/test-login-perf.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Login to Friends Performance Test
 ---
 # Measures time from nsec login to Friends tab being responsive

--- a/tests/e2e/test-login.yaml
+++ b/tests/e2e/test-login.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Nostr Login Test
 ---
 # Tests logging in with an nsec key

--- a/tests/e2e/test-logout.yaml
+++ b/tests/e2e/test-logout.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Nostr Logout Test
 ---
 # Tests logging out from Nostr (assumes already logged in)

--- a/tests/e2e/test-remove-wallet.yaml
+++ b/tests/e2e/test-remove-wallet.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Remove Wallet Test
 ---
 # Removes the currently active wallet via the settings cog.

--- a/tests/e2e/test-search.yaml
+++ b/tests/e2e/test-search.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Friends Search Test
 ---
 # Assumes app is already running via npm start

--- a/tests/e2e/test-swipe-speed.yaml
+++ b/tests/e2e/test-swipe-speed.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Wallet Swipe Speed Test
 ---
 # Tests that swiping between wallets updates transactions quickly.

--- a/tests/e2e/test-transfer-ln-to-ln.yaml
+++ b/tests/e2e/test-transfer-ln-to-ln.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Transfer LN to LN Test
 ---
 # Tests transferring 7 sats between two NWC wallets (Lightning to Lightning).

--- a/tests/e2e/test-transfer-ln-to-onchain.yaml
+++ b/tests/e2e/test-transfer-ln-to-onchain.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Transfer LN to On-chain Test
 ---
 # Tests transferring sats from an NWC wallet to an on-chain wallet via Boltz reverse swap.

--- a/tests/e2e/test-transfer-onchain-to-ln.yaml
+++ b/tests/e2e/test-transfer-onchain-to-ln.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Transfer On-chain to LN Test
 ---
 # Tests transferring sats from an on-chain hot wallet to an NWC wallet via Boltz submarine swap.

--- a/tests/e2e/test-transfer-onchain-to-onchain.yaml
+++ b/tests/e2e/test-transfer-onchain-to-onchain.yaml
@@ -1,4 +1,4 @@
-appId: com.anonymous.lightningpiggyapp
+appId: com.lightningpiggy.app
 name: Transfer On-chain to On-chain Test
 ---
 # Tests transferring sats between two on-chain hot wallets (direct BDK send).

--- a/tests/e2e/test-unfollow.yaml
+++ b/tests/e2e/test-unfollow.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID:-com.anonymous.lightningpiggyapp}
+appId: ${APP_ID:-com.lightningpiggy.app}
 name: Unfollow Contact Test
 ---
 # Tests unfollowing a contact via the contact profile sheet


### PR DESCRIPTION
## Summary
- **`app.config.ts`** — bundle IDs move from `com.bengweeks.lightningpiggy.*` / `com.anonymous.lightningpiggyapp.*` → `com.lightningpiggy.app[.preview|.dev]` to align with the `lightningpiggy.com` domain owned by the upstream Lightning Piggy team. Variant suffixes preserved so dev / preview / production still install side-by-side.
- **`docs/DEPLOYMENT.adoc`** —
  - App Variants table updated to new bundle IDs.
  - TestFlight section rewritten around the **App Store Connect API key** flow (headless, SSH-safe) instead of Apple ID + 2FA (which hits macOS Keychain error 36 over SSH).
  - New **Local build on macOS** section documenting the CocoaPods / Fastlane / `eas-cli-local-build-plugin` prerequisites and the `eas build --local` path that skips the EAS cloud queue.
  - Called out that App Store Connect *app-record creation* still needs a browser — API keys can't create new apps.

## Test plan
- [x] `eas build --platform ios --profile production --local` succeeds with the new bundle ID on the Mac Mini
- [x] App Store Connect app record created for `com.lightningpiggy.app` (ascAppId `6762218164`)
- [x] `eas submit --platform ios` uploads to TestFlight with ASC API key (no Apple ID prompt)
- [ ] App installs from TestFlight on a physical iPhone
- [ ] `eas build --platform android --profile production` succeeds with the new package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)