### PR TITLE
feat(ui): branded payment progress overlay + global incoming-payment detection

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -50,8 +50,13 @@ const toastConfig = {
 // confetti pops no matter where the user is when a payment lands.
 function GlobalIncomingPaymentOverlay() {
   const { lastIncomingPayment, clearLastIncomingPayment } = useWallet();
+  // Key on the event timestamp so a second payment arriving while the
+  // overlay is still visible remounts the component and re-arms the
+  // confetti animation. Without this, a second `success` in a row
+  // wouldn't retrigger the burst (state stays 'success', no transition).
   return (
     <PaymentProgressOverlay
+      key={lastIncomingPayment?.at ?? 'idle'}
       state={lastIncomingPayment ? 'success' : 'hidden'}
       direction="receive"
       amountSats={lastIncomingPayment?.amountSats}

--- a/App.tsx
+++ b/App.tsx
@@ -7,9 +7,10 @@ import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import Toast, { BaseToast, ErrorToast, InfoToast } from 'react-native-toast-message';
-import { WalletProvider } from './src/contexts/WalletContext';
+import { WalletProvider, useWallet } from './src/contexts/WalletContext';
 import { NostrProvider } from './src/contexts/NostrContext';
 import AppNavigator from './src/navigation/AppNavigator';
+import PaymentProgressOverlay from './src/components/PaymentProgressOverlay';
 
 // Render toasts with unlimited-line body so long error messages (e.g. Electrum
 // script-verify errors) aren't truncated. Height grows to fit content.
@@ -43,6 +44,22 @@ const toastConfig = {
   ),
 };
 
+// Renders the global incoming-payment celebration on top of the nav
+// stack. Lives inside the WalletProvider so it can subscribe to the
+// context's incoming-payment event bus, and above any screen so the
+// confetti pops no matter where the user is when a payment lands.
+function GlobalIncomingPaymentOverlay() {
+  const { lastIncomingPayment, clearLastIncomingPayment } = useWallet();
+  return (
+    <PaymentProgressOverlay
+      state={lastIncomingPayment ? 'success' : 'hidden'}
+      direction="receive"
+      amountSats={lastIncomingPayment?.amountSats}
+      onDismiss={clearLastIncomingPayment}
+    />
+  );
+}
+
 export default function App() {
   return (
     <GestureHandlerRootView style={styles.container}>
@@ -53,6 +70,7 @@ export default function App() {
             <AppNavigator />
           </BottomSheetModalProvider>
           <Toast topOffset={60} config={toastConfig} />
+          <GlobalIncomingPaymentOverlay />
         </NostrProvider>
       </WalletProvider>
     </GestureHandlerRootView>

--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -1,0 +1,468 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  useWindowDimensions,
+  ActivityIndicator,
+} from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  useAnimatedReaction,
+  withTiming,
+  withDelay,
+  withRepeat,
+  withSpring,
+  withSequence,
+  interpolate,
+  interpolateColor,
+  cancelAnimation,
+  Easing,
+} from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
+import { Check, X } from 'lucide-react-native';
+import { colors } from '../styles/theme';
+
+export type PaymentProgressState = 'sending' | 'success' | 'error' | 'hidden';
+export type PaymentDirection = 'send' | 'receive';
+
+interface Props {
+  state: PaymentProgressState;
+  direction?: PaymentDirection; // default 'send'
+  amountSats?: number;
+  recipientName?: string;
+  errorMessage?: string;
+  onDismiss: () => void;
+}
+
+const BUBBLE_COUNT = 140;
+const CONFETTI_COUNT = 90;
+// Screen should be packed with bubbles by ~5s. Quadratic stagger means
+// early bubbles are sparse and density ramps up rapidly toward the 5s mark.
+const FULL_DENSITY_MS = 5000;
+// Auto-dismiss delay once we hit `success`; gives the user a beat to see
+// the tick + the green bubble wave (or confetti burst) before closing.
+const SUCCESS_DISMISS_MS = 2200;
+
+// On-brand confetti palette — Piggy pink plus blues and purples.
+const CONFETTI_COLORS = [
+  colors.brandPink,
+  '#FF6BB7', // light pink
+  '#7A5CFF', // violet
+  '#5B8DEF', // blue
+  '#22C1E4', // cyan
+  '#A77BFF', // lavender
+];
+
+interface BubbleSpec {
+  index: number;
+  startXRatio: number;
+  size: number;
+  duration: number;
+  driftPx: number;
+  delayMs: number;
+  opacityPeak: number;
+}
+
+function makeSpecs(count: number, screenHeight: number): BubbleSpec[] {
+  const specs: BubbleSpec[] = [];
+  for (let i = 0; i < count; i++) {
+    const t = i / count; // 0..1
+    // Quadratic stagger: sparse at first, denser toward FULL_DENSITY_MS.
+    const delayMs = t * t * FULL_DENSITY_MS;
+    specs.push({
+      index: i,
+      startXRatio: Math.random(),
+      size: 10 + Math.random() * 34,
+      duration: 2400 + Math.random() * 1800,
+      driftPx: -40 + Math.random() * 80,
+      delayMs,
+      opacityPeak: 0.35 + Math.random() * 0.4,
+    });
+  }
+  // Unused screenHeight param kept for future tuning (eg size scaling
+  // on short screens). Silence the lint by using it.
+  void screenHeight;
+  return specs;
+}
+
+interface ConfettiSpec {
+  index: number;
+  startXRatio: number;
+  width: number;
+  height: number;
+  color: string;
+  duration: number;
+  driftPx: number;
+  delayMs: number;
+  spinTurns: number;
+  opacityPeak: number;
+}
+
+function makeConfettiSpecs(count: number): ConfettiSpec[] {
+  const specs: ConfettiSpec[] = [];
+  for (let i = 0; i < count; i++) {
+    // Staggered launch over ~800ms for a celebratory wave rather than
+    // a hard burst. Longer than that and it feels sluggish.
+    const delayMs = Math.random() * 800;
+    specs.push({
+      index: i,
+      startXRatio: Math.random(),
+      width: 7 + Math.random() * 6,
+      height: 10 + Math.random() * 8,
+      color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+      duration: 2200 + Math.random() * 1600,
+      driftPx: -60 + Math.random() * 120,
+      delayMs,
+      spinTurns: 2 + Math.random() * 4,
+      opacityPeak: 0.85 + Math.random() * 0.15,
+    });
+  }
+  return specs;
+}
+
+interface BubbleProps {
+  spec: BubbleSpec;
+  colorProgress: SharedValue<number>;
+  screenWidth: number;
+  screenHeight: number;
+}
+
+function Bubble({ spec, colorProgress, screenWidth, screenHeight }: BubbleProps) {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withDelay(
+      spec.delayMs,
+      withRepeat(withTiming(1, { duration: spec.duration, easing: Easing.linear }), -1, false),
+    );
+    return () => cancelAnimation(progress);
+  }, [progress, spec.delayMs, spec.duration]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const y = interpolate(progress.value, [0, 1], [screenHeight + 60, -80]);
+    const xOffset = Math.sin(progress.value * Math.PI * 2) * spec.driftPx;
+    const opacity = interpolate(
+      progress.value,
+      [0, 0.12, 0.85, 1],
+      [0, spec.opacityPeak, spec.opacityPeak, 0],
+    );
+    const bg = interpolateColor(colorProgress.value, [0, 1], [colors.brandPink, colors.green]);
+    return {
+      transform: [{ translateX: xOffset }, { translateY: y }],
+      opacity,
+      backgroundColor: bg,
+    };
+  });
+
+  const baseLeft = spec.startXRatio * screenWidth - spec.size / 2;
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.bubble,
+        {
+          width: spec.size,
+          height: spec.size,
+          borderRadius: spec.size / 2,
+          left: baseLeft,
+          top: 0,
+        },
+        animatedStyle,
+      ]}
+    />
+  );
+}
+
+interface ConfettiProps {
+  spec: ConfettiSpec;
+  armed: SharedValue<number>;
+  screenWidth: number;
+  screenHeight: number;
+}
+
+function Confetti({ spec, armed, screenWidth, screenHeight }: ConfettiProps) {
+  const progress = useSharedValue(0);
+
+  // React to the `armed` shared value flipping 0 → 1 — that kicks off the
+  // fall animation for this piece with its per-spec stagger.
+  useAnimatedReaction(
+    () => armed.value,
+    (armedNow, armedBefore) => {
+      if (armedNow === 1 && armedBefore !== 1) {
+        progress.value = withDelay(
+          spec.delayMs,
+          withTiming(1, { duration: spec.duration, easing: Easing.in(Easing.quad) }),
+        );
+      } else if (armedNow === 0) {
+        cancelAnimation(progress);
+        progress.value = 0;
+      }
+    },
+  );
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const y = interpolate(progress.value, [0, 1], [-80, screenHeight + 80]);
+    const xOffset = Math.sin(progress.value * Math.PI * 1.5) * spec.driftPx;
+    const rotate = `${progress.value * spec.spinTurns * 360}deg`;
+    const opacity = interpolate(
+      progress.value,
+      [0, 0.05, 0.9, 1],
+      [0, spec.opacityPeak, spec.opacityPeak, 0],
+    );
+    return {
+      transform: [{ translateX: xOffset }, { translateY: y }, { rotate }],
+      opacity,
+    };
+  });
+
+  const baseLeft = spec.startXRatio * screenWidth - spec.width / 2;
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.confetti,
+        {
+          width: spec.width,
+          height: spec.height,
+          backgroundColor: spec.color,
+          left: baseLeft,
+          top: 0,
+        },
+        animatedStyle,
+      ]}
+    />
+  );
+}
+
+export default function PaymentProgressOverlay({
+  state,
+  direction = 'send',
+  amountSats,
+  recipientName,
+  errorMessage,
+  onDismiss,
+}: Props) {
+  const { width, height } = useWindowDimensions();
+
+  // Keep the overlay mounted across `hidden` so bubbles don't flash
+  // when state flips back to sending mid-flow. We drive the Modal's
+  // `visible` from state.
+  const visible = state !== 'hidden';
+
+  const bubbleSpecs = useMemo(() => makeSpecs(BUBBLE_COUNT, height), [height]);
+  const confettiSpecs = useMemo(() => makeConfettiSpecs(CONFETTI_COUNT), []);
+
+  // 0 = pink (sending / error), 1 = green (success). The error case
+  // keeps pink so the green-flood doesn't imply success on a failure.
+  const colorProgress = useSharedValue(0);
+  // 0 while holding fire, 1 once success fires — gates the confetti launch.
+  const confettiArmed = useSharedValue(0);
+  const cardScale = useSharedValue(0.9);
+  const cardOpacity = useSharedValue(0);
+  const iconScale = useSharedValue(0);
+
+  // Entry animation when overlay first appears.
+  useEffect(() => {
+    if (visible) {
+      cardScale.value = withSpring(1, { damping: 14, stiffness: 180 });
+      cardOpacity.value = withTiming(1, { duration: 220 });
+    } else {
+      cardScale.value = 0.9;
+      cardOpacity.value = 0;
+      colorProgress.value = 0;
+      iconScale.value = 0;
+      confettiArmed.value = 0;
+    }
+  }, [visible, cardScale, cardOpacity, colorProgress, iconScale, confettiArmed]);
+
+  // Drive colour + icon animations on state change, and auto-dismiss on success.
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (state === 'success') {
+      if (direction === 'send') {
+        // Bubbles morph from pink to green on a successful send.
+        colorProgress.value = withTiming(1, { duration: 650 });
+      } else {
+        // Receive: fire the on-brand confetti burst.
+        confettiArmed.value = 1;
+      }
+      iconScale.value = withSequence(
+        withTiming(0, { duration: 0 }),
+        withSpring(1, { damping: 10, stiffness: 220 }),
+      );
+      dismissTimerRef.current = setTimeout(() => {
+        onDismiss();
+      }, SUCCESS_DISMISS_MS);
+    } else if (state === 'error') {
+      iconScale.value = withSequence(
+        withTiming(0, { duration: 0 }),
+        withSpring(1, { damping: 10, stiffness: 220 }),
+      );
+    } else if (state === 'sending') {
+      colorProgress.value = 0;
+      iconScale.value = 0;
+      confettiArmed.value = 0;
+    }
+    return () => {
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+    };
+  }, [state, direction, colorProgress, iconScale, confettiArmed, onDismiss]);
+
+  const cardAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: cardScale.value }],
+    opacity: cardOpacity.value,
+  }));
+
+  const iconAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: iconScale.value }],
+    opacity: iconScale.value,
+  }));
+
+  const formattedAmount =
+    typeof amountSats === 'number' && amountSats > 0
+      ? `${amountSats.toLocaleString()} sats`
+      : undefined;
+
+  const isReceive = direction === 'receive';
+  let title = isReceive ? 'Waiting for payment…' : 'Sending payment…';
+  let subtitle: string | undefined = recipientName
+    ? isReceive
+      ? `from ${recipientName}`
+      : `to ${recipientName}`
+    : formattedAmount;
+  if (state === 'success') {
+    title = isReceive ? 'Payment received!' : 'Payment sent!';
+    subtitle = formattedAmount
+      ? recipientName
+        ? isReceive
+          ? `${formattedAmount} from ${recipientName}`
+          : `${formattedAmount} to ${recipientName}`
+        : formattedAmount
+      : recipientName
+        ? isReceive
+          ? `from ${recipientName}`
+          : `to ${recipientName}`
+        : undefined;
+  } else if (state === 'error') {
+    title = 'Payment failed';
+    subtitle = errorMessage || 'Please try again.';
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      statusBarTranslucent
+      animationType="fade"
+      onRequestClose={state === 'sending' ? undefined : onDismiss}
+    >
+      <View style={styles.root}>
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          {isReceive
+            ? confettiSpecs.map((spec) => (
+                <Confetti
+                  key={spec.index}
+                  spec={spec}
+                  armed={confettiArmed}
+                  screenWidth={width}
+                  screenHeight={height}
+                />
+              ))
+            : bubbleSpecs.map((spec) => (
+                <Bubble
+                  key={spec.index}
+                  spec={spec}
+                  colorProgress={colorProgress}
+                  screenWidth={width}
+                  screenHeight={height}
+                />
+              ))}
+        </View>
+
+        <Animated.View style={[styles.card, cardAnimatedStyle]}>
+          {state === 'sending' && (
+            <ActivityIndicator size="large" color={colors.brandPink} style={styles.iconSlot} />
+          )}
+          {state === 'success' && (
+            <Animated.View style={[styles.iconSlot, styles.successCircle, iconAnimatedStyle]}>
+              <Check size={44} color={colors.white} strokeWidth={3.5} />
+            </Animated.View>
+          )}
+          {state === 'error' && (
+            <Animated.View style={[styles.iconSlot, styles.errorCircle, iconAnimatedStyle]}>
+              <X size={44} color={colors.white} strokeWidth={3.5} />
+            </Animated.View>
+          )}
+
+          <Text style={styles.title}>{title}</Text>
+          {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: 'rgba(21, 23, 26, 0.45)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  bubble: {
+    position: 'absolute',
+  },
+  confetti: {
+    position: 'absolute',
+    borderRadius: 2,
+  },
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 28,
+    paddingVertical: 32,
+    paddingHorizontal: 28,
+    minWidth: 260,
+    maxWidth: 340,
+    alignItems: 'center',
+    gap: 14,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.2,
+    shadowRadius: 24,
+    elevation: 12,
+  },
+  iconSlot: {
+    width: 72,
+    height: 72,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  successCircle: {
+    borderRadius: 36,
+    backgroundColor: colors.green,
+  },
+  errorCircle: {
+    borderRadius: 36,
+    backgroundColor: colors.red,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textHeader,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.textSupplementary,
+    textAlign: 'center',
+  },
+});

