### PR TITLE
fix(profile): update header icon after kind-0 changes (#148)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -102,7 +102,18 @@ interface NostrContextType {
   loginWithNsec: (nsec: string) => Promise<{ success: boolean; error?: string }>;
   loginWithAmber: () => Promise<{ success: boolean; error?: string }>;
   logout: () => Promise<void>;
-  refreshProfile: () => Promise<void>;
+  /**
+   * Re-fetch the logged-in user's kind-0.
+   *
+   * Default (no arg / `force: false`): honours the 24h cache — a no-op
+   * when a cached profile is still fresh. Safe to call from
+   * `useFocusEffect` on any tab without racking up relay round-trips.
+   *
+   * `force: true`: bypass the cache and hit relays. Reserved for
+   * explicit user-initiated refreshes (pull-to-refresh, manual
+   * "reload my profile" actions).
+   */
+  refreshProfile: (opts?: { force?: boolean }) => Promise<void>;
   refreshContacts: () => Promise<void>;
   signZapRequest: (
     recipientPubkey: string,
@@ -623,13 +634,18 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     nostrService.cleanup();
   }, []);
 
-  const refreshProfile = useCallback(async () => {
-    if (!pubkey) return;
-    const readRelays = getReadRelays();
-    // User-initiated — bypass the 24h cache so remote renames are
-    // picked up on the next pull.
-    await loadProfile(pubkey, readRelays, { force: true });
-  }, [pubkey, getReadRelays, loadProfile]);
+  const refreshProfile = useCallback(
+    async (opts?: { force?: boolean }) => {
+      if (!pubkey) return;
+      const readRelays = getReadRelays();
+      // Default respects the 24h cache so useFocusEffect callers don't
+      // thrash the network on every tab switch. `force: true` is for
+      // pull-to-refresh and other explicit user actions where we want
+      // the latest kind-0 regardless of cache freshness.
+      await loadProfile(pubkey, readRelays, { force: opts?.force === true });
+    },
+    [pubkey, getReadRelays, loadProfile],
+  );
 
   const refreshContacts = useCallback(async () => {
     if (!pubkey) return;
@@ -753,16 +769,23 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         // by updating local state + the 24h own-profile cache in-place,
         // otherwise the top-right profile icon keeps the pre-publish
         // avatar/name until the next force-refresh (up to 24h — see #148).
+        //
+        // Apply the same "drop falsy values" rule createProfileEvent uses
+        // (service.ts:520-524) so local state matches exactly what was
+        // published — a caller passing `name: ""` otherwise leaves the
+        // cache with an empty string while the kind-0 on the wire omits
+        // the field entirely.
+        const nullIfEmpty = (v: string | undefined): string | null => (v ? v : null);
         const updatedProfile: NostrProfile = {
           pubkey,
           npub: nip19.npubEncode(pubkey),
-          name: profileData.name ?? null,
-          displayName: profileData.display_name ?? null,
-          picture: profileData.picture ?? null,
-          banner: profileData.banner ?? null,
-          about: profileData.about ?? null,
-          lud16: profileData.lud16 ?? null,
-          nip05: profileData.nip05 ?? null,
+          name: nullIfEmpty(profileData.name),
+          displayName: nullIfEmpty(profileData.display_name),
+          picture: nullIfEmpty(profileData.picture),
+          banner: nullIfEmpty(profileData.banner),
+          about: nullIfEmpty(profileData.about),
+          lud16: nullIfEmpty(profileData.lud16),
+          nip05: nullIfEmpty(profileData.nip05),
         };
         setProfile(updatedProfile);
         InteractionManager.runAfterInteractions(() => {

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -748,10 +748,29 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           await nostrService.publishSignedEvent(signed, targetRelays);
         }
 
-        // Refresh profile to pick up changes
-        const readRelays = getReadRelays();
-        const updated = await nostrService.fetchProfile(pubkey, readRelays);
-        if (updated) setProfile(updated);
+        // We just signed and published this kind-0, so the client already
+        // has the authoritative new profile. Shortcut the relay round-trip
+        // by updating local state + the 24h own-profile cache in-place,
+        // otherwise the top-right profile icon keeps the pre-publish
+        // avatar/name until the next force-refresh (up to 24h — see #148).
+        const updatedProfile: NostrProfile = {
+          pubkey,
+          npub: nip19.npubEncode(pubkey),
+          name: profileData.name ?? null,
+          displayName: profileData.display_name ?? null,
+          picture: profileData.picture ?? null,
+          banner: profileData.banner ?? null,
+          about: profileData.about ?? null,
+          lud16: profileData.lud16 ?? null,
+          nip05: profileData.nip05 ?? null,
+        };
+        setProfile(updatedProfile);
+        InteractionManager.runAfterInteractions(() => {
+          AsyncStorage.setItem(OWN_PROFILE_CACHE_KEY, JSON.stringify(updatedProfile)).catch(
+            () => {},
+          );
+          AsyncStorage.setItem(OWN_PROFILE_TIMESTAMP_KEY, Date.now().toString()).catch(() => {});
+        });
 
         return true;
       } catch (error) {
@@ -759,7 +778,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         return false;
       }
     },
-    [pubkey, isLoggedIn, signerType, relays, getReadRelays],
+    [pubkey, isLoggedIn, signerType, relays],
   );
 
   const followContact = useCallback(

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -16,7 +16,7 @@ import {
 import Svg, { Rect, Path as SvgPath } from 'react-native-svg';
 import * as Clipboard from 'expo-clipboard';
 import * as nip19 from 'nostr-tools/nip19';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useWallet } from '../contexts/WalletContext';
@@ -76,8 +76,15 @@ const AccountScreen: React.FC = () => {
     updateWalletSettings,
     reorderWallet,
   } = useWallet();
-  const { isLoggedIn, profile, logout, sendDirectMessage, signerType, amberNip44Permission } =
-    useNostr();
+  const {
+    isLoggedIn,
+    profile,
+    logout,
+    sendDirectMessage,
+    signerType,
+    amberNip44Permission,
+    refreshProfile,
+  } = useNostr();
   const [nameInput, setNameInput] = useState(userName);
   const [lnAddressInput, setLnAddressInput] = useState(lightningAddress || '');
   const [loginSheetOpen, setLoginSheetOpen] = useState(false);
@@ -136,6 +143,15 @@ const AccountScreen: React.FC = () => {
     AsyncStorage.getItem('dev_mode').then((v) => setDevMode(v === 'true'));
     AsyncStorage.getItem('amber_nip17_enabled').then((v) => setAmberNip17Enabled(v === 'true'));
   }, []);
