### PR TITLE
chore: release on publish — attach APK + Technical Solution PDF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,37 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # Fire when a GitHub Release is published (UI: Releases → Draft a new release).
+  # The Release creates the tag server-side; no separate tag-push trigger needed.
+  release:
+    types: [published]
+  # Allow manual re-run without re-tagging (e.g. to retry a failed EAS build).
   workflow_dispatch:
     inputs:
       platform:
         description: Platform(s) to release
         type: choice
-        default: ios
+        default: all
         options: [ios, android, all]
 
 concurrency:
-  group: release
+  group: release-${{ github.event.release.tag_name || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write   # needed to upload assets to the Release
 
 env:
   EAS_CLI_VERSION: '18.6.0'
 
 jobs:
-  release:
-    name: Build & submit via EAS
+  build-and-submit:
+    name: EAS build & submit
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    outputs:
+      platform: ${{ steps.platform.outputs.value }}
     steps:
       - name: Verify EXPO_TOKEN is set
         run: |
@@ -57,7 +61,7 @@ jobs:
       - name: Resolve platform
         id: platform
         run: |
-          echo "value=${{ github.event.inputs.platform || 'ios' }}" >> "$GITHUB_OUTPUT"
+          echo "value=${{ github.event.inputs.platform || 'all' }}" >> "$GITHUB_OUTPUT"
 
       - name: EAS build + auto-submit
         run: |
@@ -67,13 +71,95 @@ jobs:
             --non-interactive \
             --auto-submit
 
-      - name: Summary
-        if: always()
+  attach-android-apk:
+    name: Attach Android APK to Release
+    # Only runs on an actual Release event, not workflow_dispatch (no release to attach to).
+    if: github.event_name == 'release'
+    needs: build-and-submit
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+
+      - name: Find the Android build
+        id: find
+        run: |
+          # Pick the most recent FINISHED Android production build (the one we just submitted).
+          url=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
+            --platform android --status finished --limit 1 --json \
+            --non-interactive | jq -r '.[0].artifacts.buildUrl')
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Download APK
+        run: |
+          mkdir -p dist
+          curl -sSL "${{ steps.find.outputs.url }}" -o "dist/lightning-piggy-${{ github.event.release.tag_name }}.apk"
+          ls -la dist/
+
+      - name: Upload APK to Release
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/lightning-piggy-${{ github.event.release.tag_name }}.apk \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
+  attach-technical-pdf:
+    name: Generate & attach Technical Solution PDF
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install asciidoctor-pdf + rouge
+        run: |
+          gem install asciidoctor-pdf asciidoctor-diagram rouge
+
+      - name: Setup Node (for mermaid-cli)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+
+      - name: Install mermaid-cli + Chromium
+        run: |
+          npm install -g @mermaid-js/mermaid-cli
+          sudo apt-get update && sudo apt-get install -y chromium-browser
+          echo '{"args":["--no-sandbox","--disable-setuid-sandbox"]}' > /tmp/puppeteer-config.json
+
+      - name: Generate PDF
+        run: bash docs/generate-docs.sh
+
+      - name: Upload PDF to Release
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            docs/TECHNICAL_SOLUTION_DOCUMENT.pdf \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
+  summary:
+    name: Summary
+    if: always()
+    needs: [build-and-submit, attach-android-apk, attach-technical-pdf]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
         run: |
           {
-            echo "## Release $GITHUB_REF_NAME"
+            echo "## Release ${{ github.event.release.tag_name || github.ref_name }}"
             echo ""
-            echo "Platform: \`${{ steps.platform.outputs.value }}\`"
-            echo "Builds dashboard: https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/builds"
-            echo "Submissions: https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/submissions"
+            echo "- EAS builds: https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/builds"
+            echo "- Submissions: https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/submissions"
+            if [ "${{ github.event_name }}" = "release" ]; then
+              echo "- Release assets: ${{ github.event.release.html_url }}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set user-visible version from Release tag
+        # Triggered Releases set tag_name (e.g. "v1.0.1"). Strip the leading "v"
+        # and write into app.config.ts so iOS CFBundleShortVersionString and
+        # Android versionName both pick it up. Build numbers (CFBundleVersion /
+        # versionCode) come from EAS via appVersionSource: remote + autoIncrement.
+        if: github.event_name == 'release'
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          # Strip any pre-release suffix (e.g. 1.0.0-rc1 → 1.0.0); store-side
+          # versions must be strict X.Y.Z. Keep the original tag in the commit
+          # history / Release page for traceability.
+          VERSION="${VERSION%%-*}"
+          echo "Setting version to $VERSION (from tag $TAG)"
+          sed -i "s/version: '[^']*'/version: '$VERSION'/" app.config.ts
+          git diff app.config.ts
+
       - name: Quality gates
         run: |
           npm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-    outputs:
-      platform: ${{ steps.platform.outputs.value }}
     steps:
       - name: Verify EXPO_TOKEN is set
         run: |
@@ -81,24 +79,44 @@ jobs:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Checkout
+        # eas build:list resolves the project via app.config.ts / eas.json from the repo root.
+        uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
 
-      - name: Find the Android build
+      - name: Resolve latest finished Android APK URL
         id: find
         run: |
           # Pick the most recent FINISHED Android production build (the one we just submitted).
+          # Filter by the git commit of the Release tag so we don't accidentally grab an
+          # unrelated older build.
           url=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
-            --platform android --status finished --limit 1 --json \
-            --non-interactive | jq -r '.[0].artifacts.buildUrl')
+            --platform android --status finished --limit 5 --json \
+            --non-interactive \
+            | jq -r --arg sha "${{ github.sha }}" \
+                '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty')
+          if [ -z "$url" ] || [ "$url" = "null" ]; then
+            echo "::error title=No Android build artifact::Could not find a finished Android build for commit ${{ github.sha }}. The EAS build may still be running, or failed."
+            exit 1
+          fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Download APK
         run: |
           mkdir -p dist