--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -364,13 +364,23 @@ export default function PaymentProgressOverlay({
     subtitle = errorMessage || 'Please try again.';
   }
 
+  // Android expects a stable `onRequestClose` for hardware-back behaviour
+  // — passing `undefined` intermittently can warn and makes the button
+  // feel inconsistent. Always provide a handler; swallow the back press
+  // while the payment is still in flight so the user doesn't accidentally
+  // dismiss the "Sending…" state and lose sight of the outcome.
+  const handleRequestClose = () => {
+    if (state === 'sending') return;
+    onDismiss();
+  };
+
   return (
     <Modal
       visible={visible}
       transparent
       statusBarTranslucent
       animationType="fade"
-      onRequestClose={state === 'sending' ? undefined : onDismiss}
+      onRequestClose={handleRequestClose}
     >
       <View style={styles.root}>
         {/* Particle layer renders BEHIND the card — later siblings stack

--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -373,20 +373,32 @@ export default function PaymentProgressOverlay({
       onRequestClose={state === 'sending' ? undefined : onDismiss}
     >
       <View style={styles.root}>
-        {/* Bubbles live behind the card on the send flow. */}
-        {!isReceive ? (
-          <View style={StyleSheet.absoluteFill} pointerEvents="none">
-            {bubbleSpecs.map((spec) => (
-              <Bubble
-                key={spec.index}
-                spec={spec}
-                colorProgress={colorProgress}
-                screenWidth={width}
-                screenHeight={height}
-              />
-            ))}
-          </View>
-        ) : null}
+        {/* Particle layer renders BEHIND the card — later siblings stack
+         *  above earlier ones in RN, so this block must come first.
+         *  Send = pink bubbles rising; Receive = radial confetti burst
+         *  from card centre, so pieces appear to launch out from behind
+         *  the card and fly past its edges. */}
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          {isReceive
+            ? confettiSpecs.map((spec) => (
+                <Confetti
+                  key={spec.index}
+                  spec={spec}
+                  armed={confettiArmed}
+                  originX={width / 2}
+                  originY={height / 2}
+                />
+              ))
+            : bubbleSpecs.map((spec) => (
+                <Bubble
+                  key={spec.index}
+                  spec={spec}
+                  colorProgress={colorProgress}
+                  screenWidth={width}
+                  screenHeight={height}
+                />
+              ))}
+        </View>
 
         <Animated.View style={[styles.card, cardAnimatedStyle]}>
           {state === 'sending' && (
@@ -420,23 +432,6 @@ export default function PaymentProgressOverlay({
             </TouchableOpacity>
           ) : null}
         </Animated.View>
-
-        {/* Confetti sits on top of the card so pieces visibly burst past
-         *  the card edges as they fly radially outward. Origin = screen
-         *  centre, which matches the card's visual centre. */}
-        {isReceive ? (
-          <View style={StyleSheet.absoluteFill} pointerEvents="none">
-            {confettiSpecs.map((spec) => (
-              <Confetti
-                key={spec.index}
-                spec={spec}
-                armed={confettiArmed}
-                originX={width / 2}
-                originY={height / 2}
-              />
-            ))}
-          </View>
-        ) : null}
       </View>
     </Modal>
   );

--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -39,7 +39,7 @@ interface Props {
 }
 
 const BUBBLE_COUNT = 140;
-const CONFETTI_COUNT = 90;
+const CONFETTI_COUNT = 135;
 // Screen should be packed with bubbles by ~5s. Quadratic stagger means
 // early bubbles are sparse and density ramps up rapidly toward the 5s mark.
 const FULL_DENSITY_MS = 5000;

--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Modal,
   View,
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   useWindowDimensions,
   ActivityIndicator,
+  TouchableOpacity,
 } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -42,9 +43,6 @@ const CONFETTI_COUNT = 90;
 // Screen should be packed with bubbles by ~5s. Quadratic stagger means
 // early bubbles are sparse and density ramps up rapidly toward the 5s mark.
 const FULL_DENSITY_MS = 5000;
-// Auto-dismiss delay once we hit `success`; gives the user a beat to see
-// the tick + the green bubble wave (or confetti burst) before closing.
-const SUCCESS_DISMISS_MS = 2200;
 
 // On-brand confetti palette — Piggy pink plus blues and purples.
 const CONFETTI_COLORS = [
@@ -75,7 +73,7 @@ function makeSpecs(count: number, screenHeight: number): BubbleSpec[] {
     specs.push({
       index: i,
       startXRatio: Math.random(),
-      size: 10 + Math.random() * 34,
+      size: 22 + Math.random() * 46,
       duration: 2400 + Math.random() * 1800,
       driftPx: -40 + Math.random() * 80,
       delayMs,
@@ -90,12 +88,17 @@ function makeSpecs(count: number, screenHeight: number): BubbleSpec[] {
 
 interface ConfettiSpec {
   index: number;
-  startXRatio: number;
   width: number;
   height: number;
   color: string;
+  // Radial burst from the card centre: initial velocity (px/s).
+  vx: number;
+  vy: number;
+  // Gravity pulls pieces down after the initial burst (px/s²).
+  gravity: number;
+  // Total animation duration (ms).
   duration: number;
-  driftPx: number;
+  // Small per-piece launch stagger so the burst feels alive, not mechanical.
   delayMs: number;
   spinTurns: number;
   opacityPeak: number;
@@ -104,20 +107,27 @@ interface ConfettiSpec {
 function makeConfettiSpecs(count: number): ConfettiSpec[] {
   const specs: ConfettiSpec[] = [];
   for (let i = 0; i < count; i++) {
-    // Staggered launch over ~800ms for a celebratory wave rather than
-    // a hard burst. Longer than that and it feels sluggish.
-    const delayMs = Math.random() * 800;
+    // Pick a random angle across the full circle, then bias slightly
+    // upward so the burst feels explosive rather than dribbling straight
+    // down into gravity.
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 320 + Math.random() * 380; // px/s
+    const vx = Math.cos(angle) * speed;
+    // Bias upward: subtract a small extra upward component so on average
+    // pieces launch *outward-and-up* before gravity takes over.
+    const vy = Math.sin(angle) * speed - 80;
     specs.push({
       index: i,
-      startXRatio: Math.random(),
       width: 7 + Math.random() * 6,
       height: 10 + Math.random() * 8,
       color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
-      duration: 2200 + Math.random() * 1600,
-      driftPx: -60 + Math.random() * 120,
-      delayMs,
-      spinTurns: 2 + Math.random() * 4,
-      opacityPeak: 0.85 + Math.random() * 0.15,
+      vx,
+      vy,
+      gravity: 780 + Math.random() * 180,
+      duration: 1800 + Math.random() * 900,
+      delayMs: Math.random() * 220,
+      spinTurns: 1.5 + Math.random() * 3.5,
+      opacityPeak: 0.9 + Math.random() * 0.1,
     });
   }
   return specs;
@@ -180,22 +190,23 @@ function Bubble({ spec, colorProgress, screenWidth, screenHeight }: BubbleProps)
 interface ConfettiProps {
   spec: ConfettiSpec;
   armed: SharedValue<number>;
-  screenWidth: number;
-  screenHeight: number;
+  originX: number;
+  originY: number;
 }
 
-function Confetti({ spec, armed, screenWidth, screenHeight }: ConfettiProps) {
+function Confetti({ spec, armed, originX, originY }: ConfettiProps) {
+  // `progress` goes 0 → 1 across `spec.duration`. We interpret it as
+  // elapsed-time in seconds via `progress * duration/1000` and plug that
+  // into a standard projectile equation with gravity.
   const progress = useSharedValue(0);
 
-  // React to the `armed` shared value flipping 0 → 1 — that kicks off the
-  // fall animation for this piece with its per-spec stagger.
   useAnimatedReaction(
     () => armed.value,
     (armedNow, armedBefore) => {
       if (armedNow === 1 && armedBefore !== 1) {
         progress.value = withDelay(
           spec.delayMs,
-          withTiming(1, { duration: spec.duration, easing: Easing.in(Easing.quad) }),
+          withTiming(1, { duration: spec.duration, easing: Easing.linear }),
         );
       } else if (armedNow === 0) {
         cancelAnimation(progress);
@@ -205,21 +216,24 @@ function Confetti({ spec, armed, screenWidth, screenHeight }: ConfettiProps) {
   );
 
   const animatedStyle = useAnimatedStyle(() => {
-    const y = interpolate(progress.value, [0, 1], [-80, screenHeight + 80]);
-    const xOffset = Math.sin(progress.value * Math.PI * 1.5) * spec.driftPx;
+    // Seconds since this piece launched.
+    const t = (progress.value * spec.duration) / 1000;
+    // Classic projectile: s = v0·t + ½·g·t². Horizontal has no accel.
+    const tx = spec.vx * t;
+    const ty = spec.vy * t + 0.5 * spec.gravity * t * t;
     const rotate = `${progress.value * spec.spinTurns * 360}deg`;
+    // Quick fade-in at the start (so it pops from behind the card), then
+    // a longer tail fade as pieces fall past the edges.
     const opacity = interpolate(
       progress.value,
-      [0, 0.05, 0.9, 1],
+      [0, 0.06, 0.75, 1],
       [0, spec.opacityPeak, spec.opacityPeak, 0],
     );
     return {
-      transform: [{ translateX: xOffset }, { translateY: y }, { rotate }],
+      transform: [{ translateX: tx }, { translateY: ty }, { rotate }],
       opacity,
     };
   });
-
-  const baseLeft = spec.startXRatio * screenWidth - spec.width / 2;
 
   return (
     <Animated.View
@@ -230,8 +244,8 @@ function Confetti({ spec, armed, screenWidth, screenHeight }: ConfettiProps) {
           width: spec.width,
           height: spec.height,
           backgroundColor: spec.color,
-          left: baseLeft,
-          top: 0,
+          left: originX - spec.width / 2,
+          top: originY - spec.height / 2,
         },
         animatedStyle,
       ]}
@@ -280,24 +294,24 @@ export default function PaymentProgressOverlay({
     }
   }, [visible, cardScale, cardOpacity, colorProgress, iconScale, confettiArmed]);
 
-  // Drive colour + icon animations on state change, and auto-dismiss on success.
-  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Drive colour + icon animations on state change. Dismissal is
+  // user-driven — neither send nor receive auto-closes, so the user
+  // always confirms they saw the outcome before we tear down the sheet.
   useEffect(() => {
     if (state === 'success') {
       if (direction === 'send') {
         // Bubbles morph from pink to green on a successful send.
         colorProgress.value = withTiming(1, { duration: 650 });
       } else {
-        // Receive: fire the on-brand confetti burst.
-        confettiArmed.value = 1;
+        // Receive: fire the on-brand confetti burst. We delay the
+        // launch by 280ms so the card visibly springs in *first* and
+        // the burst reads as coming from behind it.
+        confettiArmed.value = withDelay(280, withTiming(1, { duration: 0 }));
       }
       iconScale.value = withSequence(
         withTiming(0, { duration: 0 }),
         withSpring(1, { damping: 10, stiffness: 220 }),
       );
-      dismissTimerRef.current = setTimeout(() => {
-        onDismiss();
-      }, SUCCESS_DISMISS_MS);
     } else if (state === 'error') {
       iconScale.value = withSequence(
         withTiming(0, { duration: 0 }),
@@ -308,13 +322,7 @@ export default function PaymentProgressOverlay({
       iconScale.value = 0;
       confettiArmed.value = 0;
     }
-    return () => {
-      if (dismissTimerRef.current) {
-        clearTimeout(dismissTimerRef.current);
-        dismissTimerRef.current = null;
-      }
-    };
-  }, [state, direction, colorProgress, iconScale, confettiArmed, onDismiss]);
+  }, [state, direction, colorProgress, iconScale, confettiArmed]);
 
   const cardAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: cardScale.value }],
@@ -365,27 +373,20 @@ export default function PaymentProgressOverlay({
       onRequestClose={state === 'sending' ? undefined : onDismiss}
     >
       <View style={styles.root}>
-        <View style={StyleSheet.absoluteFill} pointerEvents="none">
-          {isReceive
-            ? confettiSpecs.map((spec) => (
-                <Confetti
-                  key={spec.index}
-                  spec={spec}
-                  armed={confettiArmed}
-                  screenWidth={width}
-                  screenHeight={height}
-                />
-              ))
-            : bubbleSpecs.map((spec) => (
-                <Bubble
-                  key={spec.index}
-                  spec={spec}
-                  colorProgress={colorProgress}
-                  screenWidth={width}
-                  screenHeight={height}
-                />
-              ))}
-        </View>
+        {/* Bubbles live behind the card on the send flow. */}
+        {!isReceive ? (
+          <View style={StyleSheet.absoluteFill} pointerEvents="none">
+            {bubbleSpecs.map((spec) => (
+              <Bubble
+                key={spec.index}
+                spec={spec}
+                colorProgress={colorProgress}
+                screenWidth={width}
+                screenHeight={height}
+              />
+            ))}
+          </View>
+        ) : null}
 
         <Animated.View style={[styles.card, cardAnimatedStyle]}>
           {state === 'sending' && (
@@ -404,7 +405,38 @@ export default function PaymentProgressOverlay({
 
           <Text style={styles.title}>{title}</Text>
           {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+
+          {/* The user must acknowledge send/receive/error outcomes before
+           *  we tear down the sheet — auto-dismiss can hide the fact the
+           *  money moved if they weren't looking. No button while sending. */}
+          {state !== 'sending' ? (
+            <TouchableOpacity
+              style={styles.okButton}
+              onPress={onDismiss}
+              accessibilityLabel="Dismiss payment confirmation"
+              testID="payment-overlay-ok"
+            >
+              <Text style={styles.okButtonText}>{state === 'error' ? 'Dismiss' : 'OK'}</Text>
+            </TouchableOpacity>
+          ) : null}
         </Animated.View>
+
+        {/* Confetti sits on top of the card so pieces visibly burst past
+         *  the card edges as they fly radially outward. Origin = screen
+         *  centre, which matches the card's visual centre. */}
+        {isReceive ? (
+          <View style={StyleSheet.absoluteFill} pointerEvents="none">
+            {confettiSpecs.map((spec) => (
+              <Confetti
+                key={spec.index}
+                spec={spec}
+                armed={confettiArmed}
+                originX={width / 2}
+                originY={height / 2}
+              />
+            ))}
+          </View>
+        ) : null}
       </View>
     </Modal>
   );
@@ -464,5 +496,20 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: colors.textSupplementary,
     textAlign: 'center',
+  },
+  okButton: {
+    marginTop: 12,
+    alignSelf: 'stretch',
+    backgroundColor: colors.brandPink,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 14,
+    alignItems: 'center',
+  },
+  okButtonText: {
+    color: colors.white,
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: 0.3,
   },
 });

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -30,7 +30,6 @@ import { colors } from '../styles/theme';
 import { receiveSheetStyles as styles } from '../styles/ReceiveSheet.styles';
 import { satsToFiatString, satsToFiat } from '../services/fiatService';
 import FriendPickerSheet, { PickedFriend } from './FriendPickerSheet';
-import PaymentProgressOverlay, { PaymentProgressState } from './PaymentProgressOverlay';
 import type { RootStackParamList } from '../navigation/types';
 // On-chain address fetching is done via WalletContext.getReceiveAddress
 
@@ -74,8 +73,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   const [onchainAddress, setOnchainAddress] = useState<string | null>(null);
   const [friendPickerOpen, setFriendPickerOpen] = useState(false);
   const [sendingToFriend, setSendingToFriend] = useState(false);
-  const [celebrateState, setCelebrateState] = useState<PaymentProgressState>('hidden');
-  const [celebrateAmount, setCelebrateAmount] = useState<number | undefined>(undefined);
   const intervalId = useRef<ReturnType<typeof setInterval> | null>(null);
   const prevBalance = useRef<number | null>(null);
   // When true, the next observed balance is treated as the "pre-invoice"
@@ -228,14 +225,11 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [capturedWalletId]);
 
-  // Detect payment by watching balance changes. The first balance we
-  // observe after sheet-open / wallet-switch / invoice-regeneration is
-  // treated as the baseline — pending credits from prior invoices get
-  // absorbed here rather than firing a misattributed celebration. On
-  // fire we advance the baseline to the new balance so another incoming
-  // payment (second invoice in the same session) still registers, and
-  // we do NOT stop polling — the overlay stays up until the user taps OK
-  // but the detector continues to work if they dismiss and invoice again.
+  // The "paymentReceived" checkmark on the QR thumbnail is driven by
+  // any balance increment while the sheet is open. The actual
+  // celebration overlay (confetti + tick card) is now rendered at app
+  // root via WalletContext.lastIncomingPayment — that way it pops on
+  // any screen, for any wallet, not just while this sheet is visible.
   useEffect(() => {
     if (!visible || balance === null) return;
     if (needsBaseline.current) {
@@ -244,19 +238,10 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
       return;
     }
     if (prevBalance.current !== null && balance > prevBalance.current) {
-      const delta = balance - prevBalance.current;
       prevBalance.current = balance;
-      setCelebrateAmount(delta > 0 ? delta : undefined);
-      setCelebrateState('success');
       setPaymentReceived(true);
     }
   }, [balance, visible]);
-
-  const handleCelebrateDismiss = useCallback(() => {
-    setCelebrateState('hidden');
-    setCelebrateAmount(undefined);
-    onClose();
-  }, [onClose]);
 
   const scheduleInvoice = (sats: number) => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
@@ -722,12 +707,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         onSelect={handleFriendPicked}
         title="Send invoice to a friend"
         subtitle="They'll get an encrypted Nostr DM with a Pay button."
-      />
-      <PaymentProgressOverlay
-        state={celebrateState}
-        direction="receive"
-        amountSats={celebrateAmount}
-        onDismiss={handleCelebrateDismiss}
       />
     </>
   );

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -78,6 +78,13 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   const [celebrateAmount, setCelebrateAmount] = useState<number | undefined>(undefined);
   const intervalId = useRef<ReturnType<typeof setInterval> | null>(null);
   const prevBalance = useRef<number | null>(null);
+  // When true, the next observed balance is treated as the "pre-invoice"
+  // baseline and is NOT fired as a received payment. Reset on sheet-open,
+  // wallet-switch, and each new invoice creation — so pending credits
+  // that settle between app-open and invoice-create get absorbed into
+  // the baseline instead of firing a bogus celebration attributed to
+  // the newly-created invoice.
+  const needsBaseline = useRef(true);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const { sendDirectMessage, contacts } = useNostr();
@@ -111,13 +118,16 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         if (!wId) return;
         const inv = await makeInvoiceForWallet(wId, sats, 'Lightning Piggy');
         setInvoice(inv);
+        // Re-baseline: any pending credit from a previous invoice must
+        // not fire a celebration attributed to the new one. The first
+        // balance we see after this poll starts becomes the baseline.
+        needsBaseline.current = true;
         // Poll every 1.5 s while the receive sheet is open. NWC
         // notifications (NIP-47) would eliminate the wait entirely, but
         // support is patchy across wallets (LNbits, Mutiny, Alby etc.),
-        // so a short active-poll remains the fallback. Battery cost is
-        // bounded — the interval is cleared as soon as the sheet closes
-        // or the balance increment is detected (see the paymentReceived
-        // handler further down).
+        // so a short active-poll remains the fallback. Polling continues
+        // after a celebration fires so subsequent receives still register
+        // (user could create a second invoice without closing the sheet).
         intervalId.current = setInterval(async () => {
           if (wId) await refreshBalanceForWallet(wId);
         }, 1500);
@@ -138,7 +148,12 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     if (visible) {
       setCapturedWalletId(activeWalletId);
       setDropdownOpen(false);
-      prevBalance.current = balance;
+      // Baseline is set from the first observed balance (see effect
+      // below), not from the cached value here — the cache may be stale
+      // if the app has been backgrounded and a previous invoice settled
+      // while we weren't polling.
+      prevBalance.current = null;
+      needsBaseline.current = true;
       setOnchainAddress(null);
       setSatsValue('');
       setFiatValue('');
@@ -194,7 +209,10 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     setPaymentReceived(false);
     setSatsValue('');
     setFiatValue('');
-    prevBalance.current = selectedWallet?.balance ?? null;
+    // Wallet switch clears the baseline; the next balance observed for
+    // the new wallet is treated as the pre-invoice starting point.
+    prevBalance.current = null;
+    needsBaseline.current = true;
     if (intervalId.current) {
       clearInterval(intervalId.current);
       intervalId.current = null;
@@ -210,22 +228,27 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [capturedWalletId]);
 
-  // Detect payment by watching balance changes
+  // Detect payment by watching balance changes. The first balance we
+  // observe after sheet-open / wallet-switch / invoice-regeneration is
+  // treated as the baseline — pending credits from prior invoices get
+  // absorbed here rather than firing a misattributed celebration. On
+  // fire we advance the baseline to the new balance so another incoming
+  // payment (second invoice in the same session) still registers, and
+  // we do NOT stop polling — the overlay stays up until the user taps OK
+  // but the detector continues to work if they dismiss and invoice again.
   useEffect(() => {
-    if (
-      visible &&
-      prevBalance.current !== null &&
-      balance !== null &&
-      balance > prevBalance.current
-    ) {
+    if (!visible || balance === null) return;
+    if (needsBaseline.current) {
+      prevBalance.current = balance;
+      needsBaseline.current = false;
+      return;
+    }
+    if (prevBalance.current !== null && balance > prevBalance.current) {
       const delta = balance - prevBalance.current;
+      prevBalance.current = balance;
       setCelebrateAmount(delta > 0 ? delta : undefined);
       setCelebrateState('success');
       setPaymentReceived(true);
-      if (intervalId.current) {
-        clearInterval(intervalId.current);
-        intervalId.current = null;
-      }
     }
   }, [balance, visible]);
 

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -30,7 +30,6 @@ import { walletLabel } from '../types/wallet';
 import { colors } from '../styles/theme';
 import { receiveSheetStyles as styles } from '../styles/ReceiveSheet.styles';
 import { satsToFiatString, satsToFiat } from '../services/fiatService';
-import * as nwcService from '../services/nwcService';
 import FriendPickerSheet, { PickedFriend } from './FriendPickerSheet';
 import type { RootStackParamList } from '../navigation/types';
 
@@ -98,6 +97,7 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     currency,
     lightningAddress,
     getReceiveAddress,
+    expectPayment,
   } = useWallet();
   const [capturedWalletId, setCapturedWalletId] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -111,11 +111,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   const [onchainAddress, setOnchainAddress] = useState<string | null>(null);
   const [friendPickerOpen, setFriendPickerOpen] = useState(false);
   const [sendingToFriend, setSendingToFriend] = useState(false);
-  const intervalId = useRef<ReturnType<typeof setInterval> | null>(null);
-  // Timer that downshifts the poll cadence once the user has been
-  // actively waiting for a payment for a while. Avoids running a 1.5 s
-  // poll forever if the user leaves the sheet open and walks away.
-  const pollDownshiftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevBalance = useRef<number | null>(null);
   // When true, the next observed balance is treated as the "pre-invoice"
   // baseline and is NOT fired as a received payment. Reset on sheet-open,
@@ -146,10 +141,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
 
   const generateInvoice = useCallback(
     async (sats: number) => {
-      if (intervalId.current) {
-        clearInterval(intervalId.current);
-        intervalId.current = null;
-      }
       setLoading(true);
       setPaymentReceived(false);
       try {
@@ -162,56 +153,28 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         // balance we see after this poll starts becomes the baseline.
         needsBaseline.current = true;
 
-        // Belt-and-suspenders poll: on every tick we fire BOTH a
-        // `lookup_invoice` (targeted per-hash check — fastest signal
-        // when paid flips, independent of balance aggregation) AND a
-        // `refreshBalanceForWallet` (which ultimately lands in the
-        // WalletContext diff-detector that renders the global overlay).
-        // Running both means a flaky NWC backend — `get_balance` is
-        // observed to time out on our LNbits occasionally — still
-        // has a fallback path: whichever returns first wins. The
-        // balance refresh is the one that actually fires the overlay,
-        // so don't early-return from the lookup path; let the balance
-        // diff drive detection.
+        // Hand the invoice off to WalletContext.expectPayment, which
+        // runs a 1 s lookup_invoice + balance poll for the next 3 min.
+        // The poll lives in the context (not this sheet), so it keeps
+        // running even if the user closes the receive sheet and wanders
+        // off to Friends / Home etc. — the app-root overlay still pops
+        // on settle regardless of which screen is active.
         const paymentHash = paymentHashFromBolt11(inv);
-        if (__DEV__)
-          console.log(
-            `[Receive] starting 1 s poll · paymentHash=${paymentHash ? paymentHash.slice(0, 12) + '…' : 'null (fallback to balance)'}`,
-          );
-        if (pollDownshiftTimer.current) clearTimeout(pollDownshiftTimer.current);
-        intervalId.current = setInterval(async () => {
-          if (!wId) return;
-          const [lookupResult] = await Promise.allSettled([
-            paymentHash ? nwcService.lookupInvoice(wId, paymentHash) : Promise.resolve(null),
-            refreshBalanceForWallet(wId),
-          ]);
-          if (lookupResult.status === 'fulfilled' && lookupResult.value?.paid) {
-            if (__DEV__) console.log('[Receive] lookup_invoice reports PAID — stopping poll');
-            if (intervalId.current) {
-              clearInterval(intervalId.current);
-              intervalId.current = null;
-            }
-          }
-        }, 1000);
-        // Stop the aggressive poll after 3 min. A late-arriving payment
-        // is still detected by any organic refresh (pull-to-refresh,
-        // foreground resume, etc.) — see WalletContext baseline logic.
-        pollDownshiftTimer.current = setTimeout(
-          () => {
-            if (intervalId.current) {
-              clearInterval(intervalId.current);
-              intervalId.current = null;
-            }
-          },
-          3 * 60 * 1000,
-        );
+        if (paymentHash) {
+          expectPayment(wId, paymentHash);
+        } else {
+          // Unparseable bolt11 — fall back to a single balance refresh.
+          // The WalletContext 30 s baseline poll still picks the
+          // settle up eventually if the user lingers in-app.
+          await refreshBalanceForWallet(wId);
+        }
       } catch (error) {
         console.warn('Failed to create invoice:', error);
       } finally {
         setLoading(false);
       }
     },
-    [makeInvoiceForWallet, refreshBalanceForWallet, capturedWalletId],
+    [makeInvoiceForWallet, refreshBalanceForWallet, capturedWalletId, expectPayment],
   );
 
   const isOnchainWallet = selectedWallet?.walletType === 'onchain';
@@ -256,14 +219,10 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
       bottomSheetRef.current?.dismiss();
     }
     return () => {
-      if (intervalId.current) {
-        clearInterval(intervalId.current);
-        intervalId.current = null;
-      }
-      if (pollDownshiftTimer.current) {
-        clearTimeout(pollDownshiftTimer.current);
-        pollDownshiftTimer.current = null;
-      }
+      // Poll lives in WalletContext.expectPayment now and survives
+      // sheet closure (so the user can generate an invoice, close the
+      // sheet, navigate elsewhere, and still get the celebration).
+      // Only the debounce timer is sheet-local.
       if (debounceTimer.current) clearTimeout(debounceTimer.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -291,10 +250,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     // the new wallet is treated as the pre-invoice starting point.
     prevBalance.current = null;
     needsBaseline.current = true;
-    if (intervalId.current) {
-      clearInterval(intervalId.current);
-      intervalId.current = null;
-    }
     if (selectedWallet?.walletType === 'onchain') {
       setMode('address');
       getReceiveAddress(capturedWalletId)
@@ -328,10 +283,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     if (sats <= 0) {
       setInvoice('');
-      if (intervalId.current) {
-        clearInterval(intervalId.current);
-        intervalId.current = null;
-      }
       return;
     }
     debounceTimer.current = setTimeout(() => {

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -162,34 +162,35 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         // balance we see after this poll starts becomes the baseline.
         needsBaseline.current = true;
 
-        // Targeted invoice polling: ask the NWC backend directly whether
-        // THIS invoice is settled (`lookup_invoice`) rather than polling
-        // the wallet-wide balance. LNbits flips the invoice's settled_at
-        // the moment LND signals settle — no need to wait for balance
-        // aggregation. Faster than get_balance on most backends and
-        // race-free (we get definitive paid/unpaid per invoice hash).
-        // Falls through to refreshBalanceForWallet on settle so the
-        // detector in WalletContext picks it up and fires the overlay.
+        // Belt-and-suspenders poll: on every tick we fire BOTH a
+        // `lookup_invoice` (targeted per-hash check — fastest signal
+        // when paid flips, independent of balance aggregation) AND a
+        // `refreshBalanceForWallet` (which ultimately lands in the
+        // WalletContext diff-detector that renders the global overlay).
+        // Running both means a flaky NWC backend — `get_balance` is
+        // observed to time out on our LNbits occasionally — still
+        // has a fallback path: whichever returns first wins. The
+        // balance refresh is the one that actually fires the overlay,
+        // so don't early-return from the lookup path; let the balance
+        // diff drive detection.
         const paymentHash = paymentHashFromBolt11(inv);
+        if (__DEV__)
+          console.log(
+            `[Receive] starting 1 s poll · paymentHash=${paymentHash ? paymentHash.slice(0, 12) + '…' : 'null (fallback to balance)'}`,
+          );
         if (pollDownshiftTimer.current) clearTimeout(pollDownshiftTimer.current);
         intervalId.current = setInterval(async () => {
           if (!wId) return;
-          if (paymentHash) {
-            const result = await nwcService.lookupInvoice(wId, paymentHash);
-            if (result?.paid) {
-              if (intervalId.current) {
-                clearInterval(intervalId.current);
-                intervalId.current = null;
-              }
-              // Trigger a balance refresh so the diff-detector in
-              // WalletContext fires the overlay. Wallet balance lags the
-              // invoice-settled flag by at most a tick.
-              await refreshBalanceForWallet(wId);
-              return;
+          const [lookupResult] = await Promise.allSettled([
+            paymentHash ? nwcService.lookupInvoice(wId, paymentHash) : Promise.resolve(null),
+            refreshBalanceForWallet(wId),
+          ]);
+          if (lookupResult.status === 'fulfilled' && lookupResult.value?.paid) {
+            if (__DEV__) console.log('[Receive] lookup_invoice reports PAID — stopping poll');
+            if (intervalId.current) {
+              clearInterval(intervalId.current);
+              intervalId.current = null;
             }
-          } else {
-            // No extractable payment_hash — fall back to balance polling.
-            await refreshBalanceForWallet(wId);
           }
         }, 1000);
         // Stop the aggressive poll after 3 min. A late-arriving payment

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -23,14 +23,52 @@ import * as Clipboard from 'expo-clipboard';
 import Toast from 'react-native-toast-message';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { decode as bolt11Decode } from 'light-bolt11-decoder';
 import { useWallet } from '../contexts/WalletContext';
 import { useNostr } from '../contexts/NostrContext';
 import { walletLabel } from '../types/wallet';
 import { colors } from '../styles/theme';
 import { receiveSheetStyles as styles } from '../styles/ReceiveSheet.styles';
 import { satsToFiatString, satsToFiat } from '../services/fiatService';
+import * as nwcService from '../services/nwcService';
 import FriendPickerSheet, { PickedFriend } from './FriendPickerSheet';
 import type { RootStackParamList } from '../navigation/types';
+
+function paymentHashFromBolt11(bolt11: string): string | null {
+  try {
+    const decoded = bolt11Decode(bolt11);
+    const section = decoded.sections?.find((s: { name: string }) => s.name === 'payment_hash') as
+      | { value?: string }
+      | undefined;
+    return section?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Accept only digit characters — sats are whole integers. A hardware
+// keyboard, paste, or an autocomplete suggestion can all inject junk
+// that the soft-keyboard's `numeric` hint alone doesn't block.
+function sanitizeSatsInput(text: string): string {
+  return text.replace(/[^0-9]/g, '');
+}
+
+// Accept digits and a single decimal point, with at most two decimal
+// places (standard fiat presentation). Strip everything else. Dropping
+// a stray comma / currency symbol on paste is the common reason users
+// see "Invalid amount" when they didn't mistype anything.
+function sanitizeFiatInput(text: string): string {
+  let cleaned = text.replace(/[^0-9.]/g, '');
+  const firstDot = cleaned.indexOf('.');
+  if (firstDot !== -1) {
+    // Keep the first dot, drop any subsequent ones.
+    cleaned = cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
+    // Trim to two decimal places.
+    const [intPart, fracPart = ''] = cleaned.split('.');
+    cleaned = `${intPart}.${fracPart.slice(0, 2)}`;
+  }
+  return cleaned;
+}
 // On-chain address fetching is done via WalletContext.getReceiveAddress
 
 interface Props {
@@ -123,17 +161,40 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         // not fire a celebration attributed to the new one. The first
         // balance we see after this poll starts becomes the baseline.
         needsBaseline.current = true;
-        // Poll every 1.5 s for the first 3 minutes after invoice
-        // creation — that's the window the user is actively waiting for
-        // payment. After that the aggressive poll stops; a late-arriving
-        // payment is still detected by any organic balance refresh
-        // (pull-to-refresh, send, app foreground-resume, etc.). Prevents
-        // forever-1.5 s battery/network drain if the user leaves the
-        // sheet open and walks away.
+
+        // Targeted invoice polling: ask the NWC backend directly whether
+        // THIS invoice is settled (`lookup_invoice`) rather than polling
+        // the wallet-wide balance. LNbits flips the invoice's settled_at
+        // the moment LND signals settle — no need to wait for balance
+        // aggregation. Faster than get_balance on most backends and
+        // race-free (we get definitive paid/unpaid per invoice hash).
+        // Falls through to refreshBalanceForWallet on settle so the
+        // detector in WalletContext picks it up and fires the overlay.
+        const paymentHash = paymentHashFromBolt11(inv);
         if (pollDownshiftTimer.current) clearTimeout(pollDownshiftTimer.current);
         intervalId.current = setInterval(async () => {
-          if (wId) await refreshBalanceForWallet(wId);
-        }, 1500);
+          if (!wId) return;
+          if (paymentHash) {
+            const result = await nwcService.lookupInvoice(wId, paymentHash);
+            if (result?.paid) {
+              if (intervalId.current) {
+                clearInterval(intervalId.current);
+                intervalId.current = null;
+              }
+              // Trigger a balance refresh so the diff-detector in
+              // WalletContext fires the overlay. Wallet balance lags the
+              // invoice-settled flag by at most a tick.
+              await refreshBalanceForWallet(wId);
+              return;
+            }
+          } else {
+            // No extractable payment_hash — fall back to balance polling.
+            await refreshBalanceForWallet(wId);
+          }
+        }, 1000);
+        // Stop the aggressive poll after 3 min. A late-arriving payment
+        // is still detected by any organic refresh (pull-to-refresh,
+        // foreground resume, etc.) — see WalletContext baseline logic.
         pollDownshiftTimer.current = setTimeout(
           () => {
             if (intervalId.current) {
@@ -278,8 +339,9 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   };
 
   const handleSatsChange = (text: string) => {
-    setSatsValue(text);
-    const sats = parseInt(text) || 0;
+    const clean = sanitizeSatsInput(text);
+    setSatsValue(clean);
+    const sats = parseInt(clean) || 0;
     if (btcPrice) {
       setFiatValue(satsToFiat(sats, btcPrice).toFixed(2));
     } else {
@@ -289,8 +351,9 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   };
 
   const handleFiatChange = (text: string) => {
-    setFiatValue(text);
-    const fiat = parseFloat(text) || 0;
+    const clean = sanitizeFiatInput(text);
+    setFiatValue(clean);
+    const fiat = parseFloat(clean) || 0;
     const sats = fiatToSats(fiat);
     setSatsValue(sats.toString());
     scheduleInvoice(sats);

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -40,7 +40,11 @@ function paymentHashFromBolt11(bolt11: string): string | null {
       | { value?: string }
       | undefined;
     return section?.value ?? null;
-  } catch {
+  } catch (error) {
+    // Silent null returns would mask broken invoice generation; at
+    // least surface it in dev logs so the fallback-to-balance-poll is
+    // traceable.
+    if (__DEV__) console.warn('[Receive] bolt11 decode failed:', error);
     return null;
   }
 }
@@ -98,6 +102,7 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     lightningAddress,
     getReceiveAddress,
     expectPayment,
+    lastIncomingPayment,
   } = useWallet();
   const [capturedWalletId, setCapturedWalletId] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -111,14 +116,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   const [onchainAddress, setOnchainAddress] = useState<string | null>(null);
   const [friendPickerOpen, setFriendPickerOpen] = useState(false);
   const [sendingToFriend, setSendingToFriend] = useState(false);
-  const prevBalance = useRef<number | null>(null);
-  // When true, the next observed balance is treated as the "pre-invoice"
-  // baseline and is NOT fired as a received payment. Reset on sheet-open,
-  // wallet-switch, and each new invoice creation — so pending credits
-  // that settle between app-open and invoice-create get absorbed into
-  // the baseline instead of firing a bogus celebration attributed to
-  // the newly-created invoice.
-  const needsBaseline = useRef(true);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const { sendDirectMessage, contacts } = useNostr();
@@ -137,7 +134,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     [wallets, selectedWalletId],
   );
   const walletName = selectedWallet ? walletLabel(selectedWallet) : 'Wallet';
-  const balance = selectedWallet?.balance ?? null;
 
   const generateInvoice = useCallback(
     async (sats: number) => {
@@ -148,20 +144,19 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         if (!wId) return;
         const inv = await makeInvoiceForWallet(wId, sats, 'Lightning Piggy');
         setInvoice(inv);
-        // Re-baseline: any pending credit from a previous invoice must
-        // not fire a celebration attributed to the new one. The first
-        // balance we see after this poll starts becomes the baseline.
-        needsBaseline.current = true;
 
         // Hand the invoice off to WalletContext.expectPayment, which
         // runs a 1 s lookup_invoice + balance poll for the next 3 min.
         // The poll lives in the context (not this sheet), so it keeps
         // running even if the user closes the receive sheet and wanders
         // off to Friends / Home etc. — the app-root overlay still pops
-        // on settle regardless of which screen is active.
+        // on settle regardless of which screen is active. Passing the
+        // expected amount means the overlay shows the exact invoice
+        // value rather than a balance-delta that could include prior
+        // settles piled up between polls.
         const paymentHash = paymentHashFromBolt11(inv);
         if (paymentHash) {
-          expectPayment(wId, paymentHash);
+          expectPayment(wId, paymentHash, sats);
         } else {
           // Unparseable bolt11 — fall back to a single balance refresh.
           // The WalletContext 30 s baseline poll still picks the
@@ -189,8 +184,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
       // below), not from the cached value here — the cache may be stale
       // if the app has been backgrounded and a previous invoice settled
       // while we weren't polling.
-      prevBalance.current = null;
-      needsBaseline.current = true;
       setOnchainAddress(null);
       setSatsValue('');
       setFiatValue('');
@@ -246,10 +239,6 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     setPaymentReceived(false);
     setSatsValue('');
     setFiatValue('');
-    // Wallet switch clears the baseline; the next balance observed for
-    // the new wallet is treated as the pre-invoice starting point.
-    prevBalance.current = null;
-    needsBaseline.current = true;
     if (selectedWallet?.walletType === 'onchain') {
       setMode('address');
       getReceiveAddress(capturedWalletId)
@@ -261,23 +250,23 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [capturedWalletId]);
 
-  // The "paymentReceived" checkmark on the QR thumbnail is driven by
-  // any balance increment while the sheet is open. The actual
-  // celebration overlay (confetti + tick card) is now rendered at app
-  // root via WalletContext.lastIncomingPayment — that way it pops on
-  // any screen, for any wallet, not just while this sheet is visible.
+  // The "paymentReceived" checkmark on the QR thumbnail flips to true
+  // whenever the app-root overlay fires for the wallet this sheet is
+  // currently showing. We used to duplicate the baseline-detector
+  // logic locally — pointlessly, since WalletContext already owns it.
+  // Keyed on the event timestamp so a second receive within the same
+  // sheet session still re-arms the checkmark after the user dismisses
+  // the global overlay and clears `lastIncomingPayment`.
   useEffect(() => {
-    if (!visible || balance === null) return;
-    if (needsBaseline.current) {
-      prevBalance.current = balance;
-      needsBaseline.current = false;
-      return;
-    }
-    if (prevBalance.current !== null && balance > prevBalance.current) {
-      prevBalance.current = balance;
+    if (!visible) return;
+    if (
+      lastIncomingPayment &&
+      selectedWallet &&
+      lastIncomingPayment.walletId === selectedWallet.id
+    ) {
       setPaymentReceived(true);
     }
-  }, [balance, visible]);
+  }, [lastIncomingPayment, selectedWallet, visible]);
 
   const scheduleInvoice = (sats: number) => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -125,9 +125,9 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         needsBaseline.current = true;
         // Poll every 1.5 s for the first 3 minutes after invoice
         // creation — that's the window the user is actively waiting for
-        // payment. After that, stop the aggressive poll: the global
-        // WalletContext poll (every 10 s while foreground) still catches
-        // payments that come in later, just a bit slower. Prevents
+        // payment. After that the aggressive poll stops; a late-arriving
+        // payment is still detected by any organic balance refresh
+        // (pull-to-refresh, send, app foreground-resume, etc.). Prevents
         // forever-1.5 s battery/network drain if the user leaves the
         // sheet open and walks away.
         if (pollDownshiftTimer.current) clearTimeout(pollDownshiftTimer.current);

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -74,6 +74,10 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   const [friendPickerOpen, setFriendPickerOpen] = useState(false);
   const [sendingToFriend, setSendingToFriend] = useState(false);
   const intervalId = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Timer that downshifts the poll cadence once the user has been
+  // actively waiting for a payment for a while. Avoids running a 1.5 s
+  // poll forever if the user leaves the sheet open and walks away.
+  const pollDownshiftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevBalance = useRef<number | null>(null);
   // When true, the next observed balance is treated as the "pre-invoice"
   // baseline and is NOT fired as a received payment. Reset on sheet-open,
@@ -119,15 +123,26 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         // not fire a celebration attributed to the new one. The first
         // balance we see after this poll starts becomes the baseline.
         needsBaseline.current = true;
-        // Poll every 1.5 s while the receive sheet is open. NWC
-        // notifications (NIP-47) would eliminate the wait entirely, but
-        // support is patchy across wallets (LNbits, Mutiny, Alby etc.),
-        // so a short active-poll remains the fallback. Polling continues
-        // after a celebration fires so subsequent receives still register
-        // (user could create a second invoice without closing the sheet).
+        // Poll every 1.5 s for the first 3 minutes after invoice
+        // creation — that's the window the user is actively waiting for
+        // payment. After that, stop the aggressive poll: the global
+        // WalletContext poll (every 10 s while foreground) still catches
+        // payments that come in later, just a bit slower. Prevents
+        // forever-1.5 s battery/network drain if the user leaves the
+        // sheet open and walks away.
+        if (pollDownshiftTimer.current) clearTimeout(pollDownshiftTimer.current);
         intervalId.current = setInterval(async () => {
           if (wId) await refreshBalanceForWallet(wId);
         }, 1500);
+        pollDownshiftTimer.current = setTimeout(
+          () => {
+            if (intervalId.current) {
+              clearInterval(intervalId.current);
+              intervalId.current = null;
+            }
+          },
+          3 * 60 * 1000,
+        );
       } catch (error) {
         console.warn('Failed to create invoice:', error);
       } finally {
@@ -182,6 +197,10 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
       if (intervalId.current) {
         clearInterval(intervalId.current);
         intervalId.current = null;
+      }
+      if (pollDownshiftTimer.current) {
+        clearTimeout(pollDownshiftTimer.current);
+        pollDownshiftTimer.current = null;
       }
       if (debounceTimer.current) clearTimeout(debounceTimer.current);
     };

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -30,6 +30,7 @@ import { colors } from '../styles/theme';
 import { receiveSheetStyles as styles } from '../styles/ReceiveSheet.styles';
 import { satsToFiatString, satsToFiat } from '../services/fiatService';
 import FriendPickerSheet, { PickedFriend } from './FriendPickerSheet';
+import PaymentProgressOverlay, { PaymentProgressState } from './PaymentProgressOverlay';
 import type { RootStackParamList } from '../navigation/types';
 // On-chain address fetching is done via WalletContext.getReceiveAddress
 
@@ -73,6 +74,8 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
   const [onchainAddress, setOnchainAddress] = useState<string | null>(null);
   const [friendPickerOpen, setFriendPickerOpen] = useState(false);
   const [sendingToFriend, setSendingToFriend] = useState(false);
+  const [celebrateState, setCelebrateState] = useState<PaymentProgressState>('hidden');
+  const [celebrateAmount, setCelebrateAmount] = useState<number | undefined>(undefined);
   const intervalId = useRef<ReturnType<typeof setInterval> | null>(null);
   const prevBalance = useRef<number | null>(null);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -208,6 +211,9 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
       balance !== null &&
       balance > prevBalance.current
     ) {
+      const delta = balance - prevBalance.current;
+      setCelebrateAmount(delta > 0 ? delta : undefined);
+      setCelebrateState('success');
       setPaymentReceived(true);
       if (intervalId.current) {
         clearInterval(intervalId.current);
@@ -215,6 +221,12 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
       }
     }
   }, [balance, visible]);
+
+  const handleCelebrateDismiss = useCallback(() => {
+    setCelebrateState('hidden');
+    setCelebrateAmount(undefined);
+    onClose();
+  }, [onClose]);
 
   const scheduleInvoice = (sats: number) => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
@@ -680,6 +692,12 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         onSelect={handleFriendPicked}
         title="Send invoice to a friend"
         subtitle="They'll get an encrypted Nostr DM with a Pay button."
+      />
+      <PaymentProgressOverlay
+        state={celebrateState}
+        direction="receive"
+        amountSats={celebrateAmount}
+        onDismiss={handleCelebrateDismiss}
       />
     </>
   );

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -111,9 +111,16 @@ const ReceiveSheet: React.FC<Props> = ({ visible, onClose, presetFriend, onSent 
         if (!wId) return;
         const inv = await makeInvoiceForWallet(wId, sats, 'Lightning Piggy');
         setInvoice(inv);
+        // Poll every 1.5 s while the receive sheet is open. NWC
+        // notifications (NIP-47) would eliminate the wait entirely, but
+        // support is patchy across wallets (LNbits, Mutiny, Alby etc.),
+        // so a short active-poll remains the fallback. Battery cost is
+        // bounded — the interval is cleared as soon as the sheet closes
+        // or the balance increment is detected (see the paymentReceived
+        // handler further down).
         intervalId.current = setInterval(async () => {
           if (wId) await refreshBalanceForWallet(wId);
-        }, 5000);
+        }, 1500);
       } catch (error) {
         console.warn('Failed to create invoice:', error);
       } finally {

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -32,6 +32,7 @@ import * as boltzService from '../services/boltzService';
 import * as onchainService from '../services/onchainService';
 import { npubEncode } from '../services/nostrService';
 import { recordOutgoing as recordOutgoingCounterparty } from '../services/zapCounterpartyStorage';
+import PaymentProgressOverlay, { PaymentProgressState } from './PaymentProgressOverlay';
 
 interface Props {
   visible: boolean;
@@ -128,6 +129,8 @@ const SendSheet: React.FC<Props> = ({
   const [boltzFees, setBoltzFees] = useState<boltzService.SwapFees | null>(null);
   const [loadingBoltzFees, setLoadingBoltzFees] = useState(false);
   const [onchainFeeEstimate, setOnchainFeeEstimate] = useState<string | null>(null);
+  const [progressState, setProgressState] = useState<PaymentProgressState>('hidden');
+  const [progressError, setProgressError] = useState<string | undefined>(undefined);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
 
   const snapPoints = useMemo(() => ['90%'], []);
@@ -359,6 +362,8 @@ const SendSheet: React.FC<Props> = ({
   const handleSend = async () => {
     if (!invoiceData) return;
     setSending(true);
+    setProgressError(undefined);
+    setProgressState('sending');
     try {
       if (isOnchainAddress) {
         if (currentSats <= 0) {
@@ -511,16 +516,25 @@ const SendSheet: React.FC<Props> = ({
           }
         })();
       }
-      Alert.alert('Payment Sent', 'Your payment was sent successfully!', [
-        { text: 'OK', onPress: onClose },
-      ]);
+      setProgressState('success');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Payment failed';
-      Alert.alert('Payment Failed', message);
+      setProgressError(message);
+      setProgressState('error');
     } finally {
       setSending(false);
     }
   };
+
+  const handleOverlayDismiss = useCallback(() => {
+    // Success auto-dismisses via the overlay's timer — on success we also
+    // close the parent sheet. On error we only dismiss the overlay so the
+    // user can retry from the filled-in form.
+    const wasSuccess = progressState === 'success';
+    setProgressState('hidden');
+    setProgressError(undefined);
+    if (wasSuccess) onClose();
+  }, [progressState, onClose]);
 
   const handleReset = () => {
     setInvoiceData(null);
@@ -562,317 +576,330 @@ const SendSheet: React.FC<Props> = ({
       : !!invoiceData;
 
   return (
-    <BottomSheetModal
-      ref={bottomSheetRef}
-      snapPoints={snapPoints}
-      onChange={handleSheetChange}
-      enablePanDownToClose
-      backdropComponent={renderBackdrop}
-      handleIndicatorStyle={styles.handleIndicator}
-      backgroundStyle={styles.sheetBackground}
-    >
-      <BottomSheetView style={styles.content}>
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-          <View style={styles.innerContent}>
-            <Text style={styles.title}>Send</Text>
+    <>
+      <BottomSheetModal
+        ref={bottomSheetRef}
+        snapPoints={snapPoints}
+        onChange={handleSheetChange}
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        handleIndicatorStyle={styles.handleIndicator}
+        backgroundStyle={styles.sheetBackground}
+      >
+        <BottomSheetView style={styles.content}>
+          <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+            <View style={styles.innerContent}>
+              <Text style={styles.title}>Send</Text>
 
-            {/* Wallet selector */}
-            {wallets.filter((w) => w.isConnected).length > 1 ? (
-              <View style={styles.walletDropdownRow}>
-                <Text style={styles.walletLabel}>From:</Text>
-                <View style={styles.walletDropdownWrapper}>
-                  <TouchableOpacity
-                    style={styles.walletDropdown}
-                    onPress={() => setDropdownOpen(!dropdownOpen)}
-                  >
-                    <Text style={styles.walletDropdownText}>{walletName}</Text>
-                    {dropdownOpen ? (
-                      <ChevronUp size={16} color={colors.white} />
-                    ) : (
-                      <ChevronDown size={16} color={colors.white} />
-                    )}
-                  </TouchableOpacity>
-                  {dropdownOpen && (
-                    <View style={styles.walletDropdownMenu}>
-                      {wallets
-                        .filter((w) => w.isConnected)
-                        .map((w) => (
-                          <TouchableOpacity
-                            key={w.id}
-                            style={[
-                              styles.walletDropdownItem,
-                              capturedWalletId === w.id && styles.walletDropdownItemActive,
-                            ]}
-                            onPress={() => {
-                              setCapturedWalletId(w.id);
-                              setDropdownOpen(false);
-                            }}
-                          >
-                            <Text
+              {/* Wallet selector */}
+              {wallets.filter((w) => w.isConnected).length > 1 ? (
+                <View style={styles.walletDropdownRow}>
+                  <Text style={styles.walletLabel}>From:</Text>
+                  <View style={styles.walletDropdownWrapper}>
+                    <TouchableOpacity
+                      style={styles.walletDropdown}
+                      onPress={() => setDropdownOpen(!dropdownOpen)}
+                    >
+                      <Text style={styles.walletDropdownText}>{walletName}</Text>
+                      {dropdownOpen ? (
+                        <ChevronUp size={16} color={colors.white} />
+                      ) : (
+                        <ChevronDown size={16} color={colors.white} />
+                      )}
+                    </TouchableOpacity>
+                    {dropdownOpen && (
+                      <View style={styles.walletDropdownMenu}>
+                        {wallets
+                          .filter((w) => w.isConnected)
+                          .map((w) => (
+                            <TouchableOpacity
+                              key={w.id}
                               style={[
-                                styles.walletDropdownItemText,
-                                capturedWalletId === w.id && styles.walletDropdownItemTextActive,
+                                styles.walletDropdownItem,
+                                capturedWalletId === w.id && styles.walletDropdownItemActive,
                               ]}
+                              onPress={() => {
+                                setCapturedWalletId(w.id);
+                                setDropdownOpen(false);
+                              }}
                             >
-                              {walletLabel(w)}
-                            </Text>
-                          </TouchableOpacity>
-                        ))}
-                    </View>
-                  )}
-                </View>
-              </View>
-            ) : (
-              <Text style={styles.walletLabel}>From: {walletName}</Text>
-            )}
-
-            {/* Mode tabs */}
-            {!scanned && (
-              <View style={styles.tabRow}>
-                <TouchableOpacity
-                  style={[styles.tab, inputMode === 'scan' && styles.tabActive]}
-                  onPress={() => setInputMode('scan')}
-                >
-                  <Text style={[styles.tabText, inputMode === 'scan' && styles.tabTextActive]}>
-                    Scan
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.tab, inputMode === 'paste' && styles.tabActive]}
-                  onPress={() => setInputMode('paste')}
-                >
-                  <Text style={[styles.tabText, inputMode === 'paste' && styles.tabTextActive]}>
-                    Input
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            )}
-
-            {/* Scanner or paste input */}
-            {!scanned ? (
-              inputMode === 'scan' ? (
-                <View style={styles.cameraContainer}>
-                  {!permission.granted ? (
-                    <View style={styles.permissionContainer}>
-                      <Text style={styles.permissionText}>
-                        Camera access needed to scan QR codes
-                      </Text>
-                      <TouchableOpacity style={styles.permissionButton} onPress={requestPermission}>
-                        <Text style={styles.permissionButtonText}>Grant Permission</Text>
-                      </TouchableOpacity>
-                    </View>
-                  ) : (
-                    <CameraView
-                      style={styles.camera}
-                      facing="back"
-                      barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
-                      onBarcodeScanned={handleBarCodeScanned}
-                    />
-                  )}
+                              <Text
+                                style={[
+                                  styles.walletDropdownItemText,
+                                  capturedWalletId === w.id && styles.walletDropdownItemTextActive,
+                                ]}
+                              >
+                                {walletLabel(w)}
+                              </Text>
+                            </TouchableOpacity>
+                          ))}
+                      </View>
+                    )}
+                  </View>
                 </View>
               ) : (
-                <View style={styles.pasteSection}>
-                  <BottomSheetTextInput
-                    style={styles.pasteInput}
-                    placeholder="Paste invoice, lightning or bitcoin address..."
-                    placeholderTextColor={colors.textSupplementary}
-                    value={pasteText}
-                    onChangeText={setPasteText}
-                    multiline
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                  />
-                  <View style={styles.pasteButtonRow}>
-                    <TouchableOpacity style={styles.pasteButton} onPress={handlePaste}>
-                      <Text style={styles.pasteButtonText}>Paste from clipboard</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      style={[styles.goButton, !pasteText.trim() && styles.goButtonDisabled]}
-                      onPress={handlePasteSubmit}
-                      disabled={!pasteText.trim()}
-                    >
-                      <Text style={styles.goButtonText}>Go</Text>
-                    </TouchableOpacity>
-                  </View>
-                </View>
-              )
-            ) : (
-              /* Invoice/address detected - show details */
-              <View style={styles.detailsCard}>
-                {activePicture && (
-                  <Image source={{ uri: activePicture }} style={styles.recipientPicture} />
-                )}
-                {decoded?.description ? (
-                  <Text style={styles.detailDescription}>{decoded.description}</Text>
-                ) : null}
+                <Text style={styles.walletLabel}>From: {walletName}</Text>
+              )}
 
-                {needsAmount ? (
-                  /* Lightning address or on-chain: show amount input */
-                  <View style={styles.amountSection}>
-                    {resolving ? (
-                      <ActivityIndicator size="small" color={colors.brandPink} />
-                    ) : lnurlParams || isOnchainAddress ? (
-                      <>
-                        <View style={styles.amountRow}>
-                          <BottomSheetTextInput
-                            style={styles.amountInput}
-                            value={inputUnit === 'sats' ? satsValue : fiatValue}
-                            onChangeText={
-                              inputUnit === 'sats' ? handleSatsChange : handleFiatChange
-                            }
-                            keyboardType={inputUnit === 'sats' ? 'numeric' : 'decimal-pad'}
-                            placeholder={inputUnit === 'sats' ? '0' : '0.00'}
-                            placeholderTextColor={colors.textSupplementary}
-                          />
-                          <TouchableOpacity
-                            style={[
-                              styles.unitButton,
-                              inputUnit === 'sats' && styles.unitButtonActive,
-                            ]}
-                            onPress={() => setInputUnit('sats')}
-                          >
-                            <Text
-                              style={[
-                                styles.unitButtonText,
-                                inputUnit === 'sats' && styles.unitButtonTextActive,
-                              ]}
-                            >
-                              Sats
-                            </Text>
-                          </TouchableOpacity>
-                          <TouchableOpacity
-                            style={[
-                              styles.unitButton,
-                              inputUnit === 'fiat' && styles.unitButtonActive,
-                            ]}
-                            onPress={() => setInputUnit('fiat')}
-                          >
-                            <Text
-                              style={[
-                                styles.unitButtonText,
-                                inputUnit === 'fiat' && styles.unitButtonTextActive,
-                              ]}
-                            >
-                              {currency}
-                            </Text>
-                          </TouchableOpacity>
-                        </View>
-                        <Text style={styles.convertedAmount}>
-                          {inputUnit === 'sats'
-                            ? btcPrice && currentSats > 0
-                              ? satsToFiatString(currentSats, btcPrice, currency)
-                              : ''
-                            : currentSats > 0
-                              ? `${currentSats.toLocaleString()} sats`
-                              : ''}
-                        </Text>
-                        {lnurlParams ? (
-                          <Text style={styles.rangeText}>
-                            {lnurlParams.minSats.toLocaleString()} –{' '}
-                            {lnurlParams.maxSats.toLocaleString()} sats
-                          </Text>
-                        ) : null}
-                      </>
-                    ) : null}
-                  </View>
-                ) : decoded?.amountSats !== null && decoded?.amountSats !== undefined ? (
-                  /* Bolt11 with amount */
-                  <View style={styles.amountDisplay}>
-                    <Text style={styles.amountValue}>
-                      {decoded.amountSats.toLocaleString()} sats
+              {/* Mode tabs */}
+              {!scanned && (
+                <View style={styles.tabRow}>
+                  <TouchableOpacity
+                    style={[styles.tab, inputMode === 'scan' && styles.tabActive]}
+                    onPress={() => setInputMode('scan')}
+                  >
+                    <Text style={[styles.tabText, inputMode === 'scan' && styles.tabTextActive]}>
+                      Scan
                     </Text>
-                    {btcPrice ? (
-                      <Text style={styles.amountFiat}>
-                        {satsToFiatString(decoded.amountSats, btcPrice, currency)}
-                      </Text>
-                    ) : null}
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.tab, inputMode === 'paste' && styles.tabActive]}
+                    onPress={() => setInputMode('paste')}
+                  >
+                    <Text style={[styles.tabText, inputMode === 'paste' && styles.tabTextActive]}>
+                      Input
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+
+              {/* Scanner or paste input */}
+              {!scanned ? (
+                inputMode === 'scan' ? (
+                  <View style={styles.cameraContainer}>
+                    {!permission.granted ? (
+                      <View style={styles.permissionContainer}>
+                        <Text style={styles.permissionText}>
+                          Camera access needed to scan QR codes
+                        </Text>
+                        <TouchableOpacity
+                          style={styles.permissionButton}
+                          onPress={requestPermission}
+                        >
+                          <Text style={styles.permissionButtonText}>Grant Permission</Text>
+                        </TouchableOpacity>
+                      </View>
+                    ) : (
+                      <CameraView
+                        style={styles.camera}
+                        facing="back"
+                        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+                        onBarcodeScanned={handleBarCodeScanned}
+                      />
+                    )}
                   </View>
                 ) : (
-                  <Text style={styles.amountValue}>Amount not specified</Text>
-                )}
+                  <View style={styles.pasteSection}>
+                    <BottomSheetTextInput
+                      style={styles.pasteInput}
+                      placeholder="Paste invoice, lightning or bitcoin address..."
+                      placeholderTextColor={colors.textSupplementary}
+                      value={pasteText}
+                      onChangeText={setPasteText}
+                      multiline
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                    />
+                    <View style={styles.pasteButtonRow}>
+                      <TouchableOpacity style={styles.pasteButton} onPress={handlePaste}>
+                        <Text style={styles.pasteButtonText}>Paste from clipboard</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[styles.goButton, !pasteText.trim() && styles.goButtonDisabled]}
+                        onPress={handlePasteSubmit}
+                        disabled={!pasteText.trim()}
+                      >
+                        <Text style={styles.goButtonText}>Go</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                )
+              ) : (
+                /* Invoice/address detected - show details */
+                <View style={styles.detailsCard}>
+                  {activePicture && (
+                    <Image source={{ uri: activePicture }} style={styles.recipientPicture} />
+                  )}
+                  {decoded?.description ? (
+                    <Text style={styles.detailDescription}>{decoded.description}</Text>
+                  ) : null}
 
-                {isOnchainAddress && invoiceData ? (
-                  <Text style={styles.detailAddress}>
-                    <Text style={styles.addressHighlight}>{invoiceData.slice(0, 6)}</Text>
-                    {invoiceData.slice(6, -6)}
-                    <Text style={styles.addressHighlight}>{invoiceData.slice(-6)}</Text>
-                  </Text>
-                ) : isLightningAddress(invoiceData || '') ? (
-                  <Text style={styles.detailAddress}>{invoiceData}</Text>
-                ) : (
-                  <Text style={styles.invoiceText} numberOfLines={3}>
-                    {invoiceData}
-                  </Text>
-                )}
+                  {needsAmount ? (
+                    /* Lightning address or on-chain: show amount input */
+                    <View style={styles.amountSection}>
+                      {resolving ? (
+                        <ActivityIndicator size="small" color={colors.brandPink} />
+                      ) : lnurlParams || isOnchainAddress ? (
+                        <>
+                          <View style={styles.amountRow}>
+                            <BottomSheetTextInput
+                              style={styles.amountInput}
+                              value={inputUnit === 'sats' ? satsValue : fiatValue}
+                              onChangeText={
+                                inputUnit === 'sats' ? handleSatsChange : handleFiatChange
+                              }
+                              keyboardType={inputUnit === 'sats' ? 'numeric' : 'decimal-pad'}
+                              placeholder={inputUnit === 'sats' ? '0' : '0.00'}
+                              placeholderTextColor={colors.textSupplementary}
+                            />
+                            <TouchableOpacity
+                              style={[
+                                styles.unitButton,
+                                inputUnit === 'sats' && styles.unitButtonActive,
+                              ]}
+                              onPress={() => setInputUnit('sats')}
+                            >
+                              <Text
+                                style={[
+                                  styles.unitButtonText,
+                                  inputUnit === 'sats' && styles.unitButtonTextActive,
+                                ]}
+                              >
+                                Sats
+                              </Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                              style={[
+                                styles.unitButton,
+                                inputUnit === 'fiat' && styles.unitButtonActive,
+                              ]}
+                              onPress={() => setInputUnit('fiat')}
+                            >
+                              <Text
+                                style={[
+                                  styles.unitButtonText,
+                                  inputUnit === 'fiat' && styles.unitButtonTextActive,
+                                ]}
+                              >
+                                {currency}
+                              </Text>
+                            </TouchableOpacity>
+                          </View>
+                          <Text style={styles.convertedAmount}>
+                            {inputUnit === 'sats'
+                              ? btcPrice && currentSats > 0
+                                ? satsToFiatString(currentSats, btcPrice, currency)
+                                : ''
+                              : currentSats > 0
+                                ? `${currentSats.toLocaleString()} sats`
+                                : ''}
+                          </Text>
+                          {lnurlParams ? (
+                            <Text style={styles.rangeText}>
+                              {lnurlParams.minSats.toLocaleString()} –{' '}
+                              {lnurlParams.maxSats.toLocaleString()} sats
+                            </Text>
+                          ) : null}
+                        </>
+                      ) : null}
+                    </View>
+                  ) : decoded?.amountSats !== null && decoded?.amountSats !== undefined ? (
+                    /* Bolt11 with amount */
+                    <View style={styles.amountDisplay}>
+                      <Text style={styles.amountValue}>
+                        {decoded.amountSats.toLocaleString()} sats
+                      </Text>
+                      {btcPrice ? (
+                        <Text style={styles.amountFiat}>
+                          {satsToFiatString(decoded.amountSats, btcPrice, currency)}
+                        </Text>
+                      ) : null}
+                    </View>
+                  ) : (
+                    <Text style={styles.amountValue}>Amount not specified</Text>
+                  )}
 
-                {/* Fee estimate for on-chain addresses */}
-                {isOnchainAddress && currentSats > 0 && (
-                  <Text style={styles.feeText}>
-                    {selectedWallet?.walletType === 'onchain' &&
-                    selectedWallet?.onchainImportMethod === 'mnemonic'
-                      ? (onchainFeeEstimate ?? 'Estimating fee...')
-                      : loadingBoltzFees
-                        ? 'Loading fees...'
-                        : boltzFees
-                          ? `Swap fee: ~${boltzService.calculateSwapFee(currentSats, boltzFees).toLocaleString()} sats \u00B7 ~10-60 min`
-                          : 'Fee estimate unavailable'}
-                  </Text>
-                )}
+                  {isOnchainAddress && invoiceData ? (
+                    <Text style={styles.detailAddress}>
+                      <Text style={styles.addressHighlight}>{invoiceData.slice(0, 6)}</Text>
+                      {invoiceData.slice(6, -6)}
+                      <Text style={styles.addressHighlight}>{invoiceData.slice(-6)}</Text>
+                    </Text>
+                  ) : isLightningAddress(invoiceData || '') ? (
+                    <Text style={styles.detailAddress}>{invoiceData}</Text>
+                  ) : (
+                    <Text style={styles.invoiceText} numberOfLines={3}>
+                      {invoiceData}
+                    </Text>
+                  )}
 
-                {/* Memo / comment field for Lightning address payments */}
-                {needsAmount && (
-                  <BottomSheetTextInput
-                    style={styles.memoInput}
-                    placeholder={activePubkey ? 'Zap message (optional)' : 'Comment (optional)'}
-                    placeholderTextColor={colors.textSupplementary}
-                    value={memo}
-                    onChangeText={setMemo}
-                    maxLength={lnurlParams?.commentAllowed || 150}
-                    autoCorrect
-                  />
-                )}
+                  {/* Fee estimate for on-chain addresses */}
+                  {isOnchainAddress && currentSats > 0 && (
+                    <Text style={styles.feeText}>
+                      {selectedWallet?.walletType === 'onchain' &&
+                      selectedWallet?.onchainImportMethod === 'mnemonic'
+                        ? (onchainFeeEstimate ?? 'Estimating fee...')
+                        : loadingBoltzFees
+                          ? 'Loading fees...'
+                          : boltzFees
+                            ? `Swap fee: ~${boltzService.calculateSwapFee(currentSats, boltzFees).toLocaleString()} sats \u00B7 ~10-60 min`
+                            : 'Fee estimate unavailable'}
+                    </Text>
+                  )}
 
-                <TouchableOpacity onPress={handleReset}>
-                  <Text style={styles.resetText}>Scan / paste different invoice</Text>
+                  {/* Memo / comment field for Lightning address payments */}
+                  {needsAmount && (
+                    <BottomSheetTextInput
+                      style={styles.memoInput}
+                      placeholder={activePubkey ? 'Zap message (optional)' : 'Comment (optional)'}
+                      placeholderTextColor={colors.textSupplementary}
+                      value={memo}
+                      onChangeText={setMemo}
+                      maxLength={lnurlParams?.commentAllowed || 150}
+                      autoCorrect
+                    />
+                  )}
+
+                  <TouchableOpacity onPress={handleReset}>
+                    <Text style={styles.resetText}>Scan / paste different invoice</Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+
+              {/* Balance */}
+              {walletBalance !== null && btcPrice !== null && (
+                <Text style={styles.balanceText}>
+                  Balance: {walletBalance.toLocaleString()} sats (
+                  {satsToFiatString(walletBalance, btcPrice, currency)})
+                </Text>
+              )}
+
+              {/* Action buttons */}
+              <View style={styles.buttonRow}>
+                <TouchableOpacity
+                  style={styles.cancelButton}
+                  onPress={() => {
+                    handleReset();
+                    onClose();
+                  }}
+                >
+                  <Text style={styles.cancelButtonText}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.sendButton, (!canSend || sending) && styles.sendButtonDisabled]}
+                  onPress={handleSend}
+                  disabled={!canSend || sending}
+                >
+                  {sending ? (
+                    <ActivityIndicator color={colors.brandPink} />
+                  ) : (
+                    <Text style={styles.sendButtonText}>Send</Text>
+                  )}
                 </TouchableOpacity>
               </View>
-            )}
-
-            {/* Balance */}
-            {walletBalance !== null && btcPrice !== null && (
-              <Text style={styles.balanceText}>
-                Balance: {walletBalance.toLocaleString()} sats (
-                {satsToFiatString(walletBalance, btcPrice, currency)})
-              </Text>
-            )}
-
-            {/* Action buttons */}
-            <View style={styles.buttonRow}>
-              <TouchableOpacity
-                style={styles.cancelButton}
-                onPress={() => {
-                  handleReset();
-                  onClose();
-                }}
-              >
-                <Text style={styles.cancelButtonText}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.sendButton, (!canSend || sending) && styles.sendButtonDisabled]}
-                onPress={handleSend}
-                disabled={!canSend || sending}
-              >
-                {sending ? (
-                  <ActivityIndicator color={colors.brandPink} />
-                ) : (
-                  <Text style={styles.sendButtonText}>Send</Text>
-                )}
-              </TouchableOpacity>
             </View>
-          </View>
-        </TouchableWithoutFeedback>
-      </BottomSheetView>
-    </BottomSheetModal>
+          </TouchableWithoutFeedback>
+        </BottomSheetView>
+      </BottomSheetModal>
+      <PaymentProgressOverlay
+        state={progressState}
+        direction="send"
+        amountSats={currentSats || decoded?.amountSats || undefined}
+        recipientName={recipientName}
+        errorMessage={progressError}
+        onDismiss={handleOverlayDismiss}
+      />
+    </>
   );
 };
 

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -548,9 +548,9 @@ const SendSheet: React.FC<Props> = ({
   };
 
   const handleOverlayDismiss = useCallback(() => {
-    // Success auto-dismisses via the overlay's timer — on success we also
-    // close the parent sheet. On error we only dismiss the overlay so the
-    // user can retry from the filled-in form.
+    // Dismissing the overlay after a successful payment also closes the
+    // parent sheet. On error we only dismiss the overlay so the user can
+    // retry from the filled-in form.
     const wasSuccess = progressState === 'success';
     setProgressState('hidden');
     setProgressError(undefined);

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -78,6 +78,25 @@ function isLightningAddress(input: string): boolean {
   return input.includes('@') && !input.startsWith('lnbc') && !input.startsWith('lntb');
 }
 
+// Accept only digits — sats are whole integers. A hardware keyboard,
+// paste, or autocomplete can inject junk that the soft-keyboard's
+// `numeric` hint alone doesn't block.
+function sanitizeSatsInput(text: string): string {
+  return text.replace(/[^0-9]/g, '');
+}
+
+// Digits + a single decimal point, max two decimal places.
+function sanitizeFiatInput(text: string): string {
+  let cleaned = text.replace(/[^0-9.]/g, '');
+  const firstDot = cleaned.indexOf('.');
+  if (firstDot !== -1) {
+    cleaned = cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
+    const [intPart, fracPart = ''] = cleaned.split('.');
+    cleaned = `${intPart}.${fracPart.slice(0, 2)}`;
+  }
+  return cleaned;
+}
+
 function isValidInvoice(data: string): boolean {
   const lower = data.toLowerCase();
   return (
@@ -343,8 +362,9 @@ const SendSheet: React.FC<Props> = ({
   };
 
   const handleSatsChange = (text: string) => {
-    setSatsValue(text);
-    const sats = parseInt(text) || 0;
+    const clean = sanitizeSatsInput(text);
+    setSatsValue(clean);
+    const sats = parseInt(clean) || 0;
     if (btcPrice) {
       setFiatValue(satsToFiat(sats, btcPrice).toFixed(2));
     } else {
@@ -353,8 +373,9 @@ const SendSheet: React.FC<Props> = ({
   };
 
   const handleFiatChange = (text: string) => {
-    setFiatValue(text);
-    const fiat = parseFloat(text) || 0;
+    const clean = sanitizeFiatInput(text);
+    setFiatValue(clean);
+    const fiat = parseFloat(clean) || 0;
     const sats = fiatToSats(fiat);
     setSatsValue(sats.toString());
   };

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -21,8 +21,15 @@ import {
 export interface IncomingPayment {
   walletId: string;
   amountSats: number;
-  walletAlias: string;
+  // Timestamp; also serves as a stable React key for the overlay so a
+  // second payment with the same amount to the same wallet still
+  // re-mounts the animation.
   at: number;
+  // Set when detection came via a known invoice hash (expectPayment
+  // path); null when it came via balance-diff (e.g. lightning-address
+  // receive). Consumers can use this to distinguish "exactly this
+  // invoice settled" from "something credited the wallet".
+  paymentHash: string | null;
 }
 
 const USER_NAME_KEY = 'user_display_name';
@@ -126,14 +133,34 @@ interface WalletContextType {
   lastIncomingPayment: IncomingPayment | null;
   clearLastIncomingPayment: () => void;
 
-  // Kick off aggressive 1 s polling for a specific NWC invoice for the
-  // next 3 minutes. Called by ReceiveSheet when an invoice is
-  // generated — the poll lives in the context so it survives the sheet
-  // closing (user can generate an invoice, close the sheet, wander
-  // into Friends, and still get the confetti pop). Subsequent calls
-  // replace any in-flight expectation. Stops early on detected
-  // settlement or after the duration elapses.
-  expectPayment: (walletId: string, paymentHash: string, durationMs?: number) => void;
+  /**
+   * Kick off aggressive 1 s polling for a specific NWC invoice for up
+   * to `durationMs` (default 3 min). Called by ReceiveSheet when an
+   * invoice is generated — the poll lives in the context so it survives
+   * the sheet closing (user can generate an invoice, close the sheet,
+   * wander into Friends, and still get the confetti pop).
+   *
+   * **Replacement semantics:** subsequent calls replace any in-flight
+   * expectation (only one tracked at a time). This is safe because the
+   * balance-diff detector still runs independently — so if invoice A's
+   * expectation is replaced by invoice B before A settles, A's eventual
+   * balance increment will *still* fire the overlay via the diff path,
+   * just with worst-case 30 s latency (baseline poll) instead of 1 s.
+   *
+   * When `expectedAmountSats` is provided and the lookup reports
+   * `paid: true`, the overlay uses that exact amount rather than the
+   * balance-delta heuristic. This matters when two invoices settle
+   * between polls: the delta would report the combined total, the
+   * explicit amount reports what *this* invoice was for.
+   *
+   * Stops early on detected settlement or after the duration elapses.
+   */
+  expectPayment: (
+    walletId: string,
+    paymentHash: string,
+    expectedAmountSats?: number,
+    durationMs?: number,
+  ) => void;
 
   // Legacy compatibility
   isConnected: boolean;
@@ -1209,8 +1236,12 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const expectedPaymentRef = useRef<{
     walletId: string;
     paymentHash: string;
+    expectedAmountSats: number | null;
     interval: ReturnType<typeof setInterval>;
     timeout: ReturnType<typeof setTimeout>;
+    // Guards against pile-up on slow backends: if tick N hasn't
+    // completed by the time tick N+1 fires, we skip N+1.
+    inFlight: boolean;
   } | null>(null);
 
   const stopExpectedPayment = useCallback(() => {
@@ -1222,27 +1253,69 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   const expectPayment = useCallback(
-    (walletId: string, paymentHash: string, durationMs: number = 3 * 60 * 1000) => {
+    (
+      walletId: string,
+      paymentHash: string,
+      expectedAmountSats?: number,
+      durationMs: number = 3 * 60 * 1000,
+    ) => {
       // Replace any previous expectation — we only track one at a time.
+      // The balance-diff detector still catches the displaced invoice
+      // when it settles (just on a slower cadence), so we never drop
+      // detection entirely; see the expectPayment JSDoc in the context
+      // interface above.
       stopExpectedPayment();
 
       const tick = async () => {
-        const [lookupResult] = await Promise.allSettled([
-          nwcService.lookupInvoice(walletId, paymentHash),
-          // The balance refresh is what ultimately drives the
-          // WalletContext diff-detector and fires the overlay; fire
-          // both every tick so either path catches the settle.
-          (async () => {
-            const b = await nwcService.getBalance(walletId);
-            if (b !== null) updateWalletInState(walletId, { balance: b });
-          })(),
-        ]);
-        if (lookupResult.status === 'fulfilled' && lookupResult.value?.paid) {
-          if (__DEV__)
-            console.log(
-              `[Wallet] expected invoice paid (${paymentHash.slice(0, 12)}…) — stopping poll`,
-            );
-          stopExpectedPayment();
+        const current = expectedPaymentRef.current;
+        // Pile-up guard: if the previous tick is still in flight (slow
+        // NWC backend, see #133), skip this interval firing entirely
+        // rather than stacking N concurrent requests.
+        if (!current || current.inFlight) return;
+        current.inFlight = true;
+        try {
+          const [lookupResult] = await Promise.allSettled([
+            nwcService.lookupInvoice(walletId, paymentHash),
+            // The balance refresh feeds the generic balance-diff
+            // detector as a fallback; run it every tick so a flaky
+            // lookup_invoice path still settles detection.
+            (async () => {
+              const b = await nwcService.getBalance(walletId);
+              if (b !== null) updateWalletInState(walletId, { balance: b });
+            })(),
+          ]);
+          if (
+            lookupResult.status === 'fulfilled' &&
+            lookupResult.value?.paid &&
+            expectedPaymentRef.current?.paymentHash === paymentHash
+          ) {
+            if (__DEV__)
+              console.log(
+                `[Wallet] expected invoice paid (${paymentHash.slice(0, 12)}…) — stopping poll`,
+              );
+            // Fire with the *known* invoice amount rather than the
+            // balance delta. Two invoices settling between polls would
+            // show a combined delta on the generic path; the explicit
+            // amount is always correct.
+            if (expectedAmountSats !== undefined && expectedAmountSats > 0) {
+              // Advance the balance-diff baseline to the current balance
+              // so the /same/ settle doesn't also fire via the diff path.
+              const currentBalance = walletsRef.current.find((w) => w.id === walletId)?.balance;
+              if (currentBalance !== null && currentBalance !== undefined) {
+                paymentBaselinesRef.current.set(walletId, currentBalance);
+              }
+              setLastIncomingPayment({
+                walletId,
+                amountSats: expectedAmountSats,
+                at: Date.now(),
+                paymentHash,
+              });
+            }
+            stopExpectedPayment();
+          }
+        } finally {
+          const still = expectedPaymentRef.current;
+          if (still) still.inFlight = false;
         }
       };
 
@@ -1259,10 +1332,17 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         }
       }, durationMs);
 
-      expectedPaymentRef.current = { walletId, paymentHash, interval, timeout };
+      expectedPaymentRef.current = {
+        walletId,
+        paymentHash,
+        expectedAmountSats: expectedAmountSats ?? null,
+        interval,
+        timeout,
+        inFlight: false,
+      };
       if (__DEV__)
         console.log(
-          `[Wallet] expecting payment on ${paymentHash.slice(0, 12)}… (${Math.round(durationMs / 1000)} s window)`,
+          `[Wallet] expecting payment on ${paymentHash.slice(0, 12)}… (${Math.round(durationMs / 1000)} s window, amount=${expectedAmountSats ?? '?'})`,
         );
     },
     [stopExpectedPayment, updateWalletInState],
@@ -1299,6 +1379,15 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   // money lands — ReceiveSheet being open is no longer required.
   useEffect(() => {
     const baselines = paymentBaselinesRef.current;
+    const liveIds = new Set(wallets.map((w) => w.id));
+
+    // Garbage-collect baselines for wallets that have been removed.
+    // Without this the Map grows monotonically (e.g. user adds and
+    // removes wallets repeatedly during onboarding / debugging).
+    for (const id of baselines.keys()) {
+      if (!liveIds.has(id)) baselines.delete(id);
+    }
+
     for (const wallet of wallets) {
       const bal = wallet.balance;
       if (bal === null || bal === undefined) continue;
@@ -1317,8 +1406,11 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         setLastIncomingPayment({
           walletId: wallet.id,
           amountSats: delta,
-          walletAlias: walletLabel(wallet),
           at: Date.now(),
+          // Balance-diff path doesn't know which invoice settled — only
+          // expectPayment can attribute by hash. Lightning-address /
+          // multi-invoice receives land here.
+          paymentHash: null,
         });
       } else if (bal < prev) {
         // Outgoing payment or reorg adjustment — silently rebase.
@@ -1343,12 +1435,24 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   // On-chain is skipped — BDK sync is expensive and not safe to run
   // every 30 s; #134 tracks the on-chain variant of this coverage.
   // True background / app-closed delivery needs OS push (#45).
+  // Track the active wallet's connection state as an explicit dep so
+  // the poll starts/stops when a wallet reconnects without the active
+  // id changing. (Previous version only re-ran on `activeWalletId`
+  // change and could leave the poll running against a disconnected
+  // wallet — flagged in PR #135 review.) We still avoid putting the
+  // full `wallets` array in deps, which would thrash on every balance
+  // tick.
+  const activeWalletConnected =
+    activeWallet?.walletType !== 'onchain' && activeWallet?.isConnected === true;
+
   useEffect(() => {
-    if (!activeWalletId) return;
-    const wallet = wallets.find((w) => w.id === activeWalletId);
-    if (!wallet || wallet.walletType === 'onchain' || !wallet.isConnected) return;
+    if (!activeWalletId || !activeWalletConnected) return;
 
     const refreshOnce = () => {
+      // Bail if the wallet has since disconnected — we read through
+      // `walletsRef` rather than the closure so this is current.
+      const current = walletsRef.current.find((w) => w.id === activeWalletId);
+      if (!current || !current.isConnected || current.walletType === 'onchain') return;
       nwcService
         .getBalance(activeWalletId)
         .then((b) => {
@@ -1385,11 +1489,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       stopPoll();
       sub.remove();
     };
-    // `wallets` is intentionally omitted so we don't thrash the
-    // subscription on every balance tick — we only re-wire when the
-    // active wallet itself changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeWalletId, updateWalletInState]);
+  }, [activeWalletId, activeWalletConnected, updateWalletInState]);
 
   return (
     <WalletContext.Provider

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -126,6 +126,15 @@ interface WalletContextType {
   lastIncomingPayment: IncomingPayment | null;
   clearLastIncomingPayment: () => void;
 
+  // Kick off aggressive 1 s polling for a specific NWC invoice for the
+  // next 3 minutes. Called by ReceiveSheet when an invoice is
+  // generated — the poll lives in the context so it survives the sheet
+  // closing (user can generate an invoice, close the sheet, wander
+  // into Friends, and still get the confetti pop). Subsequent calls
+  // replace any in-flight expectation. Stops early on detected
+  // settlement or after the duration elapses.
+  expectPayment: (walletId: string, paymentHash: string, durationMs?: number) => void;
+
   // Legacy compatibility
   isConnected: boolean;
   balance: number | null;
@@ -1192,6 +1201,79 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const clearLastIncomingPayment = useCallback(() => setLastIncomingPayment(null), []);
 
+  // In-flight "I'm expecting a payment on this invoice" poll state.
+  // Only one at a time — a new expectPayment() replaces the previous.
+  // The balance-diff detector still runs independently, so even if this
+  // poll is replaced before the first invoice settles, the eventual
+  // balance increment will still fire the overlay.
+  const expectedPaymentRef = useRef<{
+    walletId: string;
+    paymentHash: string;
+    interval: ReturnType<typeof setInterval>;
+    timeout: ReturnType<typeof setTimeout>;
+  } | null>(null);
+
+  const stopExpectedPayment = useCallback(() => {
+    const current = expectedPaymentRef.current;
+    if (!current) return;
+    clearInterval(current.interval);
+    clearTimeout(current.timeout);
+    expectedPaymentRef.current = null;
+  }, []);
+
+  const expectPayment = useCallback(
+    (walletId: string, paymentHash: string, durationMs: number = 3 * 60 * 1000) => {
+      // Replace any previous expectation — we only track one at a time.
+      stopExpectedPayment();
+
+      const tick = async () => {
+        const [lookupResult] = await Promise.allSettled([
+          nwcService.lookupInvoice(walletId, paymentHash),
+          // The balance refresh is what ultimately drives the
+          // WalletContext diff-detector and fires the overlay; fire
+          // both every tick so either path catches the settle.
+          (async () => {
+            const b = await nwcService.getBalance(walletId);
+            if (b !== null) updateWalletInState(walletId, { balance: b });
+          })(),
+        ]);
+        if (lookupResult.status === 'fulfilled' && lookupResult.value?.paid) {
+          if (__DEV__)
+            console.log(
+              `[Wallet] expected invoice paid (${paymentHash.slice(0, 12)}…) — stopping poll`,
+            );
+          stopExpectedPayment();
+        }
+      };
+
+      const interval = setInterval(tick, 1000);
+      const timeout = setTimeout(() => {
+        // Only clear if THIS expectation is still current; a newer one
+        // may have replaced it already.
+        if (expectedPaymentRef.current?.interval === interval) {
+          if (__DEV__)
+            console.log(
+              `[Wallet] expected payment poll window expired (${paymentHash.slice(0, 12)}…)`,
+            );
+          stopExpectedPayment();
+        }
+      }, durationMs);
+
+      expectedPaymentRef.current = { walletId, paymentHash, interval, timeout };
+      if (__DEV__)
+        console.log(
+          `[Wallet] expecting payment on ${paymentHash.slice(0, 12)}… (${Math.round(durationMs / 1000)} s window)`,
+        );
+    },
+    [stopExpectedPayment, updateWalletInState],
+  );
+
+  // Tear down any outstanding expectation when the context unmounts —
+  // leaked intervals kept polling NWC after a logout / hot-reload.
+  useEffect(() => {
+    return () => stopExpectedPayment();
+  }, [stopExpectedPayment]);
+
   // When an incoming payment is detected, also pull the latest
   // transaction list for that wallet so the Home / Transactions screens
   // show the new tx immediately — not on the user's next manual refresh.
@@ -1245,18 +1327,22 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   }, [wallets]);
 
-  // Refresh the active wallet's balance once whenever the app returns
-  // to the foreground. Cheap (one NWC round-trip per resume) and
-  // catches payments that arrived while the app was backgrounded — the
-  // balance diff then fires the global celebration overlay. We
-  // deliberately do NOT run a continuous baseline poll: the
-  // ReceiveSheet's 1.5 s window covers the "actively waiting" case,
-  // and any other organic refresh (pull-to-refresh, tab swap, invoice
-  // creation, send flow) will also trigger the detector. Burning a
-  // network request every 10 s just in case a lightning-address
-  // payment lands isn't worth the battery for most users.
-  // NOTE: true background / app-closed delivery needs OS push
-  // (FCM/APNs + backend relay), tracked in issue #45.
+  // Keep the active NWC wallet's balance in rough sync so the global
+  // overlay pops for *any* incoming payment — not just ones the user
+  // explicitly asked us to watch via expectPayment. Covers:
+  //
+  //   - app returns to foreground → one-shot refresh to catch anything
+  //     that arrived while backgrounded.
+  //   - 30 s slow poll while the app is foregrounded → catches
+  //     lightning-address payments that land without an in-app
+  //     invoice-generation trigger. Worst-case latency ~30 s, which
+  //     is acceptable for casual address receives; the expectPayment
+  //     fast poll (1 s for 3 min) takes over when the user is
+  //     *actively* waiting on a specific invoice.
+  //
+  // On-chain is skipped — BDK sync is expensive and not safe to run
+  // every 30 s; #134 tracks the on-chain variant of this coverage.
+  // True background / app-closed delivery needs OS push (#45).
   useEffect(() => {
     if (!activeWalletId) return;
     const wallet = wallets.find((w) => w.id === activeWalletId);
@@ -1271,10 +1357,34 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         .catch(() => {});
     };
 
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const startPoll = () => {
+      if (interval) return;
+      interval = setInterval(refreshOnce, 30000);
+    };
+    const stopPoll = () => {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+
+    if (AppState.currentState === 'active') {
+      refreshOnce();
+      startPoll();
+    }
     const sub = AppState.addEventListener('change', (next) => {
-      if (next === 'active') refreshOnce();
+      if (next === 'active') {
+        refreshOnce();
+        startPoll();
+      } else {
+        stopPoll();
+      }
     });
-    return () => sub.remove();
+    return () => {
+      stopPoll();
+      sub.remove();
+    };
     // `wallets` is intentionally omitted so we don't thrash the
     // subscription on every balance tick — we only re-wire when the
     // active wallet itself changes.
@@ -1316,6 +1426,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         getReceiveAddress,
         lastIncomingPayment,
         clearLastIncomingPayment,
+        expectPayment,
         isConnected,
         balance,
         walletAlias,

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1212,6 +1212,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       if (bal > prev) {
         const delta = bal - prev;
         baselines.set(wallet.id, bal);
+        if (__DEV__)
+          console.log(
+            `[Wallet] incoming payment detected: +${delta} sats on ${walletLabel(wallet)} (${prev} → ${bal})`,
+          );
         setLastIncomingPayment({
           walletId: wallet.id,
           amountSats: delta,

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as nwcService from '../services/nwcService';
 import * as nostrService from '../services/nostrService';
@@ -14,7 +15,15 @@ import {
   WalletState,
   WalletTransaction,
   ZapCounterpartyInfo,
+  walletLabel,
 } from '../types/wallet';
+
+export interface IncomingPayment {
+  walletId: string;
+  amountSats: number;
+  walletAlias: string;
+  at: number;
+}
 
 const USER_NAME_KEY = 'user_display_name';
 const CURRENCY_KEY = 'user_fiat_currency';
@@ -111,6 +120,12 @@ interface WalletContextType {
   // On-chain actions
   getReceiveAddress: (walletId: string) => Promise<string>;
 
+  // Incoming payment event bus. Set whenever any connected wallet's
+  // balance goes UP; consumed by the app-root PaymentProgressOverlay
+  // so the celebration appears regardless of which screen is active.
+  lastIncomingPayment: IncomingPayment | null;
+  clearLastIncomingPayment: () => void;
+
   // Legacy compatibility
   isConnected: boolean;
   balance: number | null;
@@ -128,7 +143,14 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [currency, setCurrencyState] = useState<FiatCurrency>('USD');
   const [btcPrice, setBtcPrice] = useState<number | null>(null);
   const [lightningAddress, setLightningAddressState] = useState<string | null>(null);
+  const [lastIncomingPayment, setLastIncomingPayment] = useState<IncomingPayment | null>(null);
   const priceInterval = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Per-wallet baseline balances. Used to decide whether a balance
+  // change is an incoming payment (increment) or the local consequence
+  // of a send / send-like flow (decrement). First observation of a
+  // wallet seeds its baseline silently — we don't fire for the initial
+  // balance we happen to observe.
+  const paymentBaselinesRef = useRef<Map<string, number>>(new Map());
 
   // Derived state
   const activeWallet = wallets.find((w) => w.id === activeWalletId) ?? null;
@@ -1168,6 +1190,89 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     return onchainService.getNextReceiveAddress(walletId);
   }, []);
 
+  const clearLastIncomingPayment = useCallback(() => setLastIncomingPayment(null), []);
+
+  // Incoming-payment detector. Watches every wallet's balance: the first
+  // time we see a wallet, we record its balance silently as a baseline;
+  // any subsequent increase fires a `lastIncomingPayment` event that the
+  // app-root overlay consumes. Decreases simply re-baseline (a send is
+  // not a "received payment" event). Because this lives in the context,
+  // the overlay pops regardless of which screen the user is on when
+  // money lands — ReceiveSheet being open is no longer required.
+  useEffect(() => {
+    const baselines = paymentBaselinesRef.current;
+    for (const wallet of wallets) {
+      const bal = wallet.balance;
+      if (bal === null || bal === undefined) continue;
+      const prev = baselines.get(wallet.id);
+      if (prev === undefined) {
+        baselines.set(wallet.id, bal);
+        continue;
+      }
+      if (bal > prev) {
+        const delta = bal - prev;
+        baselines.set(wallet.id, bal);
+        setLastIncomingPayment({
+          walletId: wallet.id,
+          amountSats: delta,
+          walletAlias: walletLabel(wallet),
+          at: Date.now(),
+        });
+      } else if (bal < prev) {
+        // Outgoing payment or reorg adjustment — silently rebase.
+        baselines.set(wallet.id, bal);
+      }
+    }
+  }, [wallets]);
+
+  // Foreground polling for the active wallet. ReceiveSheet runs its own
+  // 1.5s poll while an invoice is pending (for fast detection); this
+  // slower 10s baseline covers the case where the user is *not* on the
+  // receive sheet — e.g. sitting on Home when someone pays their
+  // lightning address. On-chain wallets are skipped here; BDK sync is
+  // expensive and runs on its own cadence elsewhere.
+  // NOTE: background / app-closed delivery is a separate concern — OS
+  // push requires FCM/APNs + a backend, tracked in issue #45.
+  useEffect(() => {
+    if (!activeWalletId) return;
+    const wallet = wallets.find((w) => w.id === activeWalletId);
+    if (!wallet || wallet.walletType === 'onchain' || !wallet.isConnected) return;
+
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const start = () => {
+      if (interval) return;
+      interval = setInterval(() => {
+        // Fire-and-forget: failures are non-fatal (next tick retries)
+        // and must not leak unhandled promise rejections.
+        nwcService
+          .getBalance(activeWalletId)
+          .then((b) => {
+            if (b !== null) updateWalletInState(activeWalletId, { balance: b });
+          })
+          .catch(() => {});
+      }, 10000);
+    };
+    const stop = () => {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+    if (AppState.currentState === 'active') start();
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') start();
+      else stop();
+    });
+    return () => {
+      stop();
+      sub.remove();
+    };
+    // `wallets` is intentionally omitted so we don't thrash the
+    // interval on every balance tick — we only re-wire when the active
+    // wallet itself changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWalletId, updateWalletInState]);
+
   return (
     <WalletContext.Provider
       value={{
@@ -1201,6 +1306,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         fetchTransactionsForWallet,
         addPendingTransaction,
         getReceiveAddress,
+        lastIncomingPayment,
+        clearLastIncomingPayment,
         isConnected,
         balance,
         walletAlias,

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1192,6 +1192,22 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const clearLastIncomingPayment = useCallback(() => setLastIncomingPayment(null), []);
 
+  // When an incoming payment is detected, also pull the latest
+  // transaction list for that wallet so the Home / Transactions screens
+  // show the new tx immediately — not on the user's next manual refresh.
+  // Separate effect so it reads `fetchTransactionsForWallet` after it's
+  // defined below without the closure-ordering dance.
+  useEffect(() => {
+    if (!lastIncomingPayment) return;
+    fetchTransactionsForWallet(lastIncomingPayment.walletId).catch(() => {
+      // Non-fatal: next organic refresh will pick the tx up.
+    });
+    // Intentionally only fire on `lastIncomingPayment` changes; the
+    // callback identity is stable enough across renders that adding it
+    // would double-fetch on unrelated renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastIncomingPayment]);
+
   // Incoming-payment detector. Watches every wallet's balance: the first
   // time we see a wallet, we record its balance silently as a baseline;
   // any subsequent increase fires a `lastIncomingPayment` event that the

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1225,51 +1225,39 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   }, [wallets]);
 
-  // Foreground polling for the active wallet. ReceiveSheet runs its own
-  // 1.5s poll while an invoice is pending (for fast detection); this
-  // slower 10s baseline covers the case where the user is *not* on the
-  // receive sheet — e.g. sitting on Home when someone pays their
-  // lightning address. On-chain wallets are skipped here; BDK sync is
-  // expensive and runs on its own cadence elsewhere.
-  // NOTE: background / app-closed delivery is a separate concern — OS
-  // push requires FCM/APNs + a backend, tracked in issue #45.
+  // Refresh the active wallet's balance once whenever the app returns
+  // to the foreground. Cheap (one NWC round-trip per resume) and
+  // catches payments that arrived while the app was backgrounded — the
+  // balance diff then fires the global celebration overlay. We
+  // deliberately do NOT run a continuous baseline poll: the
+  // ReceiveSheet's 1.5 s window covers the "actively waiting" case,
+  // and any other organic refresh (pull-to-refresh, tab swap, invoice
+  // creation, send flow) will also trigger the detector. Burning a
+  // network request every 10 s just in case a lightning-address
+  // payment lands isn't worth the battery for most users.
+  // NOTE: true background / app-closed delivery needs OS push
+  // (FCM/APNs + backend relay), tracked in issue #45.
   useEffect(() => {
     if (!activeWalletId) return;
     const wallet = wallets.find((w) => w.id === activeWalletId);
     if (!wallet || wallet.walletType === 'onchain' || !wallet.isConnected) return;
 
-    let interval: ReturnType<typeof setInterval> | null = null;
-    const start = () => {
-      if (interval) return;
-      interval = setInterval(() => {
-        // Fire-and-forget: failures are non-fatal (next tick retries)
-        // and must not leak unhandled promise rejections.
-        nwcService
-          .getBalance(activeWalletId)
-          .then((b) => {
-            if (b !== null) updateWalletInState(activeWalletId, { balance: b });
-          })
-          .catch(() => {});
-      }, 10000);
+    const refreshOnce = () => {
+      nwcService
+        .getBalance(activeWalletId)
+        .then((b) => {
+          if (b !== null) updateWalletInState(activeWalletId, { balance: b });
+        })
+        .catch(() => {});
     };
-    const stop = () => {
-      if (interval) {
-        clearInterval(interval);
-        interval = null;
-      }
-    };
-    if (AppState.currentState === 'active') start();
+
     const sub = AppState.addEventListener('change', (next) => {
-      if (next === 'active') start();
-      else stop();
+      if (next === 'active') refreshOnce();
     });
-    return () => {
-      stop();
-      sub.remove();
-    };
+    return () => sub.remove();
     // `wallets` is intentionally omitted so we don't thrash the
-    // interval on every balance tick — we only re-wire when the active
-    // wallet itself changes.
+    // subscription on every balance tick — we only re-wire when the
+    // active wallet itself changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeWalletId, updateWalletInState]);
 


### PR DESCRIPTION
## Summary

Replaces the bare `Alert.alert("Payment Sent")` native dialog (white square, no rounding) with a rounded, on-brand **PaymentProgressOverlay** covering both send and receive flows, and lifts incoming-payment detection up to the app root so the celebration pops on any screen.

### Send flow
- "Sending payment…" spinner + amount on a rounded card, pink bubbles rising behind it. Bubble count 140, size 22–68 px, quadratic stagger over 5 s so density ramps up as time passes.
- On success: bubbles morph pink → green, a green tick swaps in, card requires an explicit OK tap to dismiss (no auto-close — a receiver who wasn't looking should still see the outcome when they come back).
- On failure: red × + error message, "Dismiss" button.

### Receive flow
- Global overlay at the app root — lives above any screen.
- "Payment received!" card with on-brand confetti (pink, light pink, violet, blue, cyan, lavender) bursting **radially from behind the card** using projectile-with-gravity physics.
- Amount and sending wallet shown. Requires an OK tap to dismiss.
- 50 % more confetti pieces (135) vs. original prototype so the burst reads as a full celebration.

### Detection + polling model
Poll ownership moved from `ReceiveSheet` up to `WalletContext` so the detector survives the sheet closing. User can generate an invoice, close the sheet, wander into Friends / Home, and still get the pop when the payment lands.

| scenario | cadence | lives in |
| --- | --- | --- |
| ReceiveSheet-generated invoice pending | 1 s for 3 min | `WalletContext.expectPayment(walletId, paymentHash)` |
| Lightning-address receive while app foregrounded | ≤ 30 s | WalletContext baseline poll |
| App resume from background | one-shot refresh | WalletContext AppState listener |
| On-chain receive | ❌ see #134 | — |
| App closed / phone locked | ❌ see #45 | — |

Fast poll uses NIP-47 `lookup_invoice` on the specific payment hash (lighter + faster than `get_balance` on most backends) with a parallel balance refresh as fallback. On `paid: true`, a tx-list refresh is auto-triggered so the transaction row is visible by the time the user taps OK.

### Also in this PR
- **Baseline fix:** ignore the cached balance at sheet open / wallet switch and treat the first *observed* balance as the baseline. A prior invoice that settled while the app was backgrounded no longer fires a bogus celebration attributed to the next invoice.
- **Numeric-only amount inputs** in Send and Receive sheets — digits only (sats), digits + single decimal capped at 2 places (fiat). Blocks hardware-keyboard / paste / autocomplete injection that the soft-keyboard `numeric` hint alone doesn't catch.
- Send / receive copy no longer wraps around the unbranded Android Alert dialog.

### Build
- No new dependencies. Uses `react-native-reanimated` (already in the project) for bubbles + confetti; `light-bolt11-decoder` (already in the project) for payment-hash extraction.
- TypeScript, ESLint, Prettier clean on changed files. (Two pre-existing `Keyboard` / `TouchableWithoutFeedback` unused warnings in `ReceiveSheet.tsx` are on `main` already.)

## Related issues

Shipped here:
- Closes nothing directly; this is a UX feature PR.

Filed as follow-ups, referenced for context:
- #132 — `fix(send): characters dropped while typing amount in Send sheet` (separate from input sanitisation — that's a re-render race)
- #133 — `perf(nwc): get_balance reply timeouts add ~10 s latency to payment detection` (server-side NWC round-trip latency; SSH-verified LNbits is healthy, NIP-20 fix present, no IN_FLIGHT spam — the remaining gap is likely SDK reply-timeout tuning or upstream relay)
- #134 — `feat(receive): celebration overlay for on-chain incoming payments` (BDK sync isn't foreground-polled; on-chain needs its own trigger)
- #45 — `Add OS push notifications for incoming payments` (background / app-closed delivery — out of scope for this PR, needs FCM/APNs + backend)

Upstream:
- [lnbits/nwcprovider#30](https://github.com/lnbits/nwcprovider/pull/30) — NIP-47 notifications (kind 23196). Would eliminate polling entirely; currently not merged.

## Test plan

- [ ] Send → `Alert.alert` is gone; rounded card with spinner + pink bubbles; on success, bubbles turn green and a tick appears; OK dismisses.
- [ ] Send failure → red × + error message, Dismiss button.
- [ ] Receive → generate an amount invoice, pay it, overlay pops with confetti bursting radially from behind the card; OK closes.
- [ ] Receive, cross-screen → generate invoice, close sheet, navigate to Friends, pay invoice from an external wallet, overlay still pops over Friends.
- [ ] Receive, lightning address → sit on Home, pay the user's lightning address from another wallet, overlay fires within ≤ 30 s.
- [ ] Receive after backgrounding → generate invoice, pay it while app is backgrounded, return to app, overlay fires on resume.
- [ ] Baseline fix → previously-settled-but-uncached payment does not fire a bogus celebration attributed to a freshly-generated invoice.
- [ ] Amount input → paste `abc123.45xyz` into sats and fiat inputs; only the numeric portion sticks.
- [ ] Tx list refresh → after receiving, the Home / Transactions screens show the new row without a manual pull-to-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)