### PR TITLE
feat(messaging): kid-friendly GIF picker in conversation composer (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ npm start
 
 > **Note:** Always use `npm start` (not `npx expo start`) — the start script includes `--dev-client` which is required for custom native modules. Using `npx expo start` directly will launch in Expo Go mode and show "Something went wrong".
 
+### Environment variables
+
+Optional keys are read from `.env` at the repo root (gitignored) and inlined into the bundle at build time via `app.config.ts` / Metro's `EXPO_PUBLIC_*` handling.
+
+| Variable                    | Used by                    | Notes                                                                                                                                                                                                                                                                                                |
+| --------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXPO_PUBLIC_GIPHY_API_KEY` | In-conversation GIF picker | Free key from [developers.giphy.com/dashboard](https://developers.giphy.com/dashboard/). Restrict it to the Android package / iOS bundle ID in the GIPHY dashboard — keys are public by design, not a secret. When unset, the "Send GIF" row is hidden from the attach menu and nothing else breaks. |
+
+After changing `.env`, restart Metro (`npm start`) so the new value gets inlined. No native rebuild is required for `EXPO_PUBLIC_*` changes.
+
 ### Building an APK
 
 ```bash

--- a/app.config.ts
+++ b/app.config.ts
@@ -91,6 +91,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     eas: {
       projectId: 'b01d6b21-2f80-40af-b58c-c40e4302fa65',
     },
+    // GIPHY API key for the conversation GIF picker. Build-time only —
+    // picker silently omits itself from the Attach menu when the key is
+    // absent. See `src/services/giphyService.ts` and README for setup.
+    giphyApiKey: process.env.EXPO_PUBLIC_GIPHY_API_KEY ?? null,
   },
   owner: 'bengweeks',
 });