-          curl -sSL "${{ steps.find.outputs.url }}" -o "dist/lightning-piggy-${{ github.event.release.tag_name }}.apk"
+          curl --fail --location --silent --show-error --retry 3 --retry-delay 2 \
+            "${{ steps.find.outputs.url }}" \
+            -o "dist/lightning-piggy-${{ github.event.release.tag_name }}.apk"
+          # Verify it's actually an APK (ZIP magic bytes), not an HTML error page.
+          file dist/*.apk | grep -qi 'zip\|android' || {
+            echo "::error title=APK download invalid::Downloaded file does not look like an APK."
+            file dist/*.apk
+            exit 1
+          }
           ls -la dist/
 
       - name: Upload APK to Release
@@ -125,17 +143,6 @@ jobs:
       - name: Install asciidoctor-pdf + rouge
         run: |
           gem install asciidoctor-pdf asciidoctor-diagram rouge
-
-      - name: Setup Node (for mermaid-cli)
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.13.0'
-
-      - name: Install mermaid-cli + Chromium
-        run: |
-          npm install -g @mermaid-js/mermaid-cli
-          sudo apt-get update && sudo apt-get install -y chromium-browser
-          echo '{"args":["--no-sandbox","--disable-setuid-sandbox"]}' > /tmp/puppeteer-config.json
 
       - name: Generate PDF
         run: bash docs/generate-docs.sh

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -76,9 +76,8 @@ Releases are cut by publishing a **GitHub Release** (which creates the tag serve
 
 ==== Cutting a release
 
-. Bump the `version` in `app.config.ts` (and optionally `ios.buildNumber` / `android.versionCode`) on `main`, then merge.
 . Go to https://github.com/BenGWeeks/lightning-piggy-mobile/releases → *Draft a new release*.
-. Choose a tag like `v1.0.1` (create on publish) targeted at `main`.
+. Choose a tag like `v1.0.1` (create on publish) targeted at `main`. **The tag is the source of truth for the user-visible version** — the workflow strips the leading `v` and sets `version` in `app.config.ts` (which becomes iOS `CFBundleShortVersionString` and Android `versionName`). Pre-release suffixes (e.g. `v1.0.0-rc1`) are stripped to keep the store-facing version a strict `X.Y.Z`.
 . Write release notes, click *Publish release*.
 . Watch *Actions → Release*. When it finishes, the Release page has the APK and PDF attached; TestFlight has the iOS build.
 

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -48,9 +48,9 @@ Build profiles are defined in `eas.json`:
 | For internal distribution to testers
 
 | `production`
-| Store
-| App Bundle (AAB)
-| For Google Play Store submission
+| Store (iOS) / Internal sideload (Android, today)
+| APK
+| Used by the release workflow. Outputs an APK for sideloading + Release attachment. **Switch to App Bundle (AAB)** once we enrol on Google Play, or split into a `production-aab` profile alongside.
 
 |===
 

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -65,23 +65,34 @@ APP_VARIANT=development npx expo run:android
 npx expo run:android
 ----
 
-=== Tag-based release workflow
+=== Release workflow
 
-The preferred way to cut a release is to tag `main` — `.github/workflows/release.yml` handles the rest. Pushing a `v*` tag triggers EAS build + auto-submit; a manual run via *Actions → Release → Run workflow* lets you override the target platform.
+Releases are cut by publishing a **GitHub Release** (which creates the tag server-side and fires `.github/workflows/release.yml`). The workflow:
 
-[source,bash]
-----
-# 1. Bump the version in app.config.ts (and commit) if you want a new user-facing version.
-# 2. Tag and push.
-git tag v1.0.0
-git push origin v1.0.0   # push this specific tag — avoid `--tags`, which fires every local tag
-----
+1. Runs quality gates (typecheck / lint / format-check).
+2. Kicks off EAS production builds for both platforms with `--auto-submit` (TestFlight for iOS, Play Internal once the Google Play account is wired up).
+3. Downloads the resulting Android APK and attaches it to the Release for sideloading.
+4. Regenerates `docs/TECHNICAL_SOLUTION_DOCUMENT.pdf` from the AsciiDoc sources and attaches that too.
 
-Required GitHub secret: **`EXPO_TOKEN`** — generate at https://expo.dev/accounts/bengweeks/settings/access-tokens and add it under *Settings → Secrets and variables → Actions*.
+==== Cutting a release
 
-All other credentials (iOS ASC API key, Apple distribution cert, future Google Play service account) live on the EAS server (uploaded once via `eas credentials`), so the workflow itself never handles a `.p8` or a service account JSON.
+. Bump the `version` in `app.config.ts` (and optionally `ios.buildNumber` / `android.versionCode`) on `main`, then merge.
+. Go to https://github.com/BenGWeeks/lightning-piggy-mobile/releases → *Draft a new release*.
+. Choose a tag like `v1.0.1` (create on publish) targeted at `main`.
+. Write release notes, click *Publish release*.
+. Watch *Actions → Release*. When it finishes, the Release page has the APK and PDF attached; TestFlight has the iOS build.
 
-Default platform is `ios`; switch to `all` (or add the Android secrets) once the Google Play account exists.
+The tag format is `v*` (SemVer). A pre-release tag like `v1.0.0-rc1` publishes as a pre-release via the GitHub UI; the workflow still runs.
+
+==== Manual re-run without re-tagging
+
+If a release run fails (EAS queue timeout, flaky network), re-run it via *Actions → Release → Run workflow* without creating a new tag. Platform can be overridden (ios / android / all) — useful for retrying just one platform.
+
+Manual runs skip the asset-attach steps (they need a Release to attach to); use them for rebuilds, not for the first cut.
+
+==== Secrets
+
+- **`EXPO_TOKEN`** — repo secret. Generate at https://expo.dev/accounts/bengweeks/settings/access-tokens and add under *Settings → Secrets and variables → Actions*. Everything else (iOS ASC API key, Apple distribution cert, future Google Play service account) lives on EAS's server via `eas credentials`, so the workflow never handles a `.p8` or service account JSON.
 
 === EAS Cloud Builds
 

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 3.0.0"
+    "version": ">= 3.0.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -22,6 +23,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "android": {
         "buildType": "apk"
       }

--- a/eas.json
+++ b/eas.json
@@ -23,7 +23,7 @@
     },
     "production": {
       "android": {
-        "buildType": "app-bundle"
+        "buildType": "apk"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Switch the release workflow trigger from `push: tags` to `release: [published]`. Publishing a GitHub Release (which creates the tag server-side) is now what kicks everything off — cleaner UX than tagging from the CLI and exposes the Release object to downstream jobs for asset uploads.
- **The Release tag is the single source of truth for versioning**:
  - The workflow strips the leading `v` (and any pre-release suffix) and writes the result into `app.config.ts` → drives both iOS `CFBundleShortVersionString` and Android `versionName`.
  - `eas.json` sets `cli.appVersionSource: "remote"` + `build.production.autoIncrement: true` so EAS auto-increments iOS `CFBundleVersion` and Android `versionCode` for every build. No more manual file edits between releases. Closes #73.
- Three parallel jobs in `release.yml`:
  1. `build-and-submit` — quality gates + `eas build --profile production --auto-submit` for both platforms (TestFlight + future Play Internal).
  2. `attach-android-apk` — selects the finished Android build matching `github.sha`, downloads the APK with hardened curl + magic-byte sanity check, attaches to the Release for sideloading.
  3. `attach-technical-pdf` — installs `asciidoctor-pdf` + `rouge`, runs `docs/generate-docs.sh`, attaches the regenerated PDF to the Release.
- `eas.json` — production Android now outputs APK (sideloadable). When we wire up the Google Play account, we'll add a parallel `production-aab` profile so both shipping paths have their own artefact.
- `docs/DEPLOYMENT.adoc` — rewrote the Release section around the new flow, updated the build-profiles table, dropped the manual version-bump step.

## Cutting a release

1. Go to **Releases → Draft a new release**.
2. Tag: `v1.0.1` (create on publish), target: `main`.
3. Optionally tick **Set as a pre-release** for `v0.0.1-rc1`-style tags.
4. **Publish release**.
5. Actions runs the workflow; the Release page ends up with the APK + PDF attached, TestFlight has the iOS build.

No file edits between releases — the tag drives everything.

## Test plan
- [ ] Publish a pre-release `v0.0.1-rc1` from the UI → workflow fires.
- [ ] EAS builds queued for both platforms with the right version (`0.0.1`) and an auto-incremented build number.
- [ ] Release page ends up with `lightning-piggy-v0.0.1-rc1.apk` and `TECHNICAL_SOLUTION_DOCUMENT.pdf`.
- [ ] iOS build appears in TestFlight.

## Notes

- `workflow_dispatch` retained for manual re-runs (skips asset attach — needs a real Release).
- Apple IPA is **not** attached: ad-hoc IPAs are UDID-locked and store-signed IPAs are DRM-locked, so neither is sideloadable. TestFlight handles iOS distribution.
- With `appVersionSource: remote`, EAS owns the build-number stream — local ad-hoc `eas build` runs share the same monotonic counter as CI, so no risk of CI/dev collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)