### PR TITLE
docs: iOS ad-hoc sideload + 8 troubleshooting entries from today's deploy

### DIFF
--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -198,6 +198,103 @@ eas submit --platform ios --path /tmp/lightning-piggy.ipa
 
 After submission, the build appears in App Store Connect under the TestFlight tab. Add internal testers (up to 100) or create external test groups (up to 10,000 testers).
 
+=== iOS Distribution — Ad-hoc (sideload)
+
+Ad-hoc distribution installs a signed IPA onto a specific iPhone without going through TestFlight or the App Store. Use it when:
+
+* The tester is **under 13** (Apple blocks them from TestFlight's terms).
+* You want to install a build immediately without waiting for Apple's Beta App Review or TestFlight processing.
+* The build will only run on a small, known set of devices (ad-hoc profiles cap at 100 registered device UDIDs per Apple Developer year).
+
+==== How it works
+
+* EAS builds an IPA signed with an **ad-hoc provisioning profile** that has specific **device UDIDs** baked in at signing time.
+* The IPA only installs on iPhones whose UDID is in that profile. Every new tester requires re-signing (or a fresh rebuild) after their UDID is registered.
+* Unlike TestFlight, there's no age check — this is an Apple-sanctioned developer distribution channel, not a consumer beta programme.
+
+==== One-time Apple Developer Portal setup
+
+. Register the preview bundle ID at https://developer.apple.com/account/resources/identifiers[developer.apple.com/account/resources/identifiers]:
++
+* **Identifier type:** App IDs → App
+* **Description:** `Lightning Piggy Preview`
+* **Bundle ID (Explicit):** `com.lightningpiggy.app.preview`
+* Leave capabilities at defaults.
++
+(The production bundle ID gets auto-registered by EAS on the first iOS build, but the preview variant needs manual registration because the ad-hoc build path doesn't auto-create it.)
+
+. Register each tester's device UDID once via `eas device:create`:
++
+[source,bash]
+----
+npx -p eas-cli eas device:create
+----
++
+This produces a single reusable URL. Send it to every tester — they open it in Safari on their iPhone, tap *Download Profile*, then *Settings → General → VPN & Device Management* → install the profile. Their UDID is then reported back to your Apple team automatically.
+
+. Verify all UDIDs landed:
++
+[source,bash]
+----
+npx -p eas-cli eas device:list
+----
+
+==== Build the ad-hoc IPA
+
+Local build on macOS (recommended — skips the EAS queue):
+
+[source,bash]
+----
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+eas build --platform ios --profile preview --local \
+  --output /tmp/lightning-piggy-preview.ipa
+----
+
+Expected prompts on first run per bundle ID:
+
+* *"Log in to your Apple Developer account?"* → **Yes** (API keys cannot manage ad-hoc provisioning profiles — this needs full Developer Portal scope, Apple ID + 2FA).
+* *"Reuse this distribution certificate?"* → **Yes**.
+* *"Generate a new Apple Provisioning Profile?"* → **Yes**.
+* *"Select devices for the ad hoc build"* → select all registered UDIDs.
+
+If the Mac login keychain is locked (common when running over SSH without an active GUI session) you'll see *"Security returned a non-successful error code: 36"*. Unlock first:
+
+[source,bash]
+----
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+----
+
+==== Install the IPA
+
+Two install paths depending on whether the iPhone is near the Mac or near your Linux box.
+
+**Option A — push over USB from Linux** (requires `libimobiledevice` / `ideviceinstaller`):
+
+[source,bash]
+----
+# One-time on Linux
+sudo apt install -y ideviceinstaller
+
+# For each install
+scp Bens-Mac-Mini.local:/tmp/lightning-piggy-preview.ipa /tmp/
+ideviceinstaller -i /tmp/lightning-piggy-preview.ipa
+----
+
+On the iPhone:
+
+* The first time, iOS prompts *"Trust this computer?"* → **Trust**, enter passcode.
+* On iOS 16+, Developer Mode must be enabled before sideloaded apps will launch. *Settings → Privacy & Security → Developer Mode → toggle on → Restart*. If the row isn't visible, tap the freshly installed app icon once to trigger iOS to reveal it.
+* First launch of the installed app: iOS shows *"Untrusted Developer"*. Go to *Settings → General → VPN & Device Management*, tap the developer profile, *Trust*.
+
+**Option B — EAS install URL via Safari** (works over cellular / WiFi, no USB):
+
+Local builds don't upload to EAS automatically; to get a shareable install URL, either use the EAS cloud build path (`eas build --platform ios --profile preview` without `--local`) or host the IPA plus an install manifest plist yourself (GitHub Release attachments require the `itms-services://` install URL to point at a plist you generate). Cloud build is simpler unless the queue is heavily backlogged.
+
+==== Limits
+
+* Ad-hoc provisioning profiles expire **1 year** after generation — rebuild or `eas build:resign` before expiry.
+* **100 registered devices per Apple product category** (iPhone, iPad, etc.) per membership year. You can remove unregistered devices at year-end to free slots.
+
 === Android Distribution — Google Play Internal Testing
 
 Google Play's Internal Testing track is the Android equivalent of TestFlight.

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -204,7 +204,7 @@ Ad-hoc distribution installs a signed IPA onto a specific iPhone without going t
 
 * The tester is **under 13** (Apple blocks them from TestFlight's terms).
 * You want to install a build immediately without waiting for Apple's Beta App Review or TestFlight processing.
-* The build will only run on a small, known set of devices (ad-hoc profiles cap at 100 registered device UDIDs per Apple Developer year).
+* The build will only run on a small, known set of devices (ad-hoc profiles cap at 100 registered device UDIDs per product category — iPhone, iPad, etc. — per Apple Developer membership year).
 
 ==== How it works
 
@@ -276,7 +276,8 @@ Two install paths depending on whether the iPhone is near the Mac or near your L
 sudo apt install -y ideviceinstaller
 
 # For each install
-scp Bens-Mac-Mini.local:/tmp/lightning-piggy-preview.ipa /tmp/
+# Replace <user>@<mac-hostname> and the source path with the Mac + IPA you built on.
+scp <user>@<mac-hostname>:/tmp/lightning-piggy-preview.ipa /tmp/
 ideviceinstaller -i /tmp/lightning-piggy-preview.ipa
 ----
 

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -131,7 +131,7 @@ The fix script (`apply_nip20_fix.py`) patches `router.py` to send `["OK", event_
 | The Mac's login keychain is locked because there's no active GUI session — `fastlane` can't save the Apple ID password so it treats auth as failed, even when the password is correct. +
 *Fix:* unlock the keychain once per session before running EAS commands: +
 `security unlock-keychain ~/Library/Keychains/login.keychain-db` +
-(prompts for the Mac login password, not the Apple ID). Stays unlocked for ~5 min — enough time to clear Apple ID + 2FA + device selection.
+(prompts for the Mac login password, not the Apple ID). Stays unlocked per the machine's keychain auto-lock settings — typically long enough to clear Apple ID + 2FA + device selection.
 
 | `eas submit` fails with *"Invalid Export Compliance Code. The export compliance key value [] in the app's Info.plist doesn't match..."*
 | `ios.infoPlist.ITSAppUsesNonExemptEncryption: true` in `app.config.ts` tells App Store Connect to expect filed export-compliance documentation (a CCATS code). With no docs filed, uploads bounce. +
@@ -143,7 +143,7 @@ The fix script (`apply_nip20_fix.py`) patches `router.py` to send `["OK", event_
 
 | Local Android build fails with *"Failed to run Gradle Worker Daemon... build machine is extremely loaded"*
 | The Gradle JVM worker was OOM-killed. Gradle + Android tooling needs ~4–6 GB RAM; if the machine is close to swap exhaustion the worker's 120 s daemon-connect timeout fires and Gradle errors out. +
-*Fix:* check `free -h` and `ps axo pid,rss,comm --sort=-rss | head`. Close heavy processes (VMs like WinApps/QEMU can easily eat 8 GB, browsers another couple) and kill any leftover `java` processes from the failed build: `pkill -9 -f java`. Retry.
+*Fix:* check `free -h` and `ps axo pid,rss,comm --sort=-rss | head`. Close heavy processes (VMs like WinApps/QEMU can easily eat 8 GB, browsers another couple), then stop Gradle cleanly with `./gradlew --stop`. If stale build processes still linger, target them narrowly rather than every Java process on the box: `pkill -f 'GradleDaemon|org\.gradle\.|com\.android\.'`. Retry.
 
 | `eas build --local --auto-submit` fails with *"Auto-submits are not yet supported when building locally"*
 | `--auto-submit` only works on cloud builds. Split into two commands: `eas build --platform ios --profile production --local --output /tmp/app.ipa` then `eas submit --platform ios --path /tmp/app.ipa`.

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -127,6 +127,39 @@ Boltz Mini IS publicly routable, but initial swap attempts failed because LND's 
 4. Verify: `ssh black-panther "docker exec lnbits-family grep 'NIP-01: OK' /app/lnbits/extensions/nostrclient/router.py"` +
 The fix script (`apply_nip20_fix.py`) patches `router.py` to send `["OK", event_id, true, ""]` after publishing EVENT messages, and `["OK", event_id, false, "error: no relay connections"]` when no relays are connected.
 
+| `Security returned a non-successful error code: 36` during `eas build` or `eas submit` over SSH
+| The Mac's login keychain is locked because there's no active GUI session — `fastlane` can't save the Apple ID password so it treats auth as failed, even when the password is correct. +
+*Fix:* unlock the keychain once per session before running EAS commands: +
+`security unlock-keychain ~/Library/Keychains/login.keychain-db` +
+(prompts for the Mac login password, not the Apple ID). Stays unlocked for ~5 min — enough time to clear Apple ID + 2FA + device selection.
+
+| `eas submit` fails with *"Invalid Export Compliance Code. The export compliance key value [] in the app's Info.plist doesn't match..."*
+| `ios.infoPlist.ITSAppUsesNonExemptEncryption: true` in `app.config.ts` tells App Store Connect to expect filed export-compliance documentation (a CCATS code). With no docs filed, uploads bounce. +
+*Fix:* set `ITSAppUsesNonExemptEncryption: false`. The app only uses standard cryptography (secp256k1, SHA-256, BIP-32/39/84, AES/TLS via system libraries) — all under Apple's standard cryptocurrency-wallet exemptions, so no docs are required. Rebuild and re-submit.
+
+| EAS iOS build stuck in `NEW` status for hours (`queuePosition: null`)
+| Free-tier iOS build queue gets heavily backlogged during peak (the public dashboard at https://expo.dev/eas/build-status occasionally shows 2000+ builds queued, 5–6 h low-priority wait times). The build hasn't failed — EAS just hasn't assigned it a queue slot yet. +
+*Options:* (1) wait it out; (2) cancel with `npx -p eas-cli eas build:cancel <id>` and build locally (`--local` flag) instead; (3) upgrade to a paid plan for priority queue. Also check https://status.expo.dev for active incidents.
+
+| Local Android build fails with *"Failed to run Gradle Worker Daemon... build machine is extremely loaded"*
+| The Gradle JVM worker was OOM-killed. Gradle + Android tooling needs ~4–6 GB RAM; if the machine is close to swap exhaustion the worker's 120 s daemon-connect timeout fires and Gradle errors out. +
+*Fix:* check `free -h` and `ps axo pid,rss,comm --sort=-rss | head`. Close heavy processes (VMs like WinApps/QEMU can easily eat 8 GB, browsers another couple) and kill any leftover `java` processes from the failed build: `pkill -9 -f java`. Retry.
+
+| `eas build --local --auto-submit` fails with *"Auto-submits are not yet supported when building locally"*
+| `--auto-submit` only works on cloud builds. Split into two commands: `eas build --platform ios --profile production --local --output /tmp/app.ipa` then `eas submit --platform ios --path /tmp/app.ipa`.
+
+| `eas build` iOS errors with *"Failed to find Bundle ID item with identifier 'com.lightningpiggy.app.preview'"*
+| EAS auto-registers only the *production* bundle ID on first iOS build. The preview / dev variants need manual registration the first time they're built. +
+*Fix:* at https://developer.apple.com/account/resources/identifiers → *+* → App IDs → App → Explicit Bundle ID → `com.lightningpiggy.app.preview` (or `.dev`). Then re-run the build.
+
+| iOS build installs but the app won't launch — *"Developer Mode required"*
+| iOS 16+ requires Developer Mode to be explicitly enabled before sideloaded / ad-hoc / dev-signed apps will run. +
+*Fix on the iPhone:* tap the just-installed app icon once so iOS recognises a dev-signed app is present → *Settings → Privacy & Security → Developer Mode* → toggle on → Restart → after reboot, *"Turn On Developer Mode?"* dialog → passcode. The row doesn't appear in Settings until iOS detects a dev-signed app.
+
+| TestFlight tester dropped with *"You must be 13 years or older to use TestFlight Beta Testing"*
+| Apple's TestFlight Terms of Service require testers be 13+ (16+ in parts of the EU). The rule is TestFlight-wide, not just internal vs external. +
+*Workarounds:* (1) use **ad-hoc distribution** instead — no age check, see the DEPLOYMENT.adoc *iOS Distribution — Ad-hoc* section; (2) wait for public App Store release (no age restriction); (3) test on Android (no TestFlight equivalent, APK installs directly).
+
 | On-chain transactions slow to load on first launch
 | Balance and tx history come from BDK's `wallet.sync(chain)`. BDK is configured with an in-memory database (`DatabaseConfig().memory()`), so sync state does not persist across app restarts — the first sync after launch rescans from scratch and can take 10–30 seconds on busy wallets. +
 *Mitigations:* WalletContext caches transactions per wallet ID and writes them to AsyncStorage, so the UI renders cached data instantly on wallet swipe while the background sync runs. *Future:* switch BDK to a persistent database config so only the delta is fetched across launches.


### PR DESCRIPTION
## Summary
- **New iOS Distribution — Ad-hoc (sideload) section** in \`docs/DEPLOYMENT.adoc\`: when to use ad-hoc over TestFlight (under-13 testers, etc.), bundle-ID registration, \`eas device:create\` UDID collection, local build with expected prompts, keychain-unlock workaround for SSH, USB-install via \`ideviceinstaller\` on Linux, iOS 16+ Developer Mode enablement, 100-device / 1-year profile limits.
- **8 new entries in \`docs/TROUBLESHOOTING.adoc\`** capturing today's gotchas:
  - \`Security returned a non-successful error code: 36\` over SSH → \`security unlock-keychain\`.
  - Export-compliance upload failure → flip \`ITSAppUsesNonExemptEncryption\` to \`false\`.
  - iOS builds stuck in \`NEW\` status → free-tier queue backlog, cancel and go \`--local\`.
  - Gradle Worker Daemon OOM on local Android builds → free RAM, kill stale \`java\` processes.
  - \`eas build --local --auto-submit\` unsupported → split build and submit.
  - Preview / dev bundle IDs not auto-registered → register manually in Apple Developer Portal.
  - iOS 16+ Developer Mode prompt on install → how to enable.
  - TestFlight 13+ age block → switch to ad-hoc or Android.

## Test plan
- [ ] Both docs render cleanly in GitHub's AsciiDoc preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)