### PR TITLE
refactor(ui): replace Alert.alert with on-brand BrandedAlert (#158)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import { WalletProvider, useWallet } from './src/contexts/WalletContext';
 import { NostrProvider } from './src/contexts/NostrContext';
 import AppNavigator from './src/navigation/AppNavigator';
 import PaymentProgressOverlay from './src/components/PaymentProgressOverlay';
+import { BrandedAlertHost } from './src/components/BrandedAlert';
 
 // Render toasts with unlimited-line body so long error messages (e.g. Electrum
 // script-verify errors) aren't truncated. Height grows to fit content.
@@ -76,6 +77,7 @@ export default function App() {
           </BottomSheetModalProvider>
           <Toast topOffset={60} config={toastConfig} />
           <GlobalIncomingPaymentOverlay />
+          <BrandedAlertHost />
         </NostrProvider>
       </WalletProvider>
     </GestureHandlerRootView>

--- a/src/components/AddFriendSheet.tsx
+++ b/src/components/AddFriendSheet.tsx
@@ -5,9 +5,9 @@ import {
   TouchableOpacity,
   StyleSheet,
   BackHandler,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,

--- a/src/components/AddWalletWizard.tsx
+++ b/src/components/AddWalletWizard.tsx
@@ -4,11 +4,11 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   ActivityIndicator,
   Keyboard,
   Platform,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import {
   BottomSheetModal,

--- a/src/components/BrandedAlert.tsx
+++ b/src/components/BrandedAlert.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
+import { AlertCircle, Check, Info, X } from 'lucide-react-native';
+import { colors } from '../styles/theme';
+
+export type BrandedAlertButtonStyle = 'default' | 'cancel' | 'destructive';
+
+export interface BrandedAlertButton {
+  text: string;
+  style?: BrandedAlertButtonStyle;
+  onPress?: () => void;
+}
+
+export type BrandedAlertKind = 'info' | 'error' | 'success' | 'confirm';
+
+export interface BrandedAlertOptions {
+  cancelable?: boolean;
+  onDismiss?: () => void;
+}
+
+interface AlertPayload {
+  id: number;
+  title: string;
+  message?: string;
+  buttons: BrandedAlertButton[];
+  kind: BrandedAlertKind;
+  options?: BrandedAlertOptions;
+}
+
+type Listener = (payload: AlertPayload) => void;
+
+let listener: Listener | null = null;
+let nextId = 1;
+
+function inferKind(title: string, buttons: BrandedAlertButton[]): BrandedAlertKind {
+  if (buttons.some((b) => b.style === 'destructive')) return 'confirm';
+  if (buttons.length > 1 && buttons.some((b) => b.style === 'cancel')) return 'confirm';
+  const lower = title.toLowerCase();
+  if (/fail|error|invalid|could not|unable|denied|needed|required/.test(lower)) return 'error';
+  if (/saved|updated|copied|complete|published|success|done|enabled/.test(lower)) return 'success';
+  return 'info';
+}
+
+function alertImpl(
+  title: string,
+  message?: string,
+  buttons?: BrandedAlertButton[],
+  options?: BrandedAlertOptions,
+): void {
+  const btns = buttons && buttons.length > 0 ? buttons : [{ text: 'OK' }];
+  const payload: AlertPayload = {
+    id: nextId++,
+    title,
+    message,
+    buttons: btns,
+    kind: inferKind(title, btns),
+    options,
+  };
+  if (listener) {
+    listener(payload);
+  } else if (__DEV__) {
+    console.warn('[BrandedAlert] host is not mounted; dropping alert:', title);
+  }
+}
+
+// Drop-in for React Native's `Alert` — `Alert.alert(title, message?, buttons?)`.
+export const Alert = { alert: alertImpl };
+
+// Functional alias for callers that prefer a bare function.
+export const alert = alertImpl;
+
+export function BrandedAlertHost(): React.ReactElement | null {
+  const [payload, setPayload] = useState<AlertPayload | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    listener = (p) => {
+      if (mountedRef.current) setPayload(p);
+    };
+    return () => {
+      mountedRef.current = false;
+      listener = null;
+    };
+  }, []);
+
+  const close = () => setPayload(null);
+
+  const handleButton = (btn: BrandedAlertButton) => {
+    close();
+    // Defer onPress so the dismiss animation can start before any follow-up
+    // UI work (which may itself raise another alert) runs.
+    if (btn.onPress) setTimeout(btn.onPress, 0);
+  };
+
+  // Dismiss without a button press — triggered by the hardware back button
+  // or a backdrop tap when the alert is cancelable. Matches RN Alert's
+  // `options.onDismiss` semantic so existing call sites behave the same way.
+  const handleDismiss = () => {
+    const onDismiss = payload?.options?.onDismiss;
+    close();
+    if (onDismiss) setTimeout(onDismiss, 0);
+  };
+
+  if (!payload) return null;
+
+  const cancelable = payload.options?.cancelable ?? true;
+
+  // Icon treatment mirrors PaymentProgressOverlay: a 72x72 solid-colour
+  // circle with a white glyph, so alerts and payment toasts feel like
+  // siblings from the same family.
+  const { Icon, iconBg } =
+    payload.kind === 'error'
+      ? { Icon: X, iconBg: colors.red }
+      : payload.kind === 'success'
+        ? { Icon: Check, iconBg: colors.green }
+        : payload.kind === 'confirm'
+          ? { Icon: AlertCircle, iconBg: colors.brandPink }
+          : { Icon: Info, iconBg: colors.brandPink };
+
+  const stackButtons = payload.buttons.length > 2;
+
+  return (
+    <Modal
+      visible
+      transparent
+      statusBarTranslucent
+      animationType="fade"
+      onRequestClose={cancelable ? handleDismiss : close}
+    >
+      <Pressable
+        style={styles.root}
+        onPress={cancelable ? handleDismiss : undefined}
+        accessibilityLabel="Dismiss alert"
+      >
+        <View
+          onStartShouldSetResponder={() => true}
+          accessible
+          accessibilityRole="alert"
+          accessibilityLiveRegion="assertive"
+          accessibilityLabel={`${payload.title}${payload.message ? `. ${payload.message}` : ''}`}
+          style={styles.card}
+          testID="branded-alert"
+        >
+          <View style={[styles.iconSlot, { backgroundColor: iconBg }]}>
+            <Icon size={44} color={colors.white} strokeWidth={3.5} />
+          </View>
+          <Text style={styles.title} testID="branded-alert-title">
+            {payload.title}
+          </Text>
+          {payload.message ? (
+            <Text style={styles.subtitle} testID="branded-alert-message">
+              {payload.message}
+            </Text>
+          ) : null}
+          <View style={[styles.buttonRow, stackButtons ? styles.buttonColumn : null]}>
+            {payload.buttons.map((btn, idx) => {
+              const isCancel = btn.style === 'cancel';
+              const isDestructive = btn.style === 'destructive';
+              return (
+                <Pressable
+                  key={`${idx}-${btn.text}`}
+                  onPress={() => handleButton(btn)}
+                  style={({ pressed }) => [
+                    styles.button,
+                    isCancel
+                      ? styles.cancelButton
+                      : isDestructive
+                        ? styles.destructiveButton
+                        : styles.primaryButton,
+                    pressed ? styles.buttonPressed : null,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={btn.text}
+                  testID={`branded-alert-button-${idx}`}
+                >
+                  <Text
+                    style={[
+                      styles.buttonText,
+                      isCancel ? styles.cancelButtonText : styles.actionButtonText,
+                    ]}
+                  >
+                    {btn.text}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+// Styles mirror PaymentProgressOverlay so send/receive confirmations and
+// system alerts feel like siblings from the same family.
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: 'rgba(21, 23, 26, 0.45)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 28,
+    paddingVertical: 32,
+    paddingHorizontal: 28,
+    minWidth: 260,
+    maxWidth: 340,
+    alignItems: 'center',
+    gap: 14,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.2,
+    shadowRadius: 24,
+    elevation: 12,
+  },
+  iconSlot: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textHeader,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.textSupplementary,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    alignSelf: 'stretch',
+    gap: 10,
+    marginTop: 6,
+  },
+  buttonColumn: {
+    flexDirection: 'column-reverse',
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButton: {
+    backgroundColor: colors.brandPink,
+  },
+  destructiveButton: {
+    backgroundColor: colors.red,
+  },
+  cancelButton: {
+    backgroundColor: colors.background,
+  },
+  buttonPressed: {
+    opacity: 0.75,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  actionButtonText: {
+    color: colors.white,
+  },
+  cancelButtonText: {
+    color: colors.textBody,
+  },
+});
+
+export default Alert;

--- a/src/components/BrandedAlert.tsx
+++ b/src/components/BrandedAlert.tsx
@@ -29,7 +29,13 @@ interface AlertPayload {
 
 type Listener = (payload: AlertPayload) => void;
 
+const noop = () => {};
+
 let listener: Listener | null = null;
+// Monotonically-increasing id used as the Modal's React `key`, so a
+// second alert raised while the first is still visible remounts the
+// Modal and re-runs its fade-in animation (rather than silently swapping
+// the content underneath an already-presented dialog).
 let nextId = 1;
 
 function inferKind(title: string, buttons: BrandedAlertButton[]): BrandedAlertKind {
@@ -122,16 +128,18 @@ export function BrandedAlertHost(): React.ReactElement | null {
 
   return (
     <Modal
+      key={payload.id}
       visible
       transparent
       statusBarTranslucent
       animationType="fade"
-      onRequestClose={cancelable ? handleDismiss : close}
+      onRequestClose={cancelable ? handleDismiss : noop}
     >
       <Pressable
         style={styles.root}
         onPress={cancelable ? handleDismiss : undefined}
-        accessibilityLabel="Dismiss alert"
+        accessible={cancelable}
+        accessibilityLabel={cancelable ? 'Dismiss alert' : undefined}
       >
         <View
           onStartShouldSetResponder={() => true}

--- a/src/components/ContactProfileSheet.tsx
+++ b/src/components/ContactProfileSheet.tsx
@@ -6,9 +6,9 @@ import {
   TouchableOpacity,
   StyleSheet,
   BackHandler,
-  Alert,
   Linking,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import { Image } from 'expo-image';
 import {
   BottomSheetModal,

--- a/src/components/EditProfileSheet.tsx
+++ b/src/components/EditProfileSheet.tsx
@@ -8,8 +8,8 @@ import {
   Platform,
   BackHandler,
   Keyboard,
-  Alert,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import {

--- a/src/components/FeedbackSheet.tsx
+++ b/src/components/FeedbackSheet.tsx
@@ -5,11 +5,11 @@ import {
   TouchableOpacity,
   StyleSheet,
   BackHandler,
-  Alert,
   ActivityIndicator,
   Platform,
   Keyboard,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,

--- a/src/components/NostrLoginSheet.tsx
+++ b/src/components/NostrLoginSheet.tsx
@@ -8,8 +8,8 @@ import {
   Platform,
   BackHandler,
   Keyboard,
-  Alert,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import Svg, { Path } from 'react-native-svg';
 import * as Clipboard from 'expo-clipboard';
 import {

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -3,13 +3,13 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
   BackHandler,
   Image,
   Keyboard,
   Platform,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,

--- a/src/components/TransferSheet.tsx
+++ b/src/components/TransferSheet.tsx
@@ -3,7 +3,6 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
   BackHandler,
   Image,
@@ -11,6 +10,7 @@ import {
   Linking,
   Platform,
 } from 'react-native';
+import { Alert } from './BrandedAlert';
 import {
   BottomSheetModal,
   BottomSheetTextInput,

--- a/src/components/WalletSettingsSheet.tsx
+++ b/src/components/WalletSettingsSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Alert, Platform, Keyboard } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, Keyboard } from 'react-native';
+import { Alert } from './BrandedAlert';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -7,12 +7,12 @@ import {
   TouchableOpacity,
   StyleSheet,
   ScrollView,
-  Alert,
   KeyboardAvoidingView,
   Platform,
   Image,
   ActivityIndicator,
 } from 'react-native';
+import { Alert } from '../components/BrandedAlert';
 import Svg, { Rect, Path as SvgPath } from 'react-native-svg';
 import * as Clipboard from 'expo-clipboard';
 import * as nip19 from 'nostr-tools/nip19';

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -11,12 +11,12 @@ import {
   Platform,
   ActivityIndicator,
   RefreshControl,
-  Alert,
   AppState,
   Image,
   Linking,
   StyleSheet,
 } from 'react-native';
+import { Alert } from '../components/BrandedAlert';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { Zap, Send, Plus, MapPin, ArrowDown } from 'lucide-react-native';
 import { Image as ExpoImage } from 'expo-image';

--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -1,13 +1,6 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef, Profiler } from 'react';
-import {
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  Image,
-  RefreshControl,
-  Alert,
-} from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, Image, RefreshControl } from 'react-native';
+import { Alert } from '../components/BrandedAlert';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { Users } from 'lucide-react-native';

--- a/src/screens/MissionDetailScreen.tsx
+++ b/src/screens/MissionDetailScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
-import { View, Text, Image, TouchableOpacity, ScrollView, Linking, Alert } from 'react-native';
+import { View, Text, Image, TouchableOpacity, ScrollView, Linking } from 'react-native';
+import { Alert } from '../components/BrandedAlert';
 import { useFocusEffect } from '@react-navigation/native';
 import { courses } from '../data/learnContent';
 import {

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -7,8 +7,8 @@ import {
   StyleSheet,
   KeyboardAvoidingView,
   Platform,
-  Alert,
 } from 'react-native';
+import { Alert } from '../components/BrandedAlert';
 import { useWallet } from '../contexts/WalletContext';
 import { useNostr } from '../contexts/NostrContext';
 import { colors } from '../styles/theme';


### PR DESCRIPTION
Closes #158

## Summary

Replaces React Native's default `Alert.alert(...)` popup (jarring white rectangle with the OS accent-green "OK" button on Android) with an on-brand `BrandedAlert` modal that matches the rest of Lightning Piggy's playful, kid-facing styling.

The dialog's card styling deliberately mirrors `PaymentProgressOverlay` so system alerts and payment send/receive confirmations feel like siblings from the same family:

- `28px` rounded white card, soft drop shadow
- `72×72` solid-colour icon circle with a white glyph (red `X` for errors, green `Check` for success, pink `AlertCircle` for confirms, pink `Info` otherwise)
- `textHeader` title + `textSupplementary` subtitle
- Pink primary button with white text (`fontSize: 16`, weight `700`, letter-spacing `0.3`)

## Scope

All 49 `Alert.alert(...)` call sites across 14 files were migrated in a single pass (per acceptance-criteria option). Each file's migration is a straightforward import swap — no call-site changes required, because `BrandedAlert` exports an `Alert` object whose `.alert(title, message?, buttons?, options?)` shape is a direct drop-in for React Native's.

```diff
-import { Alert, ... } from 'react-native';
+import { ... } from 'react-native';
+import { Alert } from './BrandedAlert'; // or '../components/BrandedAlert'
```

Files touched:

- Component sheets: `AddFriendSheet`, `AddWalletWizard`, `ContactProfileSheet`, `EditProfileSheet`, `FeedbackSheet`, `NostrLoginSheet`, `SendSheet`, `TransferSheet`, `WalletSettingsSheet`
- Screens: `AccountScreen`, `ConversationScreen`, `FriendsScreen`, `MissionDetailScreen`, `OnboardingScreen`
- `App.tsx` mounts `<BrandedAlertHost />` once inside `NostrProvider` alongside `<Toast />` and the incoming-payment overlay so every alert in the app can find it.

## How it works

`BrandedAlert.tsx` exposes:

- `BrandedAlertHost` — singleton modal host; mounted once at the root.
- `Alert` — `{ alert(title, message?, buttons?, options?) }` — the drop-in.
- `alert` — functional alias for callers that prefer a bare function.

Under the hood, the host subscribes to a module-level listener that `Alert.alert` publishes into. Showing a new alert while one is open replaces it (RN's behaviour is platform-dependent here, so matching RN wasn't practical; replace-on-present is the simple and defensible choice for a kids wallet).

### Kind inference

Rather than require every call site to pass a kind prop, the kind is inferred from the existing title + button styles:

- `confirm` (pink AlertCircle) — any button has `style: 'destructive'`, or there's a `cancel` button alongside others.
- `error` (red X) — title matches `/fail|error|invalid|could not|unable|denied|needed|required/`.
- `success` (green Check) — title matches `/saved|updated|copied|complete|published|success|done|enabled/`.
- `info` (pink Info) — fallback.

This means the existing 49 call sites get the right colour/icon without being rewritten — "Error", "Permission needed", "Send failed" all go red; "Saved", "Profile Updated", "Copied", "Transfer Complete" all go green; "Unfollow", "Remove Wallet", "Logout", "Disconnect Nostr?" all get the confirm treatment.

### Options support

One caller (`ConversationScreen`'s location-share confirm) passes RN's 4th `options` arg — `{ cancelable, onDismiss }`. `BrandedAlert` honours both: backdrop tap / hardware back dismiss the alert and fire `onDismiss` when `cancelable !== false`.

### Accessibility

- `accessibilityRole="alert"` + `accessibilityLiveRegion="assertive"` on the card so screen readers announce the dialog on open.
- `accessibilityLabel` combines title + message on the card.
- Each button has its own `accessibilityRole="button"` and `accessibilityLabel`.
- `testID="branded-alert"`, `branded-alert-title`, `branded-alert-message`, and `branded-alert-button-{idx}` so Maestro can assert without coordinates (per `CLAUDE.md`).

## Acceptance criteria

- [x] New `BrandedAlert` component + `alert()` helper in `src/components/BrandedAlert.tsx`.
- [x] All 49 `Alert.alert(...)` call sites migrated in one pass.
- [x] Visual design covers Error (red X), Confirm (Cancel + destructive), and Success (green Check) cases.
- [x] `testID` on the dialog and each button for Maestro assertions.
- [x] Accessibility labels + live-region announcement.
- [x] `npx tsc --noEmit`, `npm run lint` (no new errors/warnings on touched files), `npm run format:check` all clean.

## Out of scope

- Native OS permission prompts (camera, location) — left untouched because they're tied to the Android permission model.
- Toast-style transient notifications — no current use; future enhancement.

## Test plan

- [ ] Trigger an error (e.g. Send → invalid amount) — red X, pink OK button, matches card styling of `PaymentProgressOverlay`.
- [ ] Trigger a success (Account → Save) — green Check, pink OK button.
- [ ] Trigger a confirm with destructive (Account → Remove Wallet) — pink AlertCircle, grey Cancel + red Remove.
- [ ] Trigger a cancelable+onDismiss alert (Conversation → share location → tap backdrop) — dismisses and fires `onDismiss`.
- [ ] Hardware back while alert is open — dismisses (fires `onDismiss` if supplied).
- [ ] Screen reader announces the alert on present.


---
_Generated by [Claude Code](https://claude.ai/code/session_017dsqu8oCBHXykWTtMwFZ6T)_