### PR TITLE
refactor(ui): shared TabHeader across Home/Messages/Friends/Learn (#139)

### DIFF
--- a/src/components/TabHeader.tsx
+++ b/src/components/TabHeader.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { View, Text, StyleSheet, type TextStyle } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import ProfileIcon from './ProfileIcon';
+import { useNostr } from '../contexts/NostrContext';
+import { colors } from '../styles/theme';
+import type { MainTabParamList } from '../navigation/types';
+
+interface Props {
+  /**
+   * The page-identifying glyph rendered inside the round badge on the
+   * left. Passed as a ReactNode so the screen can choose between tinted
+   * `Image` (Home, Learn) and `Svg` components (Messages, Friends) — both
+   * match their tab-bar counterparts. Decorative only: the badge never
+   * navigates anywhere on tap (per #139's AC).
+   */
+  icon: React.ReactNode;
+  /** Page title text. For Home this carries the "Hello, <name>!" greeting. */
+  title: string;
+  /**
+   * Right-hand slot. Defaults to a `ProfileIcon` that opens the Account
+   * screen, which is what every tab wants today. A screen can override if
+   * it needs something different (currently none do).
+   */
+  rightAction?: React.ReactNode;
+  /** Optional accessibility label for the title region (rarely useful — the
+   * title text is already announced — but lets screens override for e.g.
+   * Home's dynamic greeting). */
+  accessibilityLabel?: string;
+  /** Optional style override for the title Text. Home uses this to pull the
+   * greeting back to the lighter weight/size it had pre-#139 (section
+   * titles like "Messages"/"Friends"/"Learn" keep the default bold). */
+  titleStyle?: TextStyle;
+}
+
+/**
+ * Shared header row for the four top-level tabs (Home, Messages, Learn,
+ * Friends). Fixes the prior inconsistency where each screen rolled its
+ * own page-icon badge, title position, and profile-icon placement.
+ *
+ * Layout: `[badge]  [title]  <spacer>  [right action]`, padded above by
+ * the safe-area top inset + 12 px so the brand pink bleeds behind the
+ * status bar cleanly. The badge is brand-white with a pink-tinted glyph
+ * so it reads against the pink background art every screen sets as its
+ * container.
+ */
+const TabHeader: React.FC<Props> = ({
+  icon,
+  title,
+  rightAction,
+  accessibilityLabel,
+  titleStyle,
+}) => {
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
+  const { profile } = useNostr();
+
+  const defaultRight = (
+    <ProfileIcon uri={profile?.picture} size={36} onPress={() => navigation.navigate('Account')} />
+  );
+
+  return (
+    <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
+      <View
+        style={styles.badge}
+        accessible={false}
+        // Decorative only — not tappable. See #139 AC.
+        importantForAccessibility="no-hide-descendants"
+      >
+        {icon}
+      </View>
+      <Text
+        style={[styles.title, titleStyle]}
+        numberOfLines={1}
+        accessibilityLabel={accessibilityLabel ?? title}
+      >
+        {title}
+      </Text>
+      <View style={styles.spacer} />
+      {rightAction ?? defaultRight}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+  },
+  badge: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(255,255,255,0.9)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    color: colors.white,
+    // Slightly lighter than the previous per-screen 28/700 because Home's
+    // "Hello, <name>!" greeting reads better at a softer weight and the
+    // section titles (Messages / Friends / Learn) still look substantial.
+    fontSize: 24,
+    fontWeight: '600',
+    flexShrink: 1,
+  },
+  spacer: {
+    flex: 1,
+  },
+});
+
+export default TabHeader;

--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -15,7 +15,9 @@ import { useNavigation, CompositeNavigationProp } from '@react-navigation/native
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNostr } from '../contexts/NostrContext';
-import ProfileIcon from '../components/ProfileIcon';
+import FriendsIcon from '../components/icons/FriendsIcon';
+import TabHeader from '../components/TabHeader';
+import { colors } from '../styles/theme';
 import ContactListItem from '../components/ContactListItem';
 import ContactProfileSheet from '../components/ContactProfileSheet';
 import AddFriendSheet from '../components/AddFriendSheet';
