### PR TITLE
chore: mark app as export-compliance exempt

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -40,7 +40,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: true,
     bundleIdentifier: getIosBundleId(),
     infoPlist: {
-      ITSAppUsesNonExemptEncryption: true,
+      // The app uses only standard cryptography (secp256k1, SHA-256, BIP-32/39/84,
+      // and AES/TLS via system libraries). All of that falls under Apple's
+      // export-compliance exemptions for cryptocurrency wallets, so we don't need
+      // to file separate export-compliance documentation. See
+      // https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations
+      ITSAppUsesNonExemptEncryption: false,
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- Set \`ios.infoPlist.ITSAppUsesNonExemptEncryption\` to \`false\`.
- App only uses standard crypto (secp256k1, SHA-256, BIP-32/39/84, AES/TLS via system libraries) — all under Apple's exemptions.
- Unblocks TestFlight uploads which were failing with *Invalid Export Compliance Code*.

## Test plan
- [ ] Local iOS build on the Mac succeeds.
- [ ] \`eas submit --platform ios --path /tmp/lightning-piggy.ipa\` uploads to TestFlight without the export-compliance error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)