### PR TITLE
fix(zap): show outgoing zap in conversation thread on send (#123)

### DIFF
--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -99,6 +99,7 @@ const SendSheet: React.FC<Props> = ({
     payInvoiceForWallet,
     refreshBalanceForWallet,
     fetchTransactionsForWallet,
+    addPendingTransaction,
     activeWalletId,
     wallets,
     btcPrice,
@@ -437,7 +438,7 @@ const SendSheet: React.FC<Props> = ({
             if (paymentHash) {
               const contact = contacts.find((c) => c.pubkey === activePubkey);
               const p = contact?.profile ?? null;
-              await recordOutgoingCounterparty(paymentHash, {
+              const counterparty = {
                 pubkey: activePubkey,
                 profile: {
                   npub: npubEncode(activePubkey),
@@ -448,9 +449,31 @@ const SendSheet: React.FC<Props> = ({
                 },
                 comment: memo,
                 anonymous: false,
-              });
+              };
+              await recordOutgoingCounterparty(paymentHash, counterparty);
               if (__DEV__)
                 console.log(`[Zap-send] stored counterparty for ph=${paymentHash.slice(0, 12)}…`);
+              // Optimistic insert: surface the outgoing zap in ConversationScreen
+              // (and the transaction list) without waiting for LNbits to flush
+              // the tx and the next resolver pass. The subsequent
+              // fetchTransactionsForWallet refresh reconciles by paymentHash —
+              // see WalletContext's counterpartyByHash loop which preserves
+              // this attribution across refreshes.
+              if (walletId) {
+                const nowSec = Math.floor(Date.now() / 1000);
+                addPendingTransaction(walletId, {
+                  type: 'outgoing',
+                  amount: -currentSats,
+                  description: memo || undefined,
+                  created_at: nowSec,
+                  settled_at: nowSec,
+                  paymentHash,
+                  bolt11,
+                  invoice: bolt11,
+                  zapCounterparty: counterparty,
+                  optimistic: true,
+                });
+              }
             }
           } catch (e) {
             if (__DEV__) console.warn('[Zap-send] store failed:', e);

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -461,9 +461,13 @@ const SendSheet: React.FC<Props> = ({
               // this attribution across refreshes.
               if (walletId) {
                 const nowSec = Math.floor(Date.now() / 1000);
+                // Convention throughout the app: amount is a POSITIVE magnitude
+                // and `type` alone carries direction (see TransferSheet's
+                // optimistic inserts, ConversationScreen's zapItems, and every
+                // TransactionDetail consumer — all read Math.abs(tx.amount)).
                 addPendingTransaction(walletId, {
                   type: 'outgoing',
-                  amount: -currentSats,
+                  amount: currentSats,
                   description: memo || undefined,
                   created_at: nowSec,
                   settled_at: nowSec,

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -664,7 +664,13 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const fetchTransactionsForWallet = useCallback(
     async (walletId: string) => {
-      const wallet = wallets.find((w) => w.id === walletId);
+      // Read from walletsRef, not the closure's captured `wallets`: this
+      // callback is fired-and-forgotten by SendSheet after pay-success,
+      // so by the time the awaited setTimeout resolves, the closure's
+      // `wallets` snapshot is already stale and `find()` returns the old
+      // wallet — or undefined after a removal — and we silently bail.
+      // See #123.
+      const wallet = walletsRef.current.find((w) => w.id === walletId);
       if (!wallet) return;
 
       try {
@@ -688,8 +694,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
           const raw = await nwcService.listTransactions(walletId);
           // Preserve any previously resolved zap sender info so a refresh
           // doesn't re-trigger relay lookups for transactions we've already
-          // attributed.
-          const existing = wallets.find((w) => w.id === walletId)?.transactions ?? [];
+          // attributed. Also preserves optimistic counterparty entries
+          // written at pay-time (see SendSheet) so the zap card doesn't
+          // flicker out when the LNbits refresh lands.
+          const existing = walletsRef.current.find((w) => w.id === walletId)?.transactions ?? [];
           const counterpartyByHash = new Map<string, WalletTransaction['zapCounterparty']>();
           for (const prev of existing) {
             if (prev.paymentHash && prev.zapCounterparty !== undefined) {
@@ -722,6 +730,26 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
               typeof tx.fees_paid === 'number' ? Math.round(tx.fees_paid / 1000) : undefined,
             zapCounterparty: tx.payment_hash ? counterpartyByHash.get(tx.payment_hash) : undefined,
           }));
+          // Preserve optimistic rows that SendSheet inserted at pay-time but
+          // LNbits hasn't flushed into its own ledger yet. Without this the
+          // freshly-sent zap would disappear from the conversation thread on
+          // the very next refresh, then reappear a second or two later when
+          // LNbits catches up. Only rows marked `optimistic` are preserved —
+          // we match by paymentHash so when LNbits returns the real tx the
+          // optimistic entry is dropped and replaced. (Using a flag, rather
+          // than "any row not in the server response", avoids regrowing
+          // older historical txs that fell off the listTransactions window.)
+          const returnedHashes = new Set(
+            txs.map((t) => t.paymentHash).filter((h): h is string => !!h),
+          );
+          const stillPending = existing.filter(
+            (t) => t.optimistic && t.paymentHash && !returnedHashes.has(t.paymentHash),
+          );
+          if (stillPending.length > 0) {
+            txs = [...stillPending, ...txs].sort(
+              (a, b) => (b.settled_at ?? b.created_at ?? 0) - (a.settled_at ?? a.created_at ?? 0),
+            );
+          }
         }
         updateWalletInState(walletId, { transactions: txs });
 
@@ -737,7 +765,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         console.warn(`fetchTransactions failed for ${walletId}:`, error);
       }
     },
-    [wallets, updateWalletInState],
+    // `walletsRef` is stable, so we don't need `wallets` in the deps. Keeping
+    // the list short means callers that capture this function (e.g. SendSheet's
+    // post-pay refresh IIFE) hold onto a stable reference across renders.
+    [updateWalletInState],
   );
 
   /**

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -735,15 +735,17 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
           // freshly-sent zap would disappear from the conversation thread on
           // the very next refresh, then reappear a second or two later when
           // LNbits catches up. Only rows marked `optimistic` are preserved —
-          // we match by paymentHash so when LNbits returns the real tx the
-          // optimistic entry is dropped and replaced. (Using a flag, rather
-          // than "any row not in the server response", avoids regrowing
-          // older historical txs that fell off the listTransactions window.)
-          const returnedHashes = new Set(
-            txs.map((t) => t.paymentHash).filter((h): h is string => !!h),
+          // the matching uses `paymentHash + type` because a self-pay produces
+          // both an incoming and an outgoing leg with the same hash; keying on
+          // hash alone would drop our optimistic outgoing leg as soon as the
+          // incoming leg came back from the server. The `optimistic` flag also
+          // scopes preservation to newly-inserted rows, so older historical
+          // txs that fall off the listTransactions window aren't regrown.
+          const returnedKeys = new Set(
+            txs.filter((t) => !!t.paymentHash).map((t) => `${t.type}:${t.paymentHash}`),
           );
           const stillPending = existing.filter(
-            (t) => t.optimistic && t.paymentHash && !returnedHashes.has(t.paymentHash),
+            (t) => t.optimistic && t.paymentHash && !returnedKeys.has(`${t.type}:${t.paymentHash}`),
           );
           if (stillPending.length > 0) {
             txs = [...stillPending, ...txs].sort(

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -83,6 +83,14 @@ export interface WalletTransaction {
   swapId?: string;
   swapType?: 'reverse' | 'submarine';
   claimTxId?: string;
+  /**
+   * Inserted client-side by SendSheet immediately after a successful
+   * pay_invoice so the UI (ConversationScreen, TransactionList) can show
+   * the send without waiting for LNbits to flush it into its ledger and
+   * the next refresh to pick it up. Dropped on the next refresh when the
+   * real tx arrives (matched by paymentHash).
+   */
+  optimistic?: boolean;
 }
 
 /** Format wallet name with type suffix for dropdowns */


### PR DESCRIPTION
Fixes #123.

## Summary

When you send a zap to a Nostr contact from `ConversationScreen`, the payment now appears as an outgoing zap card in the thread **immediately** — no manual pull-to-refresh required.

## Root cause (two compounding bugs)

1. **Stale closure in `fetchTransactionsForWallet`.** The callback was memoised with `[wallets, updateWalletInState]`, so every render built a new function capturing that render's `wallets` array. `SendSheet`'s fire-and-forget post-pay refresh IIFE captured one of those functions; by the time its `setTimeout` resolved, the closure's `wallets` snapshot was stale, `wallets.find(...)` returned the old wallet (or `undefined`), and the function silently bailed at the guard. No `listTransactions` call, no `[Zap/…]` resolver pass, no log — just nothing.

   Evidence from Metro log: two successful `[Zap-send] stored counterparty …` writes followed by zero activity until the user restarted.

2. **No optimistic insert.** Even with the refresh working, the zap card only renders after LNbits commits the tx and the resolver attaches the counterparty. That round-trip can take 1–2 seconds during which the user sees an unchanged thread — indistinguishable from "send failed".

## Fix

- `fetchTransactionsForWallet` now reads from the existing `walletsRef.current` instead of the closure's captured array, and drops `wallets` from its `useCallback` deps → the function reference is stable across renders and deferred callers always see the latest state.
- `SendSheet` calls `addPendingTransaction` right after `recordOutgoingCounterparty`, inserting the outgoing zap locally with `zapCounterparty` already attached and a new `optimistic: true` flag.
- `fetchTransactionsForWallet` preserves any still-pending optimistic row whose paymentHash the server hasn't returned yet, so the card doesn't flicker. Once LNbits catches up and includes the real tx, the optimistic row is naturally replaced (matched by paymentHash).

No changes to `ConversationScreen` — the existing `zapItems` memo already picks up the new row as soon as it lands in `wallet.transactions`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean on changed files
- [x] `npx eslint` clean on changed files
- [x] Manual: open Conversation with a Nostr contact, send 5 sats, confirm the zap card appears in the thread before the "Payment Sent" alert is dismissed.
- [x] Manual: after the LNbits refresh (≈1–2s later), confirm the card doesn't duplicate or flicker.
- [x] Manual: pull-to-refresh Home, confirm the list matches LNbits' ledger (optimistic row has been reconciled).

## Related

- #110 — delivery ticks (WhatsApp-style state per bubble). Independent; would surface this class of bug visually.
- #111 — Primal inbox not receiving outgoing DMs. Separate relay-targeting bug.