--- a/src/components/AttachSheet.tsx
+++ b/src/components/AttachSheet.tsx
@@ -6,7 +6,7 @@ import {
   BottomSheetBackdropProps,
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
-import { MapPin, Zap, Receipt, UserRound } from 'lucide-react-native';
+import { MapPin, Zap, Receipt, UserRound, Smile } from 'lucide-react-native';
 import { colors } from '../styles/theme';
 
 interface Props {
@@ -16,6 +16,7 @@ interface Props {
   onSendZap?: () => void;
   onSendInvoice?: () => void;
   onShareContact?: () => void;
+  onSendGif?: () => void;
 }
 
 const AttachSheet: React.FC<Props> = ({
@@ -25,12 +26,18 @@ const AttachSheet: React.FC<Props> = ({
   onSendZap,
   onSendInvoice,
   onShareContact,
+  onSendGif,
 }) => {
   const sheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => {
-    const rows = 1 + (onSendZap ? 1 : 0) + (onSendInvoice ? 1 : 0) + (onShareContact ? 1 : 0);
-    return [rows >= 4 ? '52%' : rows >= 3 ? '44%' : rows === 2 ? '36%' : '28%'];
-  }, [onSendZap, onSendInvoice, onShareContact]);
+    const rows =
+      1 +
+      (onSendZap ? 1 : 0) +
+      (onSendInvoice ? 1 : 0) +
+      (onShareContact ? 1 : 0) +
+      (onSendGif ? 1 : 0);
+    return [rows >= 5 ? '60%' : rows >= 4 ? '52%' : rows >= 3 ? '44%' : rows === 2 ? '36%' : '28%'];
+  }, [onSendZap, onSendInvoice, onShareContact, onSendGif]);
 
   useEffect(() => {
     if (visible) {
@@ -120,6 +127,22 @@ const AttachSheet: React.FC<Props> = ({
             <View style={styles.rowText}>
               <Text style={styles.rowTitle}>Share profile</Text>
               <Text style={styles.rowSubtitle}>Send another contact's Nostr profile.</Text>
+            </View>
+          </TouchableOpacity>
+        ) : null}
+        {onSendGif ? (
+          <TouchableOpacity
+            style={styles.row}
+            onPress={onSendGif}
+            accessibilityLabel="Send a GIF"
+            testID="attach-send-gif"
+          >
+            <View style={styles.iconBadge}>
+              <Smile size={22} color={colors.white} />
+            </View>
+            <View style={styles.rowText}>
+              <Text style={styles.rowTitle}>Send GIF</Text>
+              <Text style={styles.rowSubtitle}>Pick a reaction GIF from GIPHY (G-rated only).</Text>
             </View>
           </TouchableOpacity>
         ) : null}

--- a/src/components/GifPickerSheet.tsx
+++ b/src/components/GifPickerSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -39,7 +39,10 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
   const topInset = 60;
 
   const [search, setSearch] = useState('');
-  const deferredSearch = useDeferredValue(search);
+  // Debounced mirror — `useDeferredValue` only defers renders, not the
+  // outbound GIPHY request. A 250 ms setTimeout debounce keeps a fast
+  // typist from firing a request per keystroke (GIPHY rate-limits tight).
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [results, setResults] = useState<Gif[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -63,6 +66,7 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
       // fetch rather than briefly flashing the previous session's
       // results while the new request is in flight.
       setSearch('');
+      setDebouncedSearch('');
       setResults([]);
       setError(null);
       setLoading(configured);
@@ -71,6 +75,14 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
       sheetRef.current?.dismiss();
     }
   }, [visible, configured]);
+
+  // Debounce the outbound search. 250 ms is short enough to feel live
+  // while the user pauses between words but long enough to collapse a
+  // burst of keystrokes into a single request.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 250);
+    return () => clearTimeout(t);
+  }, [search]);
 
   useEffect(() => {
     if (!visible) return;
@@ -82,6 +94,7 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
   }, [visible, onClose]);
 
   useEffect(() => {
+    if (!visible) return;
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
     const showSub = Keyboard.addListener(showEvent, (e) => {
@@ -91,12 +104,14 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
     return () => {
       showSub.remove();
       hideSub.remove();
+      // Reset so a stale height can't leak into the next open.
+      setKeyboardHeight(0);
     };
-  }, []);
+  }, [visible]);
 
   // Fetch trending / search results as the sheet opens and whenever the
-  // deferred query settles. `useDeferredValue` + an in-effect cancel flag
-  // keeps us from stomping an older slow search over a newer fast one.
+  // debounced query settles. The in-effect `cancelled` flag also protects
+  // against a slower earlier request stomping a faster later one.
   useEffect(() => {
     if (!visible || !configured) return;
     let cancelled = false;
@@ -104,7 +119,9 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
     setError(null);
     const run = async () => {
       try {
-        const gifs = deferredSearch.trim() ? await searchGifs(deferredSearch) : await getTrending();
+        const gifs = debouncedSearch.trim()
+          ? await searchGifs(debouncedSearch)
+          : await getTrending();
         if (!cancelled) setResults(gifs);
       } catch (e) {
         if (!cancelled) {
@@ -119,7 +136,7 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
     return () => {
       cancelled = true;
     };
-  }, [visible, deferredSearch, configured]);
+  }, [visible, debouncedSearch, configured]);
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (

--- a/src/components/GifPickerSheet.tsx
+++ b/src/components/GifPickerSheet.tsx
@@ -1,0 +1,347 @@
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  BackHandler,
+  Keyboard,
+  Platform,
+  ActivityIndicator,
+  Linking,
+  Dimensions,
+} from 'react-native';
+import { Image as ExpoImage } from 'expo-image';
+import { Search, X } from 'lucide-react-native';
+import {
+  BottomSheetModal,
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetTextInput,
+  BottomSheetFlatList,
+} from '@gorhom/bottom-sheet';
+import { colors } from '../styles/theme';
+import { searchGifs, getTrending, isConfigured, Gif } from '../services/giphyService';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (gif: Gif) => void;
+}
+
+const GRID_COLUMNS = 2;
+const GRID_GAP = 8;
+const TILE_HEIGHT = 110;
+
+const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['75%'], []);
+  const topInset = 60;
+
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+  const [results, setResults] = useState<Gif[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  const configured = isConfigured();
+
+  // Derive tile width from the live window size so rotation and tablet
+  // layouts keep a square-ish grid. The sheet is full-width inside a
+  // 20 px horizontal padding and the tiles are separated by `GRID_GAP`.
+  const tileWidth = useMemo(() => {
+    const w = Dimensions.get('window').width;
+    const inner = w - 20 * 2;
+    const totalGap = GRID_GAP * (GRID_COLUMNS - 1);
+    return Math.floor((inner - totalGap) / GRID_COLUMNS);
+  }, []);
+
+  useEffect(() => {
+    if (visible) {
+      setSearch('');
+      setError(null);
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose();
+      return true;
+    });
+    return () => sub.remove();
+  }, [visible, onClose]);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  // Fetch trending / search results as the sheet opens and whenever the
+  // deferred query settles. `useDeferredValue` + an in-effect cancel flag
+  // keeps us from stomping an older slow search over a newer fast one.
+  useEffect(() => {
+    if (!visible || !configured) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const run = async () => {
+      try {
+        const gifs = deferredSearch.trim() ? await searchGifs(deferredSearch) : await getTrending();
+        if (!cancelled) setResults(gifs);
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Could not load GIFs.');
+          setResults([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, deferredSearch, configured]);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    [],
+  );
+
+  const handleSheetChange = useCallback(
+    (index: number) => {
+      if (index === -1) onClose();
+    },
+    [onClose],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: Gif }) => (
+      <TouchableOpacity
+        onPress={() => onSelect(item)}
+        activeOpacity={0.8}
+        style={[styles.tile, { width: tileWidth, height: TILE_HEIGHT }]}
+        accessibilityLabel={`Send GIF: ${item.title || 'reaction'}`}
+        testID={`gif-tile-${item.id}`}
+      >
+        <ExpoImage
+          source={{ uri: item.previewUrl }}
+          style={styles.tileImage}
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          transition={150}
+          accessibilityIgnoresInvertColors
+        />
+      </TouchableOpacity>
+    ),
+    [onSelect, tileWidth],
+  );
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      snapPoints={snapPoints}
+      topInset={topInset}
+      onChange={handleSheetChange}
+      enablePanDownToClose
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+      backdropComponent={renderBackdrop}
+      handleIndicatorStyle={styles.handleIndicator}
+      backgroundStyle={styles.sheetBackground}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>Send a GIF</Text>
+        <TouchableOpacity
+          onPress={onClose}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityLabel="Close GIF picker"
+          testID="gif-close"
+        >
+          <X size={22} color={colors.textSupplementary} />
+        </TouchableOpacity>
+      </View>
+      <View style={styles.searchRow}>
+        <Search size={18} color={colors.textSupplementary} />
+        <BottomSheetTextInput
+          style={styles.searchInput}
+          placeholder="Search for GIFs"
+          placeholderTextColor={colors.textSupplementary}
+          value={search}
+          onChangeText={setSearch}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+          accessibilityLabel="Search GIFs"
+          testID="gif-search-input"
+        />
+      </View>
+
+      {!configured ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>GIFs are not configured</Text>
+          <Text style={styles.emptySubtitle}>
+            The GIPHY API key hasn&apos;t been set for this build. Add a key to{' '}
+            <Text style={styles.code}>EXPO_PUBLIC_GIPHY_API_KEY</Text> in your environment and
+            rebuild.
+          </Text>
+          <TouchableOpacity
+            style={styles.emptyAction}
+            onPress={() => Linking.openURL('https://developers.giphy.com/dashboard/')}
+            accessibilityLabel="Open GIPHY developer dashboard"
+          >
+            <Text style={styles.emptyActionText}>Open GIPHY dashboard</Text>
+          </TouchableOpacity>
+        </View>
+      ) : error ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>Could not load GIFs</Text>
+          <Text style={styles.emptySubtitle}>{error}</Text>
+        </View>
+      ) : (
+        <BottomSheetFlatList
+          data={results}
+          keyExtractor={(item: Gif) => item.id}
+          renderItem={renderItem}
+          numColumns={GRID_COLUMNS}
+          columnWrapperStyle={styles.row}
+          contentContainerStyle={[
+            styles.grid,
+            { paddingBottom: Math.max(keyboardHeight + 24, 40) },
+          ]}
+          keyboardShouldPersistTaps="handled"
+          ListEmptyComponent={
+            loading ? (
+              <View style={styles.loading}>
+                <ActivityIndicator color={colors.brandPink} />
+              </View>
+            ) : (
+              <View style={styles.emptyState}>
+                <Text style={styles.emptySubtitle}>No GIFs matched your search.</Text>
+              </View>
+            )
+          }
+          ListFooterComponent={<Text style={styles.attribution}>Powered by GIPHY</Text>}
+        />
+      )}
+    </BottomSheetModal>
+  );
+};
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: colors.white,
+  },
+  handleIndicator: {
+    backgroundColor: colors.divider,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 4,
+    paddingBottom: 8,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.textHeader,
+  },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginHorizontal: 20,
+    marginBottom: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    backgroundColor: colors.background,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.textBody,
+    padding: 0,
+  },
+  grid: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+    gap: GRID_GAP,
+  },
+  row: {
+    gap: GRID_GAP,
+    marginBottom: GRID_GAP,
+  },
+  tile: {
+    borderRadius: 10,
+    overflow: 'hidden',
+    backgroundColor: colors.background,
+  },
+  tileImage: {
+    width: '100%',
+    height: '100%',
+  },
+  loading: {
+    paddingVertical: 60,
+    alignItems: 'center',
+  },
+  emptyState: {
+    paddingHorizontal: 20,
+    paddingVertical: 40,
+    alignItems: 'center',
+    gap: 8,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.textHeader,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: colors.textSupplementary,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  code: {
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    fontSize: 13,
+    color: colors.textBody,
+  },
+  emptyAction: {
+    marginTop: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: colors.brandPink,
+  },
+  emptyActionText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.white,
+  },
+  attribution: {
+    textAlign: 'center',
+    fontSize: 11,
+    color: colors.textSupplementary,
+    paddingVertical: 12,
+  },
+});
+
+export default GifPickerSheet;