@@ -266,27 +268,8 @@ const FriendsScreen: React.FC = () => {
         style={styles.bgImage}
         resizeMode="contain"
       />
-      <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
-        <View style={styles.titleRow}>
-          <TouchableOpacity
-            style={styles.homeButton}
-            onPress={() => navigation.navigate('Home', {})}
-          >
-            <Image
-              source={require('../../assets/images/Home.png')}
-              style={styles.homeIcon}
-              resizeMode="contain"
-            />
-          </TouchableOpacity>
-          <Text style={styles.title}>Friends</Text>
-          <View style={{ flex: 1 }} />
-          <ProfileIcon
-            uri={profile?.picture}
-            size={36}
-            onPress={() => navigation.navigate('Account')}
-          />
-        </View>
-
+      <TabHeader title="Friends" icon={<FriendsIcon size={20} color={colors.brandPink} />} />
+      <View style={styles.headerExtras}>
         {/* Filter chips + search toggle */}
         <View style={styles.chipRow}>
           {searchExpanded ? (

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -20,7 +20,7 @@ import TransactionList from '../components/TransactionList';
 import WalletCarousel from '../components/WalletCarousel';
 import AddWalletWizard from '../components/AddWalletWizard';
 import WalletSettingsSheet from '../components/WalletSettingsSheet';
-import ProfileIcon from '../components/ProfileIcon';
+import TabHeader from '../components/TabHeader';
 import { ArrowDownIcon, ArrowUpIcon, ArrowLeftRightIcon } from '../components/icons/ArrowIcons';
 import { styles } from '../styles/HomeScreen.styles';
 import type { MainTabParamList } from '../navigation/types';
@@ -175,21 +175,27 @@ const HomeScreen: React.FC = () => {
   return (
     <View style={styles.container}>
       {/* Header area with brand background + faded pig behind carousel */}
-      <View style={[styles.headerBackground, { paddingTop: insets.top + 12 }]}>
+      <View style={styles.headerBackground}>
         <Image
           source={require('../../assets/images/lightning-piggy-intro.png')}
           style={styles.bgPigImage}
           resizeMode="contain"
         />
 
-        <View style={styles.headerRow}>
-          <Text style={styles.hello}>Hello{userName ? `, ${userName}` : ''}!</Text>
-          <ProfileIcon
-            uri={profile?.picture}
-            size={36}
-            onPress={() => navigation.navigate('Account')}
-          />
-        </View>
+        <TabHeader
+          title={`Hello${userName ? `, ${userName}` : ''}!`}
+          // Keep Home's greeting at its pre-#139 lighter weight + smaller
+          // size; section titles (Messages/Friends/Learn) stay bolder to
+          // read as section labels.
+          titleStyle={{ fontSize: 22, fontWeight: '400' }}
+          icon={
+            <Image
+              source={require('../../assets/images/Home.png')}
+              style={styles.badgeIcon}
+              resizeMode="contain"
+            />
+          }
+        />
 
         <WalletCarousel
           wallets={wallets}

--- a/src/screens/LearnScreen.tsx
+++ b/src/screens/LearnScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { View, Text, Image, TouchableOpacity, ScrollView } from 'react-native';
+import TabHeader from '../components/TabHeader';
 import { useFocusEffect } from '@react-navigation/native';
 import { courses } from '../data/learnContent';
 import {
@@ -36,17 +37,16 @@ const LearnScreen: React.FC<Props> = ({ navigation }) => {
           resizeMode="cover"
         />
         <View style={styles.headerOverlay} />
-        <TouchableOpacity
-          style={styles.homeButton}
-          onPress={() => navigation.getParent()?.navigate('Home')}
-        >
-          <Image
-            source={require('../../assets/images/Home.png')}
-            style={styles.homeIcon}
-            resizeMode="contain"
-          />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Learn</Text>
+        <TabHeader
+          title="Learn"
+          icon={
+            <Image
+              source={require('../../assets/images/Learn.png')}
+              style={styles.badgeIcon}
+              resizeMode="contain"
+            />
+          }
+        />
       </View>
 
       {/* Course grid */}

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -10,11 +10,11 @@ import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNostr } from '../contexts/NostrContext';
 import { useWallet } from '../contexts/WalletContext';
-import ProfileIcon from '../components/ProfileIcon';
 import ConversationRow from '../components/ConversationRow';
 import ContactProfileSheet from '../components/ContactProfileSheet';
 import FriendPickerSheet, { type PickedFriend } from '../components/FriendPickerSheet';
 import MessagesIcon from '../components/icons/MessagesIcon';
+import TabHeader from '../components/TabHeader';
 import { colors } from '../styles/theme';
 import {
   buildConversationSummaries,
@@ -191,25 +191,8 @@ const MessagesScreen: React.FC = () => {
         style={styles.bgImage}
         resizeMode="contain"
       />
-      <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
-        <View style={styles.titleRow}>
-          <TouchableOpacity
-            style={styles.homeButton}
-            onPress={() => navigation.navigate('Home', {})}
-            accessibilityLabel="Home"
-            testID="messages-home-button"
-          >
-            <MessagesIcon size={20} color={colors.brandPink} />
-          </TouchableOpacity>
-          <Text style={styles.title}>Messages</Text>
-          <View style={{ flex: 1 }} />
-          <ProfileIcon
-            uri={profile?.picture}
-            size={36}
-            onPress={() => navigation.navigate('Account')}
-          />
-        </View>
-
+      <TabHeader title="Messages" icon={<MessagesIcon size={20} color={colors.brandPink} />} />
+      <View style={styles.headerExtras}>
         <View style={styles.chipRow}>
           {searchExpanded ? (
             <View style={styles.searchRow}>

--- a/src/styles/FriendsScreen.styles.ts
+++ b/src/styles/FriendsScreen.styles.ts
@@ -6,15 +6,12 @@ export const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.brandPink,
   },
-  header: {
+  /** Extras row below TabHeader (search + chips). TabHeader owns its own
+   * vertical padding; this just claims the bottom spacing the full header
+   * used to provide so the list content doesn't hug the chip row. */
+  headerExtras: {
     paddingHorizontal: 20,
-    paddingBottom: 40,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    marginBottom: 16,
+    paddingBottom: 24,
   },
   addButton: {
     width: 36,
@@ -23,24 +20,6 @@ export const styles = StyleSheet.create({
     backgroundColor: 'rgba(255,255,255,0.2)',
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  homeButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: 'rgba(255,255,255,0.9)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  homeIcon: {
-    width: 20,
-    height: 20,
-    tintColor: colors.brandPink,
-  },
-  title: {
-    color: colors.white,
-    fontSize: 28,
-    fontWeight: '700',
   },
   chipRow: {
     flexDirection: 'row',

--- a/src/styles/HomeScreen.styles.ts
+++ b/src/styles/HomeScreen.styles.ts
@@ -19,18 +19,12 @@ export const styles = StyleSheet.create({
     top: -20,
     opacity: 0.15,
   },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingRight: 24,
-    marginBottom: 8,
-  },
-  hello: {
-    color: colors.white,
-    fontSize: 22,
-    fontWeight: '400',
-    paddingHorizontal: 24,
+  /** Glyph inside the TabHeader round badge for Home. 20×20 matches the
+   * other tabs' badge glyphs; the Home.png is tinted pink to match. */
+  badgeIcon: {
+    width: 20,
+    height: 20,
+    tintColor: colors.brandPink,
   },
   buttonRow: {
     flexDirection: 'row',

--- a/src/styles/LearnScreen.styles.ts
+++ b/src/styles/LearnScreen.styles.ts
@@ -1,7 +1,5 @@
-import { StyleSheet, Platform, StatusBar } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { colors } from './theme';
-
-const STATUS_BAR_TOP = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 40) + 4 : 44;
 
 export const styles = StyleSheet.create({
   container: {
@@ -9,42 +7,26 @@ export const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   headerBackground: {
+    // Match the pre-#139 fixed 140 px header so the decorative image
+    // shows at the full height the design expects. TabHeader lays out
+    // inside this box at the top; the space below it shows the art.
     height: 140,
     backgroundColor: colors.brandPink,
     overflow: 'hidden',
   },
   headerImage: {
-    width: '100%',
-    height: '100%',
-  },
-  homeButton: {
-    position: 'absolute',
-    top: STATUS_BAR_TOP,
-    left: 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: 'rgba(255,255,255,0.9)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    zIndex: 10,
-  },
-  homeIcon: {
-    width: 20,
-    height: 20,
-    tintColor: colors.brandPink,
+    ...StyleSheet.absoluteFillObject,
   },
   headerOverlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(236, 0, 140, 0.65)', // brandPink with 65% opacity
   },
-  headerTitle: {
-    position: 'absolute',
-    bottom: 16,
-    alignSelf: 'center',
-    color: colors.white,
-    fontSize: 22,
-    fontWeight: '700',
+  /** Glyph inside the TabHeader round badge for Learn. 20×20 is what the
+   * other tabs' badge glyphs use; the PNG is tinted pink to match. */
+  badgeIcon: {
+    width: 20,
+    height: 20,
+    tintColor: colors.brandPink,
   },
   scrollArea: {
     flex: 1,

--- a/src/styles/MessagesScreen.styles.ts
+++ b/src/styles/MessagesScreen.styles.ts
@@ -6,33 +6,12 @@ export const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.brandPink,
   },
-  header: {
+  /** Extras row below TabHeader (search + chips). The TabHeader owns its
+   * own vertical padding; this just claims the bottom spacing the full
+   * header used to provide so the list content doesn't hug the chip row. */
+  headerExtras: {
     paddingHorizontal: 20,
-    paddingBottom: 40,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    marginBottom: 16,
-  },
-  homeButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: 'rgba(255,255,255,0.9)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  homeIcon: {
-    width: 20,
-    height: 20,
-    tintColor: colors.brandPink,
-  },
-  title: {
-    color: colors.white,
-    fontSize: 28,
-    fontWeight: '700',
+    paddingBottom: 24,
   },
   chipRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary

Closes #139.

Extracts the four top-level tabs' header rows into a single `src/components/TabHeader.tsx` with consistent vertical alignment, safe-area padding, badge icon, title, and profile-icon placement.

## What changes

- **Shared component.** Layout is `[badge] [title] [spacer] [profile icon]`. TabHeader owns the safe-area top padding, the circular white badge that frames the page glyph, the title typography, and the right-aligned `ProfileIcon` that navigates to Account.
- **Badge is decorative.** Rendered as a `View` with `importantForAccessibility="no-hide-descendants"` — tapping does nothing, which was the explicit ask on the issue. The previous per-screen `TouchableOpacity → navigate('Home')` behaviour is gone.
- **Icons match the footer tab bar.** Home → `Home.png`; Messages → `MessagesIcon`; Learn → `Learn.png`; Friends → `FriendsIcon`. The previous inconsistent header used `Home.png` on Friends + Learn by accident.
- **Home greeting preserved.** Home passes `titleStyle={{ fontSize: 22, fontWeight: '400' }}` so the `"Hello, <name>!"` greeting keeps its pre-#139 softer weight. Section titles on Messages/Friends/Learn use the default 24/600.
- **Learn header height unchanged.** `headerBackground.height` stays at 140 px so the decorative art shows at full size. TabHeader lays out inside that box at the top; the remaining space is the art backdrop.
- **Styles cleanup.** Duplicated `homeButton` / `homeIcon` / `titleRow` / `title` entries removed from the four screens' `*.styles.ts`. Each screen now owns only its background art and (where applicable) a small `headerExtras` wrapper for the search + chip row below the header.

## Manually verified on emulator

- [x] Home greeting reads `"Hello, Ben!"` at the softer weight.
- [x] Messages / Friends / Learn show their tab-bar glyph in the badge, titles at consistent position.
- [x] Profile icon position aligns across all four tabs.
- [x] Tapping the badge on any tab does nothing (not a TouchableOpacity).
- [x] Learn preserves its 140 px decorative header.

## Follow-ups (not in this PR)

- **#148** — profile icon doesn't refresh across tabs after a kind-0 edit.
- **#150** — Home greeting should prefer the Nostr display name (`"Big Piggy"`) over WalletContext's local `userName` (`"Ben"`) when connected.
- **#151** — add search to the Learn tab once the catalog grows.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` — 0 errors (pre-existing warning baseline unchanged).
- [x] `npm run format:check` clean.
- [ ] `maestro test tests/e2e/test-login.yaml` / `test-logout.yaml` — unchanged, tab-bar `testID`s not touched.
- [x] `tests/e2e/test-create-account.yaml` references `account-home-button` which is a separate Account-screen home shortcut, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)