### PR TITLE
fix(nwc): pass limit: 50 to listTransactions (was capped at 10)

### DIFF
--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -314,7 +314,12 @@ export async function listTransactions(walletId: string): Promise<any[]> {
   const maxAttempts = 3;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const result = await provider.listTransactions({});
+      // LNbits's NWC provider defaults to `limit: 10` (see
+      // extensions/nwcprovider/tasks.py::_on_list_transactions), so an empty
+      // request only returns the 10 most recent payments. 50 is a balance
+      // between showing real history and keeping the fetch + follow-up zap
+      // resolver fast; bumping higher (100+) made first-load noticeably slow.
+      const result = await provider.listTransactions({ limit: 50 });
       return result.transactions || [];
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- LNbits's NWC provider silently defaults `limit` to 10 when the request omits it (see `extensions/nwcprovider/tasks.py::_on_list_transactions`), so `provider.listTransactions({})` only returned the 10 most recent payments
- That made the transaction list look like most history was missing for wallets with many transactions (a wallet with 1k+ payments showed just 10)
- Pass an explicit `{ limit: 50 }` \u2014 enough to cover typical recent history without noticeable slowdown in the follow-up zap-receipt resolver + profile fetches

## Test plan
- [x] Verified empirically: before the fix the UI stopped at 10 tx; after, 50 are loaded (confirmed the Shopify / BTC-address / earlier zap entries that were previously hidden)
- [x] `npx tsc --noEmit` passes
- [x] `npx prettier --check` passes
- [ ] Follow-up: infinite scroll + resolver optimization for wallets with >50 recent tx

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)