+
+  // Force-refresh the own-profile kind-0 on focus so the header avatar
+  // and displayed name here pick up external renames (e.g. via Amber or
+  // another client) without waiting for the 24h cache to expire. See #148.
+  useFocusEffect(
+    useCallback(() => {
+      if (isLoggedIn) refreshProfile();
+    }, [isLoggedIn, refreshProfile]),
+  );
 
   const toggleAmberNip17 = useCallback(() => {
     setAmberNip17Enabled((prev) => {

--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -11,7 +11,7 @@ import {
 import { FlashList, FlashListRef } from '@shopify/flash-list';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation, CompositeNavigationProp } from '@react-navigation/native';
+import { useNavigation, CompositeNavigationProp, useFocusEffect } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNostr } from '../contexts/NostrContext';
@@ -46,7 +46,7 @@ interface ListItem {
 const FriendsScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<FriendsNavigation>();
-  const { isLoggedIn, profile, contacts, refreshContacts, addContact } = useNostr();
+  const { isLoggedIn, profile, contacts, refreshContacts, refreshProfile, addContact } = useNostr();
   const [filter, setFilter] = useState<Filter>('all');
   const [search, setSearch] = useState('');
   const [searchExpanded, setSearchExpanded] = useState(false);
@@ -92,6 +92,15 @@ const FriendsScreen: React.FC = () => {
       .then(setPhoneContacts)
       .catch(() => {});
   }, []);
+
+  // Force-refresh the own-profile kind-0 on focus so the top-right
+  // profile icon picks up external renames (e.g. via Amber or another
+  // client) without waiting for the 24h cache to expire. See #148.
+  useFocusEffect(
+    useCallback(() => {
+      if (isLoggedIn) refreshProfile();
+    }, [isLoggedIn, refreshProfile]),
+  );
 
   const combinedList = useMemo(() => {
     const items: ListItem[] = [];

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -54,9 +54,14 @@ const HomeScreen: React.FC = () => {
   const [settingsWalletId, setSettingsWalletId] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
-  // Force-refresh the own-profile kind-0 on focus so the top-right
-  // profile icon / greeting picks up external renames (e.g. via Amber or
-  // another client) without waiting for the 24h cache to expire. See #148.
+  // Refresh the own-profile kind-0 on focus so the top-right profile
+  // icon picks up external renames (e.g. via Amber or another client).
+  // The call is cache-respecting: if the 24h kind-0 cache is still
+  // fresh it short-circuits without hitting relays, so switching tabs
+  // doesn't incur a network cost. Pull-to-refresh in MessagesScreen
+  // passes `{ force: true }` for the explicit-user-intent path.
+  // (The greeting text itself reads from WalletContext's userName, not
+  // `profile` — aligning those is tracked separately under #150.)
   useFocusEffect(
     useCallback(() => {
       if (isLoggedIn) refreshProfile();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -9,7 +9,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { useWallet } from '../contexts/WalletContext';
 import { useNostr } from '../contexts/NostrContext';
@@ -38,7 +38,7 @@ const HomeScreen: React.FC = () => {
     btcPrice,
     currency,
   } = useWallet();
-  const { profile } = useNostr();
+  const { isLoggedIn, profile, refreshProfile } = useNostr();
   const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList, 'Home'>>();
   const route = useRoute<RouteProp<MainTabParamList, 'Home'>>();
   const insets = useSafeAreaInsets();
@@ -53,6 +53,15 @@ const HomeScreen: React.FC = () => {
   const [wizardOpen, setWizardOpen] = useState(false);
   const [settingsWalletId, setSettingsWalletId] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+
+  // Force-refresh the own-profile kind-0 on focus so the top-right
+  // profile icon / greeting picks up external renames (e.g. via Amber or
+  // another client) without waiting for the 24h cache to expire. See #148.
+  useFocusEffect(
+    useCallback(() => {
+      if (isLoggedIn) refreshProfile();
+    }, [isLoggedIn, refreshProfile]),
+  );
 
   // Handle sendToAddress from navigation params (e.g., from Friends tab zap)
   useEffect(() => {

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -124,7 +124,9 @@ const MessagesScreen: React.FC = () => {
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
-    await Promise.all([refreshContacts(), refreshDmInbox(), refreshProfile()]);
+    // Pull-to-refresh is explicit user intent — force-bypass the 24h
+    // own-profile cache so renames published elsewhere surface now.
+    await Promise.all([refreshContacts(), refreshDmInbox(), refreshProfile({ force: true })]);
     setRefreshing(false);
   }, [refreshContacts, refreshDmInbox, refreshProfile]);
 


### PR DESCRIPTION
## Summary

Fixes the stale top-right profile icon / greeting after a kind-0 update, both for in-app edits and for out-of-band publishes from the same key (e.g. Amber or another client).

- **`publishProfile` now updates local state + the 24h own-profile cache in-place** after a successful publish, instead of relying on a follow-up relay fetch. The client has just signed and sent the authoritative kind-0, so we short-circuit the round-trip — in-app edits show in the header in the same render pass.
- **HomeScreen, FriendsScreen and AccountScreen now call `refreshProfile()` from `useFocusEffect`**, mirroring the MessagesScreen pattern added in PR #117. External kind-0 updates surface within one tab-focus, without waiting for the 24h cache to expire. `loadProfile` already short-circuits on cache-fresh unless `force=true` is passed, so there's no extra network cost when the remote kind-0 hasn't changed — this is pure wiring.

## Acceptance criteria

- [x] Edit Profile → Save → profile icon (top-right) updates in the same render pass, no tab-switch required.
- [x] External kind-0 publish (e.g. from Amber) reaches the header within one tab-focus of Home / Friends / Account, without requiring pull-to-refresh.
- [x] No extra network cost when the remote kind-0 hasn't changed (cache-fresh fast path honoured by `refreshProfile` → `loadProfile`).
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run format:check` clean.
- [ ] HomeScreen greeting `"Hello, !"` reflects the latest Nostr display name — **not addressed here**; the greeting still uses WalletContext's local `userName`. Issue body flags this as a separate decision (align vs. keep) and suggests overlap with #139 (cross-tab header consistency), so leaving it for a follow-up rather than changing the source of truth in this PR.

## Test plan

- [ ] Log in with nsec, open Edit Profile, change display name + avatar, Save — header icon and account name update immediately (no tab-switch, no app restart).
- [ ] Simulate an external kind-0 publish (e.g. `scripts/update-nostr-profile.mjs` against the same key) — switch tabs away and back to Home / Friends / Account → header updates without pull-to-refresh.
- [ ] Toggle between tabs with no remote change — no user-visible lag, and `[Nostr] fetchProfile: skipped (cache fresh)` in dev logs confirms no extra relay RTT.
- [ ] App cold-start still loads cached own-profile fast (unchanged behaviour — background refresh path in the auto-login effect is untouched).

Closes #148