### PR TITLE
fix(nwc): validate payment_hash + cache failed lookups (#98)

### DIFF
--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -133,12 +133,17 @@ const TransactionDetailSheet: React.FC<Props> = ({
 
   useEffect(() => {
     setEnrichment({});
-    if (!visible || !tx || !tx.paymentHash) return;
+    if (!visible || !tx) return;
+    // Some NWC backends return transactions whose payment_hash is null /
+    // truncated / otherwise not a 64-char hex string; skip those outright
+    // so we don't kick off a lookup the backend will reject (#98).
+    if (!nwcService.isValidPaymentHash(tx.paymentHash)) return;
     if (tx.preimage && tx.invoice) return;
     if (!activeWallet || activeWallet.walletType === 'onchain') return;
+    const paymentHash = tx.paymentHash;
     let cancelled = false;
     (async () => {
-      const result = await nwcService.lookupInvoice(activeWallet.id, tx.paymentHash!);
+      const result = await nwcService.lookupInvoice(activeWallet.id, paymentHash);
       if (!cancelled && result) setEnrichment(result);
     })();
     return () => {

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -344,11 +344,14 @@ export function isValidPaymentHash(hash: string | null | undefined): hash is str
   return typeof hash === 'string' && PAYMENT_HASH_RE.test(hash);
 }
 
-// Per-session cache of payment hashes the NWC backend has already refused
-// to look up (or which were malformed). Some backends return transactions
-// whose `payment_hash` is null / truncated / otherwise rejected by the
-// NIP-47 `lookup_invoice` call — retrying those every refresh floods the
-// Metro log and burns NWC request budget (#98).
+// Per-session cache of payment hashes the NWC backend has *terminally*
+// refused (e.g. NIP-47 NOT_FOUND, or the SDK's "Missing/invalid
+// payment_hash" input rejection). Skipping these on subsequent calls
+// avoids flooding the Metro log every refresh and burning NWC request
+// budget (#98). Transient errors (relay disconnects, timeouts,
+// INTERNAL / RATE_LIMITED) are intentionally NOT cached so paid-status
+// polling (ConversationScreen) and expectPayment detection
+// (WalletContext) still settle when conditions recover.
 const failedLookupCache = new Map<string, Set<string>>();
 
 function hasFailedLookup(walletId: string, paymentHash: string): boolean {
@@ -362,6 +365,24 @@ function recordFailedLookup(walletId: string, paymentHash: string): void {
     failedLookupCache.set(walletId, set);
   }
   set.add(paymentHash);
+}
+
+// Errors that mean "this hash isn't coming back from this backend".
+// Anything else is treated as transient — caching transient failures
+// would permanently silence valid paid-status polling once a single
+// relay timeout slipped through.
+function isTerminalLookupError(error: unknown): boolean {
+  if (!error) return false;
+  const message = error instanceof Error ? error.message : String(error);
+  if (/missing payment_hash|invalid payment_hash|not[ _]?found/i.test(message)) {
+    return true;
+  }
+  // NIP-47 error responses surface a `code` on the thrown error object.
+  const code = (error as { code?: unknown })?.code;
+  if (typeof code === 'string' && code.toUpperCase() === 'NOT_FOUND') {
+    return true;
+  }
+  return false;
 }
 
 // LNbits (and some other NWC backends) omit preimage/invoice from
@@ -390,7 +411,9 @@ export async function lookupInvoice(
       paid,
     };
   } catch (error) {
-    recordFailedLookup(walletId, paymentHash);
+    if (isTerminalLookupError(error)) {
+      recordFailedLookup(walletId, paymentHash);
+    }
     console.warn(`lookupInvoice failed for ${walletId} (${paymentHash.slice(0, 12)}…):`, error);
     return null;
   }

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -337,6 +337,33 @@ export async function listTransactions(walletId: string): Promise<any[]> {
   return [];
 }
 
+// A BOLT-11 payment hash is a SHA-256 digest — 64 hex chars.
+const PAYMENT_HASH_RE = /^[0-9a-fA-F]{64}$/;
+
+export function isValidPaymentHash(hash: string | null | undefined): hash is string {
+  return typeof hash === 'string' && PAYMENT_HASH_RE.test(hash);
+}
+
+// Per-session cache of payment hashes the NWC backend has already refused
+// to look up (or which were malformed). Some backends return transactions
+// whose `payment_hash` is null / truncated / otherwise rejected by the
+// NIP-47 `lookup_invoice` call — retrying those every refresh floods the
+// Metro log and burns NWC request budget (#98).
+const failedLookupCache = new Map<string, Set<string>>();
+
+function hasFailedLookup(walletId: string, paymentHash: string): boolean {
+  return failedLookupCache.get(walletId)?.has(paymentHash) ?? false;
+}
+
+function recordFailedLookup(walletId: string, paymentHash: string): void {
+  let set = failedLookupCache.get(walletId);
+  if (!set) {
+    set = new Set();
+    failedLookupCache.set(walletId, set);
+  }
+  set.add(paymentHash);
+}
+
 // LNbits (and some other NWC backends) omit preimage/invoice from
 // list_transactions; this fills them in. Returns null on failure.
 // `paid` relies on `settled_at` (a non-zero timestamp when the invoice
@@ -346,6 +373,8 @@ export async function lookupInvoice(
   walletId: string,
   paymentHash: string,
 ): Promise<{ preimage?: string; invoice?: string; paid: boolean } | null> {
+  if (!isValidPaymentHash(paymentHash)) return null;
+  if (hasFailedLookup(walletId, paymentHash)) return null;
   const provider = await ensureConnected(walletId);
   if (!provider) return null;
   try {
@@ -361,7 +390,8 @@ export async function lookupInvoice(
       paid,
     };
   } catch (error) {
-    console.warn(`lookupInvoice failed for ${walletId}:`, error);
+    recordFailedLookup(walletId, paymentHash);
+    console.warn(`lookupInvoice failed for ${walletId} (${paymentHash.slice(0, 12)}…):`, error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Stops the Metro log flood from `Failed to request lookup_invoke [Error: Missing payment_hash or invoice]` seen on one NWC wallet (`d48fcda2-…`).

Some NWC backends (notably LNbits) return transactions whose `payment_hash` is null, truncated, or otherwise rejected by the NIP-47 `lookup_invoice` call. Every list refresh or open of the transaction-detail sheet re-invoked the lookup, triggering the Getalby SDK error and burning NWC request budget.

## Changes

**`src/services/nwcService.ts`**
- New `isValidPaymentHash(hash)` helper — a BOLT-11 payment hash is a SHA-256 digest (64 hex chars).
- New per-session `failedLookupCache: Map<walletId, Set<paymentHash>>`. Hashes the backend has already rejected are skipped on subsequent calls, so the remaining warn fires **once per broken hash per session** instead of every refresh.
- `lookupInvoice(walletId, paymentHash)` now:
  - Early-returns `null` silently for any non-64-hex input.
  - Early-returns `null` silently for any previously failed hash.
  - Records a failure in the cache when the provider throws, and truncates the hash in the warn line for readability.

**`src/components/TransactionDetailSheet.tsx`**
- Enrichment effect uses the shared `nwcService.isValidPaymentHash` guard instead of a bare truthiness check, so it no longer kicks off a lookup the backend will reject.
- Hoists `paymentHash` into a local so the `tx.paymentHash!` non-null assertion is gone.

## What this fixes for callers

The `nwcService.lookupInvoice` gate is the single choke point — the other call sites (ConversationScreen's paid-poll and WalletContext's `expectPayment` tick) already tolerate a `null` result, so they inherit the fix without call-site changes. That keeps the diff minimal.

## Test plan

- [ ] Reproduce: open a transaction sheet on the affected wallet → verify Metro no longer floods with `Missing payment_hash or invoice`; at most one warn per broken tx per app session.
- [ ] Regression: a healthy NWC wallet still enriches `preimage` / `invoice` on txs returned without them (LNbits list_transactions behaviour unchanged).
- [ ] Regression: `expectPayment` polling still settles (balance-diff fallback is unaffected).
- [ ] Regression: ConversationScreen paid-hash poll still flips outgoing open invoices to paid.
- [ ] `npx prettier --check` clean on changed files.
- [ ] `npx tsc --noEmit` — no new errors introduced (pre-existing env errors unrelated).

## Out of scope

- `fetchTransactionsForWallet` still passes backend `payment_hash` values through unchanged. Emitting a per-wallet "malformed tx" warning at ingest would be additive and can land later if the issue persists; the service-level gate already suppresses the downstream noise.
- Rolling our own on-brand modal / toast for transaction-detail errors — that's #158's scope. See my follow-up note in the PR thread.

Closes #98

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnydVwPeyHDApe4SAKPDM7)_