### PR TITLE
chore: add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  EAS_CLI_VERSION: '18.6.0'
+
 jobs:
   release:
     name: Build & submit via EAS
@@ -26,6 +29,13 @@ jobs:
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
+      - name: Verify EXPO_TOKEN is set
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error title=Missing EXPO_TOKEN::Set EXPO_TOKEN under Settings → Secrets and variables → Actions. Generate at https://expo.dev/accounts/bengweeks/settings/access-tokens."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -51,7 +61,7 @@ jobs:
 
       - name: EAS build + auto-submit
         run: |
-          npx -p eas-cli eas build \
+          npx -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build \
             --profile production \
             --platform ${{ steps.platform.outputs.value }} \
             --non-interactive \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform(s) to release
+        type: choice
+        default: ios
+        options: [ios, android, all]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build & submit via EAS
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Quality gates
+        run: |
+          npm run typecheck
+          npm run lint
+          npm run format:check
+
+      - name: Resolve platform
+        id: platform
+        run: |
+          echo "value=${{ github.event.inputs.platform || 'ios' }}" >> "$GITHUB_OUTPUT"
+
+      - name: EAS build + auto-submit
+        run: |
+          npx -p eas-cli eas build \
+            --profile production \
+            --platform ${{ steps.platform.outputs.value }} \
+            --non-interactive \
+            --auto-submit
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Release $GITHUB_REF_NAME"
+            echo ""
+            echo "Platform: \`${{ steps.platform.outputs.value }}\`"
+            echo "Builds dashboard: https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/builds"
+            echo "Submissions: https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/submissions"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -74,7 +74,7 @@ The preferred way to cut a release is to tag `main` — `.github/workflows/relea
 # 1. Bump the version in app.config.ts (and commit) if you want a new user-facing version.
 # 2. Tag and push.
 git tag v1.0.0
-git push --tags
+git push origin v1.0.0   # push this specific tag — avoid `--tags`, which fires every local tag
 ----
 
 Required GitHub secret: **`EXPO_TOKEN`** — generate at https://expo.dev/accounts/bengweeks/settings/access-tokens and add it under *Settings → Secrets and variables → Actions*.

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -65,6 +65,24 @@ APP_VARIANT=development npx expo run:android
 npx expo run:android
 ----
 
+=== Tag-based release workflow
+
+The preferred way to cut a release is to tag `main` — `.github/workflows/release.yml` handles the rest. Pushing a `v*` tag triggers EAS build + auto-submit; a manual run via *Actions → Release → Run workflow* lets you override the target platform.
+
+[source,bash]
+----
+# 1. Bump the version in app.config.ts (and commit) if you want a new user-facing version.
+# 2. Tag and push.
+git tag v1.0.0
+git push --tags
+----
+
+Required GitHub secret: **`EXPO_TOKEN`** — generate at https://expo.dev/accounts/bengweeks/settings/access-tokens and add it under *Settings → Secrets and variables → Actions*.
+
+All other credentials (iOS ASC API key, Apple distribution cert, future Google Play service account) live on the EAS server (uploaded once via `eas credentials`), so the workflow itself never handles a `.p8` or a service account JSON.
+
+Default platform is `ios`; switch to `all` (or add the Android secrets) once the Google Play account exists.
+
 === EAS Cloud Builds
 
 [source,bash]


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml` — on `v*` tag push (or manual dispatch), runs typecheck + lint + format check then `eas build --profile production --auto-submit` so builds land in TestFlight / Play Internal without any manual steps.
- Defaults to `--platform ios` (since the Google Play account isn't set up yet); the manual-dispatch `platform` input can pick `android` or `all` when ready.
- Concurrency group `release` prevents overlapping deploys.
- `docs/DEPLOYMENT.adoc` gets a new **Tag-based release workflow** subsection explaining the tag flow and where to set `EXPO_TOKEN`.

## Setup needed before first use

1. Generate an Expo access token at https://expo.dev/accounts/bengweeks/settings/access-tokens.
2. Add it as `EXPO_TOKEN` under **Settings → Secrets and variables → Actions**.
3. Cut a release: `git tag v1.0.0 && git push --tags`.

## Test plan
- [x] Secret `EXPO_TOKEN` added to repo.
- [ ] Trigger the workflow manually via *Actions → Release → Run workflow* (platform: `ios`) — confirm build kicks off in EAS dashboard.
- [ ] Push a `v0.0.1-rc1` tag — confirm the tag-trigger variant runs the same flow.
- [ ] Verify the iOS build auto-submits to TestFlight.

## Notes

- All signing credentials (iOS ASC API key, distribution cert, provisioning profile) live on EAS — the workflow never handles a `.p8` or service account JSON locally.
- Version management is currently manual (bump `version` in `app.config.ts` before tagging). Follow-up: switch `appVersionSource` to `remote` so EAS auto-increments `buildNumber` / `versionCode` (tracked in #73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)