### PR TITLE
chore: add submit.production.ios block to eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -28,5 +28,12 @@
         "buildType": "apk"
       }
     }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "ascAppId": "6762218164"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add a minimal \`submit.production.ios\` block with just \`ascAppId\` (\`6762218164\`).
- The ASC API key itself (.p8 + Key ID + Issuer ID) lives on the EAS credentials server (uploaded via \`eas credentials\` on the Mac), so nothing sensitive lands in the repo.
- Fixes the *Missing submit profile in eas.json: production* failure from PR #76's first release run (workflow 24421810218), which kicked off Android + iOS builds but couldn't auto-submit them.

## Test plan
- [ ] Re-publish (or re-run the workflow against) the next release tag → EAS build + auto-submit succeeds end-to-end without prompting for credentials.
- [ ] Android APK gets attached to the Release.
- [ ] iOS build appears in TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)