### PR TITLE
chore: release iOS only until Google Play credentials are set up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
       platform:
         description: Platform(s) to release
         type: choice
-        default: all
+        default: ios   # flip to `all` once Google Play account + service account JSON are wired up via `eas credentials`
         options: [ios, android, all]
 
 concurrency:
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    outputs:
+      platform: ${{ steps.platform.outputs.value }}
     steps:
       - name: Verify EXPO_TOKEN is set
         run: |
@@ -76,7 +78,9 @@ jobs:
       - name: Resolve platform
         id: platform
         run: |
-          echo "value=${{ github.event.inputs.platform || 'all' }}" >> "$GITHUB_OUTPUT"
+          # On Release events the input is empty, so fall back to ios-only until
+          # we wire up Google Play credentials. Switch to 'all' when ready.
+          echo "value=${{ github.event.inputs.platform || 'ios' }}" >> "$GITHUB_OUTPUT"
 
       - name: EAS build + auto-submit
         run: |
@@ -88,8 +92,9 @@ jobs:
 
   attach-android-apk:
     name: Attach Android APK to Release
-    # Only runs on an actual Release event, not workflow_dispatch (no release to attach to).
-    if: github.event_name == 'release'
+    # Only runs on an actual Release event (workflow_dispatch has no release to attach to)
+    # AND only when the build job actually built for Android.
+    if: github.event_name == 'release' && contains(fromJSON('["android","all"]'), needs.build-and-submit.outputs.platform)
     needs: build-and-submit
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- Flip the release workflow's default platform from \`all\` → \`ios\`.
- Re-add the \`platform\` output from the build job and gate \`attach-android-apk\` on \`platform ∈ {android, all}\` so it's cleanly skipped on iOS-only releases (instead of failing on a missing Android build artifact).

## Why
PR #76's first end-to-end runs failed at the auto-submit step with:

> Google Service Account Keys cannot be set up in --non-interactive mode.

We don't have a Google Play developer account or a service account JSON yet, so EAS can't submit Android. Restricting the workflow to iOS unblocks the TestFlight pipeline now; we can flip back to \`all\` once Play is wired up.

## Test plan
- [ ] Publish a fresh \`v0.0.1-rc3\` pre-release → workflow runs iOS only, PDF attaches, iOS appears in TestFlight, Android job is skipped (not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)