--- a/src/components/GifPickerSheet.tsx
+++ b/src/components/GifPickerSheet.tsx
@@ -9,7 +9,7 @@ import {
   Platform,
   ActivityIndicator,
   Linking,
-  Dimensions,
+  useWindowDimensions,
 } from 'react-native';
 import { Image as ExpoImage } from 'expo-image';
 import { Search, X } from 'lucide-react-native';
@@ -46,26 +46,31 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   const configured = isConfigured();
+  const { width: windowWidth } = useWindowDimensions();
 
   // Derive tile width from the live window size so rotation and tablet
   // layouts keep a square-ish grid. The sheet is full-width inside a
   // 20 px horizontal padding and the tiles are separated by `GRID_GAP`.
   const tileWidth = useMemo(() => {
-    const w = Dimensions.get('window').width;
-    const inner = w - 20 * 2;
+    const inner = windowWidth - 20 * 2;
     const totalGap = GRID_GAP * (GRID_COLUMNS - 1);
     return Math.floor((inner - totalGap) / GRID_COLUMNS);
-  }, []);
+  }, [windowWidth]);
 
   useEffect(() => {
     if (visible) {
+      // Clear everything so the next open starts on a fresh trending
+      // fetch rather than briefly flashing the previous session's
+      // results while the new request is in flight.
       setSearch('');
+      setResults([]);
       setError(null);
+      setLoading(configured);
       sheetRef.current?.present();
     } else {
       sheetRef.current?.dismiss();
     }
-  }, [visible]);
+  }, [visible, configured]);
 
   useEffect(() => {
     if (!visible) return;
@@ -161,9 +166,15 @@ const GifPickerSheet: React.FC<Props> = ({ visible, onClose, onSelect }) => {
       enablePanDownToClose
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustResize"
       backdropComponent={renderBackdrop}
       handleIndicatorStyle={styles.handleIndicator}
       backgroundStyle={styles.sheetBackground}
+      // Stack on top of the parent AttachSheet rather than dismissing
+      // it — @gorhom's default "switch" cascades a dismiss to the
+      // parent, whose early-return unmounts this modal mid-animation
+      // (same pattern as FriendPickerSheet).
+      stackBehavior="push"
     >
       <View style={styles.header}>
         <Text style={styles.title}>Send a GIF</Text>

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -28,6 +28,7 @@ import * as nwcService from '../services/nwcService';
 import { colors } from '../styles/theme';
 import SendSheet from '../components/SendSheet';
 import AttachSheet from '../components/AttachSheet';
+import GifPickerSheet from '../components/GifPickerSheet';
 import ReceiveSheet from '../components/ReceiveSheet';
 import TransactionDetailSheet, {
   TransactionDetailData,
@@ -52,6 +53,7 @@ import {
   buildProfileRelayHints,
   DEFAULT_RELAYS,
 } from '../services/nostrService';
+import { extractGifUrl, isConfigured as isGifConfigured, Gif } from '../services/giphyService';
 import type { NostrProfile } from '../types/nostr';
 import type { RootStackParamList } from '../navigation/types';
 
@@ -80,6 +82,13 @@ type Item =
       id: string;
       fromMe: boolean;
       location: SharedLocation;
+      createdAt: number;
+    }
+  | {
+      kind: 'gif';
+      id: string;
+      fromMe: boolean;
+      url: string;
       createdAt: number;
     };
 
@@ -210,6 +219,7 @@ const ConversationScreen: React.FC = () => {
   const [attachSheetOpen, setAttachSheetOpen] = useState(false);
   const [invoiceSheetOpen, setInvoiceSheetOpen] = useState(false);
   const [contactPickerOpen, setContactPickerOpen] = useState(false);
+  const [gifPickerOpen, setGifPickerOpen] = useState(false);
   const [sharingLocation, setSharingLocation] = useState(false);
   // Payment hashes of outgoing invoices the active NWC wallet reports paid.
   const [paidHashes, setPaidHashes] = useState<Set<string>>(() => new Set());
@@ -239,6 +249,16 @@ const ConversationScreen: React.FC = () => {
 
   const items = useMemo<Item[]>(() => {
     const msgItems: Item[] = messages.map((m) => {
+      const gifUrl = extractGifUrl(m.text);
+      if (gifUrl) {
+        return {
+          kind: 'gif',
+          id: `dm-${m.id}`,
+          fromMe: m.fromMe,
+          url: gifUrl,
+          createdAt: m.createdAt,
+        };
+      }
       const loc = parseGeoMessage(m.text);
       if (loc) {
         return {
@@ -597,6 +617,29 @@ const ConversationScreen: React.FC = () => {
     [pubkey, sendDirectMessage, contacts, relays],
   );
 
+  const handleSendGif = useCallback(
+    async (gif: Gif) => {
+      setGifPickerOpen(false);
+      setAttachSheetOpen(false);
+      const payload = gif.url;
+      const result = await sendDirectMessage(pubkey, payload);
+      if (!result.success) {
+        Alert.alert('Send failed', result.error ?? 'Could not send GIF.');
+        return;
+      }
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `local-${Date.now()}`,
+          fromMe: true,
+          text: payload,
+          createdAt: Math.floor(Date.now() / 1000),
+        },
+      ]);
+    },
+    [pubkey, sendDirectMessage],
+  );
+
   const openLocation = useCallback((loc: SharedLocation) => {
     const url = buildOsmViewUrl(loc);
     Linking.openURL(url).catch(() => {
@@ -806,6 +849,31 @@ const ConversationScreen: React.FC = () => {
                 {item.text}
               </Text>
               <Text style={[styles.bubbleTime, item.fromMe && styles.bubbleTimeMe]}>
+                {formatTime(item.createdAt)}
+              </Text>
+            </View>
+          </View>
+        );
+      }
+      if (item.kind === 'gif') {
+        return (
+          <View
+            style={[styles.bubbleRow, item.fromMe ? styles.bubbleRowRight : styles.bubbleRowLeft]}
+          >
+            <View
+              style={[styles.gifCard, item.fromMe ? styles.gifCardMe : styles.gifCardThem]}
+              accessibilityLabel={item.fromMe ? 'GIF sent' : 'GIF received'}
+              testID={`conversation-gif-${item.id}`}
+            >
+              <ExpoImage
+                source={{ uri: item.url }}
+                style={styles.gifImage}
+                contentFit="cover"
+                cachePolicy="memory-disk"
+                transition={150}
+                accessibilityIgnoresInvertColors
+              />
+              <Text style={[styles.gifTime, item.fromMe && styles.gifTimeMe]}>
                 {formatTime(item.createdAt)}
               </Text>
             </View>
@@ -1070,6 +1138,23 @@ const ConversationScreen: React.FC = () => {
           // to ~15 % of screen height.
           setContactPickerOpen(true);
         }}
+        onSendGif={
+          isGifConfigured()
+            ? () => {
+                // Same stack-without-dismiss pattern as FriendPickerSheet
+                // above — GifPickerSheet opens over the AttachSheet.
+                setGifPickerOpen(true);
+              }
+            : undefined
+        }
+      />
+      <GifPickerSheet
+        visible={gifPickerOpen}
+        onClose={() => {
+          setGifPickerOpen(false);
+          setAttachSheetOpen(false);
+        }}
+        onSelect={handleSendGif}
       />
       <FriendPickerSheet
         visible={contactPickerOpen}
@@ -1566,6 +1651,38 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: colors.background,
+  },
+  gifCard: {
+    maxWidth: '75%',
+    minWidth: 180,
+    borderRadius: 14,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  gifCardMe: {
+    backgroundColor: colors.brandPink,
+  },
+  gifCardThem: {
+    backgroundColor: colors.white,
+  },
+  gifImage: {
+    width: 220,
+    height: 220,
+    backgroundColor: colors.background,
+  },
+  gifTime: {
+    fontSize: 10,
+    color: colors.textSupplementary,
+    alignSelf: 'flex-end',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  gifTimeMe: {
+    color: 'rgba(255,255,255,0.85)',
   },
   locationCard: {
     maxWidth: '85%',

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -4,6 +4,8 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
+  Pressable,
+  Modal,
   FlatList,
   KeyboardAvoidingView,
   Platform,
@@ -220,6 +222,7 @@ const ConversationScreen: React.FC = () => {
   const [invoiceSheetOpen, setInvoiceSheetOpen] = useState(false);
   const [contactPickerOpen, setContactPickerOpen] = useState(false);
   const [gifPickerOpen, setGifPickerOpen] = useState(false);
+  const [fullscreenGifUrl, setFullscreenGifUrl] = useState<string | null>(null);
   const [sharingLocation, setSharingLocation] = useState(false);
   // Payment hashes of outgoing invoices the active NWC wallet reports paid.
   const [paidHashes, setPaidHashes] = useState<Set<string>>(() => new Set());
@@ -860,9 +863,14 @@ const ConversationScreen: React.FC = () => {
           <View
             style={[styles.bubbleRow, item.fromMe ? styles.bubbleRowRight : styles.bubbleRowLeft]}
           >
-            <View
+            <TouchableOpacity
+              activeOpacity={0.85}
+              onPress={() => setFullscreenGifUrl(item.url)}
               style={[styles.gifCard, item.fromMe ? styles.gifCardMe : styles.gifCardThem]}
-              accessibilityLabel={item.fromMe ? 'GIF sent' : 'GIF received'}
+              accessibilityLabel={
+                item.fromMe ? 'GIF sent, tap to expand' : 'GIF received, tap to expand'
+              }
+              accessibilityRole="imagebutton"
               testID={`conversation-gif-${item.id}`}
             >
               <ExpoImage
@@ -876,7 +884,7 @@ const ConversationScreen: React.FC = () => {
               <Text style={[styles.gifTime, item.fromMe && styles.gifTimeMe]}>
                 {formatTime(item.createdAt)}
               </Text>
-            </View>
+            </TouchableOpacity>
           </View>
         );
       }
@@ -1156,6 +1164,29 @@ const ConversationScreen: React.FC = () => {
         }}
         onSelect={handleSendGif}
       />
+      <Modal
+        visible={fullscreenGifUrl !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setFullscreenGifUrl(null)}
+      >
+        <Pressable
+          style={styles.fullscreenBackdrop}
+          onPress={() => setFullscreenGifUrl(null)}
+          accessibilityLabel="Close full-screen GIF"
+          testID="conversation-gif-fullscreen"
+        >
+          {fullscreenGifUrl ? (
+            <ExpoImage
+              source={{ uri: fullscreenGifUrl }}
+              style={styles.fullscreenImage}
+              contentFit="contain"
+              cachePolicy="memory-disk"
+              accessibilityIgnoresInvertColors
+            />
+          ) : null}
+        </Pressable>
+      </Modal>
       <FriendPickerSheet
         visible={contactPickerOpen}
         onClose={() => {
@@ -1653,8 +1684,10 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   gifCard: {
-    maxWidth: '75%',
-    minWidth: 180,
+    // Match contact / location / invoice card width so GIF bubbles don't
+    // look oddly narrow next to the other attachment types.
+    maxWidth: '85%',
+    minWidth: 240,
     borderRadius: 14,
     overflow: 'hidden',
     shadowColor: '#000',
@@ -1670,9 +1703,24 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
   },
   gifImage: {
-    width: 220,
-    height: 220,
+    // Concrete width matches the contact/location cards' `minWidth: 240`
+    // so the GIF card sizes to the same visual footprint as the other
+    // attachment types (text-driven content would otherwise leave the
+    // gifCard stretched to its `maxWidth` while contact cards sit near
+    // their minWidth).
+    width: 240,
+    height: 240,
     backgroundColor: colors.background,
+  },
+  fullscreenBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.92)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fullscreenImage: {
+    width: '100%',
+    height: '100%',
   },
   gifTime: {
     fontSize: 10,

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -630,10 +630,14 @@ const ConversationScreen: React.FC = () => {
         Alert.alert('Send failed', result.error ?? 'Could not send GIF.');
         return;
       }
+      // `local-<ms>` on its own collides if two sends land in the same
+      // millisecond (e.g. a double-tap on a slow network). Append a
+      // short random suffix so the FlatList keyExtractor stays unique.
+      const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       setMessages((prev) => [
         ...prev,
         {
-          id: `local-${Date.now()}`,
+          id: localId,
           fromMe: true,
           text: payload,
           createdAt: Math.floor(Date.now() / 1000),

--- a/src/services/giphyService.ts
+++ b/src/services/giphyService.ts
@@ -19,15 +19,11 @@ export interface Gif {
   url: string;
   /** Smaller preview used in the picker grid. */
   previewUrl: string;
-  width: number;
-  height: number;
   title: string;
 }
 
 interface GiphyImageFormat {
   url?: string;
-  width?: string;
-  height?: string;
 }
 
 interface GiphyResult {
@@ -67,12 +63,6 @@ function pickFormat(
   return null;
 }
 
-function toNumber(s: string | undefined): number {
-  if (!s) return 0;
-  const n = Number(s);
-  return Number.isFinite(n) ? n : 0;
-}
-
 function normalize(result: GiphyResult): Gif | null {
   // Send-order: prefer a reasonably-sized downsized variant so the bubble
   // renders crisply without pulling down the multi-megabyte original.
@@ -95,8 +85,6 @@ function normalize(result: GiphyResult): Gif | null {
     id: result.id,
     url: send.url,
     previewUrl: preview.url,
-    width: toNumber(send.width),
-    height: toNumber(send.height),
     title: result.title || '',
   };
 }

--- a/src/services/giphyService.ts
+++ b/src/services/giphyService.ts
@@ -1,0 +1,164 @@
+import Constants from 'expo-constants';
+
+// GIPHY v1 REST client. Kid-appropriate content is enforced on every
+// request by pinning `rating=g` — GIPHY's own "General Audiences" tier.
+// See https://developers.giphy.com/docs/optional-settings#rating
+//
+// The API key is bundled into the JS at build time via `app.config.ts`'s
+// `extra.giphyApiKey` (fed from `EXPO_PUBLIC_GIPHY_API_KEY`). GIPHY keys
+// are public by design — in the GIPHY dashboard restrict the key to an
+// Android package / iOS bundle ID; don't treat it as a secret.
+
+const GIPHY_BASE = 'https://api.giphy.com/v1';
+
+const DEFAULT_LIMIT = 24;
+
+export interface Gif {
+  id: string;
+  /** Direct `.gif` URL suitable for `<Image>`/`<ExpoImage>` and for sharing in a DM. */
+  url: string;
+  /** Smaller preview used in the picker grid. */
+  previewUrl: string;
+  width: number;
+  height: number;
+  title: string;
+}
+
+interface GiphyImageFormat {
+  url?: string;
+  width?: string;
+  height?: string;
+}
+
+interface GiphyResult {
+  id: string;
+  title?: string;
+  images?: Record<string, GiphyImageFormat>;
+}
+
+interface GiphyResponse {
+  data: GiphyResult[];
+}
+
+function getApiKey(): string | null {
+  const fromExtra = (Constants.expoConfig?.extra as Record<string, unknown> | undefined)
+    ?.giphyApiKey;
+  if (typeof fromExtra === 'string' && fromExtra.length > 0) return fromExtra;
+  // Fall-through for Expo Go / development where `extra` wiring isn't set
+  // up. `EXPO_PUBLIC_` env vars are inlined by Metro at bundle time.
+  const fromEnv = process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+  if (typeof fromEnv === 'string' && fromEnv.length > 0) return fromEnv;
+  return null;
+}
+
+export function isConfigured(): boolean {
+  return getApiKey() !== null;
+}
+
+function pickFormat(
+  images: Record<string, GiphyImageFormat> | undefined,
+  order: string[],
+): GiphyImageFormat | null {
+  if (!images) return null;
+  for (const key of order) {
+    const fmt = images[key];
+    if (fmt && typeof fmt.url === 'string' && fmt.url.length > 0) return fmt;
+  }
+  return null;
+}
+
+function toNumber(s: string | undefined): number {
+  if (!s) return 0;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalize(result: GiphyResult): Gif | null {
+  // Send-order: prefer a reasonably-sized downsized variant so the bubble
+  // renders crisply without pulling down the multi-megabyte original.
+  const send = pickFormat(result.images, [
+    'fixed_width',
+    'downsized_medium',
+    'downsized',
+    'original',
+  ]);
+  // Preview-order: smallest first — the picker grid only needs a thumb.
+  const preview = pickFormat(result.images, [
+    'fixed_width_small',
+    'fixed_height_small',
+    'preview_gif',
+    'fixed_width',
+    'original',
+  ]);
+  if (!send?.url || !preview?.url) return null;
+  return {
+    id: result.id,
+    url: send.url,
+    previewUrl: preview.url,
+    width: toNumber(send.width),
+    height: toNumber(send.height),
+    title: result.title || '',
+  };
+}
+
+async function fetchGiphy(path: string, params: Record<string, string>): Promise<GiphyResponse> {
+  const key = getApiKey();
+  if (!key) {
+    throw new Error('GIPHY API key is not configured');
+  }
+  const qs = new URLSearchParams({
+    api_key: key,
+    rating: 'g',
+    ...params,
+  });
+  const res = await fetch(`${GIPHY_BASE}${path}?${qs.toString()}`);
+  if (!res.ok) {
+    throw new Error(`GIPHY request failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as GiphyResponse;
+}
+
+export async function searchGifs(query: string, limit = DEFAULT_LIMIT): Promise<Gif[]> {
+  const q = query.trim();
+  if (!q) return getTrending(limit);
+  const data = await fetchGiphy('/gifs/search', {
+    q,
+    limit: String(limit),
+    lang: 'en',
+    bundle: 'messaging_non_clips',
+  });
+  return data.data.map(normalize).filter((g): g is Gif => g !== null);
+}
+
+export async function getTrending(limit = DEFAULT_LIMIT): Promise<Gif[]> {
+  const data = await fetchGiphy('/gifs/trending', {
+    limit: String(limit),
+    bundle: 'messaging_non_clips',
+  });
+  return data.data.map(normalize).filter((g): g is Gif => g !== null);
+}
+
+// GIPHY-hosted direct GIF URL. We anchor on the known media hosts rather
+// than `.gif` alone so an arbitrary `example.com/foo.gif` in a DM doesn't
+// get silently upgraded to an auto-playing image bubble — only GIFs we
+// recognise as coming from our own picker render inline.
+// `media\d*` covers `media.giphy.com`, `media0.giphy.com` … `media4.giphy.com`.
+const GIPHY_URL_REGEX = /\bhttps?:\/\/(?:i|media\d*)\.giphy\.com\/[^\s]+\.(?:gif|webp)\b/i;
+
+/**
+ * If the DM body is just a GIPHY URL (with optional surrounding
+ * whitespace), return the URL so the conversation renderer can inline it
+ * as an animated image bubble. Otherwise `null` — the message falls
+ * through to plain-text / invoice / location / contact handling.
+ */
+export function extractGifUrl(text: string): string | null {
+  if (!text) return null;
+  const trimmed = text.trim();
+  const match = trimmed.match(GIPHY_URL_REGEX);
+  if (!match) return null;
+  // Only treat the message as a GIF card when the URL *is* the whole
+  // body. A URL pasted mid-sentence is still a text message the user
+  // wrote — don't swallow it into a picture-only bubble.
+  if (match[0] !== trimmed) return null;
+  return match[0];
+}

--- a/src/services/giphyService.ts
+++ b/src/services/giphyService.ts
@@ -108,8 +108,11 @@ async function fetchGiphy(path: string, params: Record<string, string>): Promise
   }
   const qs = new URLSearchParams({
     api_key: key,
-    rating: 'g',
     ...params,
+    // `rating` is pinned AFTER the caller-supplied params so no caller
+    // can accidentally (or maliciously) loosen the safety filter by
+    // passing their own `rating` key.
+    rating: 'g',
   });
   const res = await fetch(`${GIPHY_BASE}${path}?${qs.toString()}`);
   if (!res.ok) {
@@ -143,7 +146,10 @@ export async function getTrending(limit = DEFAULT_LIMIT): Promise<Gif[]> {
 // get silently upgraded to an auto-playing image bubble — only GIFs we
 // recognise as coming from our own picker render inline.
 // `media\d*` covers `media.giphy.com`, `media0.giphy.com` … `media4.giphy.com`.
-const GIPHY_URL_REGEX = /\bhttps?:\/\/(?:i|media\d*)\.giphy\.com\/[^\s]+\.(?:gif|webp)\b/i;
+// Extension is restricted to `.gif` to match the DM payload contract the
+// picker emits (the `fixed_width` GIPHY format). If we ever start sending
+// animated WebP, both this regex and the send path need to agree.
+const GIPHY_URL_REGEX = /\bhttps?:\/\/(?:i|media\d*)\.giphy\.com\/[^\s]+\.gif\b/i;
 
 /**
  * If the DM body is just a GIPHY URL (with optional surrounding


### PR DESCRIPTION
## Summary

Adds a kid-friendly GIF picker to the per-friend conversation composer (closes #97). Tap the `+` attach button → **Send GIF** → bottom-sheet picker with search + trending, powered by GIPHY with `rating=g` pinned on every request. Selected GIFs are sent as plain-text DMs containing just the direct `.gif` URL, which:

- Flows through the existing NIP-04 send path — no protocol changes
- Renders inline as an animated image bubble in Lightning Piggy
- Shows as a clickable link in other Nostr clients (Damus / Amethyst / Primal)
- Doesn't need NIP-17 attachment tags

### Provider choice

Tenor v2 stopped accepting new API clients in January 2026, so GIPHY with `rating=g` is now the only mainstream option. The `api_key` is public by design; restrict it in the GIPHY dashboard by Android package / iOS bundle ID instead of treating it as a secret.


### Privacy note — image hotlinking

GIFs are sent as a plain URL inside the NIP-04 encrypted DM. The DM body itself is encrypted, so no third party sees the message contents. But when the recipient's client renders the bubble, it makes a direct `GET` to `media.giphy.com`, which means GIPHY sees the recipient's IP and User-Agent on first render. This is the same exposure any hotlinked image in a DM has today (maps, avatars, etc.) — flagging it so privacy-conscious downstream users can decide whether to disable the picker for their build.

### Safety posture

- Every request pins `rating=g` (GIPHY's most restrictive tier)
- Inline auto-play is gated on the GIPHY host regex — a random `example.com/foo.gif` in a DM still renders as plain text
- Attribution footer (`Powered by GIPHY`) satisfies GIPHY ToS
- Picker row hides itself when no API key is configured, so unkeyed builds degrade gracefully rather than crashing

### Files

- `src/services/giphyService.ts` — v1 client (search / trending / config check / URL detection)
- `src/components/GifPickerSheet.tsx` — bottom-sheet modal, 2-col grid, debounced search via `useDeferredValue`, friendly "not configured" empty state
- `src/components/AttachSheet.tsx` — new "Send GIF" row
- `src/screens/ConversationScreen.tsx` — new `gif` item kind, inline `expo-image` bubble, `handleSendGif`, sheet wiring
- `app.config.ts` — exposes `extra.giphyApiKey` from `EXPO_PUBLIC_GIPHY_API_KEY`

### Setup

```bash
# 1. Grab a free key at https://developers.giphy.com/dashboard/
# 2. Add to .env (or your CI / EAS secrets):
EXPO_PUBLIC_GIPHY_API_KEY=your_key_here
# 3. Rebuild the native binary:
npx expo run:android
```

## Test plan

- [ ] Without a key set, the "Send GIF" row does not appear in the Attach sheet
- [ ] With a key set, the row appears and opens the picker
- [ ] Picker shows trending GIFs on open
- [ ] Typing in the search field returns results (250 ms `setTimeout` debounce)
- [ ] Tapping a GIF sends a DM and optimistically appends a GIF bubble to the conversation
- [ ] Received GIF messages render as animated bubbles (not raw URLs)
- [ ] Rotate device — grid tiles reflow with correct spacing
- [ ] Non-GIPHY `.gif` URLs in DMs still render as plain text (no auto-play)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` introduces no new warnings (one pre-existing warning on main)
- [ ] `npm run format:check` passes

Closes #97
