### PR TITLE
fix: re-apply recipient props on SendSheet open (zap request dropped)

### DIFF
--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -159,6 +159,10 @@ const SendSheet: React.FC<Props> = ({
       setLnurlParams(null);
       setResolving(false);
       setMemo('');
+      // Sheet is kept mounted across opens, so useState(prop) init doesn't re-fire.
+      // Re-apply recipient props or Friends-tab zap keeps stale activePubkey → no 9734.
+      setActivePubkey(recipientPubkey);
+      setActivePicture(initialPicture);
       bottomSheetRef.current?.present();
       if (initialAddress) {
         // Use setTimeout to process after state reset


### PR DESCRIPTION
## Summary

- SendSheet is kept mounted by its parent — `useState(recipientPubkey)` / `useState(initialPicture)` only runs once at mount.
- After the first open with different props, the derived `activePubkey` never updated, so the NIP-57 9734 zap request was silently skipped.
- Symptom: tapping the zap icon on a Friends row after any prior send produced a plain lnurlp invoice, not a zap.

## Evidence

LNbits server logs for `bank.weeksfamily.me` show the TestFlight Friends-zap arrived without a `?nostr=` param:

```
GET /lnurlp/api/v1/lnurl/cb/9nvfGG?webhook_data=...&amount=2000&comment=Hi
```

Expected (for a NIP-57 zap):

```
GET /lnurlp/api/v1/lnurl/cb/9nvfGG?...&amount=2000&comment=Hi&nostr=<urlencoded 9734>
```

## Test plan

- [ ] Send to a Friend via the Friends-tab zap icon as the first action after app open — confirm `[Zap-send]` dev log prints `hasZapRequest=true`.
- [ ] Send to a non-Friend lightning address, close the sheet, then open SendSheet from Friends-tab zap — confirm `activePubkey` is populated (not stale `undefined`) and `hasZapRequest=true` still.
- [ ] Confirm a 9735 zap receipt is published by the recipient's LNURL server post-payment (via relay query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)