### PR TITLE
feat(home): infinite scroll on transactions list (#172)

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, forwardRef, useImperativeHandle } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Image } from 'expo-image';
 import { useNavigation } from '@react-navigation/native';
@@ -20,6 +20,11 @@ import type { RootStackParamList } from '../navigation/types';
 
 interface Props {
   transactions: WalletTransaction[];
+}
+
+export interface TransactionListHandle {
+  /** Reveal the next batch of cached transactions. No-op when all are visible. */
+  loadMore: () => void;
 }
 
 function zapCounterpartyLabel(cp: ZapCounterpartyInfo): string {
@@ -69,7 +74,7 @@ function formatTime(ts: number): string {
   });
 }
 
-const INITIAL_COUNT = 20;
+const BATCH_SIZE = 20;
 
 type ItemRow = { kind: 'tx'; tx: WalletTransaction; key: string };
 type HeaderRow = { kind: 'header'; label: string; key: string };
@@ -87,7 +92,7 @@ function txKey(tx: WalletTransaction, fallbackIndex: number): string {
   return `fb:${tx.type}:${tx.created_at ?? tx.settled_at ?? 'pending'}:${tx.amount}:${fallbackIndex}`;
 }
 
-const TransactionList: React.FC<Props> = ({ transactions }) => {
+const TransactionList = forwardRef<TransactionListHandle, Props>(({ transactions }, ref) => {
   const { btcPrice, currency } = useWallet();
   const { contacts } = useNostr();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -110,12 +115,28 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
     }
     return m;
   }, [contacts]);
-  const [showAll, setShowAll] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(BATCH_SIZE);
   const [detail, setDetail] = useState<TransactionDetailData | null>(null);
   const [profileContact, setProfileContact] = useState<CounterpartyContact | null>(null);
   const [zapContact, setZapContact] = useState<CounterpartyContact | null>(null);
 
-  React.useEffect(() => setShowAll(false), [transactions]);
+  // Reset back to the first batch when the wallet (and therefore the tx list
+  // identity) changes, so swiping wallets starts from the top.
+  React.useEffect(() => setVisibleCount(BATCH_SIZE), [transactions]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      loadMore: () => {
+        setVisibleCount((c) => {
+          const total = transactions.length;
+          if (c >= total) return c;
+          return Math.min(c + BATCH_SIZE, total);
+        });
+      },
+    }),
+    [transactions.length],
+  );
 
   if (transactions.length === 0) {
     return (
@@ -134,8 +155,7 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
     if (!bTime) return 1;
     return bTime - aTime;
   });
-  const visibleTransactions = showAll ? sorted : sorted.slice(0, INITIAL_COUNT);
-  const hasMore = transactions.length > INITIAL_COUNT;
+  const visibleTransactions = sorted.slice(0, visibleCount);
 
   // Flatten into a mixed list of day headers + rows. Pending entries (no
   // timestamp) get a "Pending" header so they still group visually.
@@ -156,7 +176,7 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
   });
 
   return (
-    <View style={styles.list}>
+    <View style={styles.list} testID="transaction-list">
       {rows.map((row) => {
         if (row.kind === 'header') {
           return (
@@ -261,11 +281,6 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
           </TouchableOpacity>
         );
       })}
-      {hasMore && !showAll && (
-        <TouchableOpacity style={styles.showMore} onPress={() => setShowAll(true)}>
-          <Text style={styles.showMoreText}>Show all {transactions.length} transactions</Text>
-        </TouchableOpacity>
-      )}
       <TransactionDetailSheet
         visible={detail !== null}
         tx={detail}
@@ -326,7 +341,9 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
       />
     </View>
   );
-};
+});
+
+TransactionList.displayName = 'TransactionList';
 
 const AVATAR_SIZE = 40;
 
@@ -425,15 +442,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
     color: colors.textSupplementary,
     marginTop: 1,
-  },
-  showMore: {
-    paddingVertical: 16,
-    alignItems: 'center',
-  },
-  showMoreText: {
-    color: colors.brandPink,
-    fontSize: 14,
-    fontWeight: '600',
   },
   incoming: {
     color: colors.green,

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -138,6 +138,21 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({ transactions
     [transactions.length],
   );
 
+  // Sort: pending (no timestamp) first, then newest first. Memoised on
+  // `transactions` identity so that infinite-scroll re-renders (which bump
+  // `visibleCount` but leave `transactions` unchanged) only re-slice the
+  // array below instead of re-sorting the full list each time.
+  const sorted = useMemo(() => {
+    return [...transactions].sort((a, b) => {
+      const aTime = a.settled_at || a.created_at;
+      const bTime = b.settled_at || b.created_at;
+      if (!aTime && !bTime) return 0;
+      if (!aTime) return -1;
+      if (!bTime) return 1;
+      return bTime - aTime;
+    });
+  }, [transactions]);
+
   if (transactions.length === 0) {
     return (
       <View style={styles.emptyContainer}>
@@ -146,15 +161,6 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({ transactions
     );
   }
 
-  // Sort: pending (no timestamp) first, then newest first.
-  const sorted = [...transactions].sort((a, b) => {
-    const aTime = a.settled_at || a.created_at;
-    const bTime = b.settled_at || b.created_at;
-    if (!aTime && !bTime) return 0;
-    if (!aTime) return -1;
-    if (!bTime) return 1;
-    return bTime - aTime;
-  });
   const visibleTransactions = sorted.slice(0, visibleCount);
 
   // Flatten into a mixed list of day headers + rows. Pending entries (no

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -76,7 +76,7 @@ function formatTime(ts: number): string {
 
 const BATCH_SIZE = 20;
 
-type ItemRow = { kind: 'tx'; tx: WalletTransaction; key: string };
+type ItemRow = { kind: 'tx'; tx: WalletTransaction; key: string; index: number };
 type HeaderRow = { kind: 'header'; label: string; key: string };
 type Row = ItemRow | HeaderRow;
 
@@ -178,7 +178,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({ transactions
       });
       currentDayKey = dayKey;
     }
-    rows.push({ kind: 'tx', tx, key: txKey(tx, fallbackIndex) });
+    rows.push({ kind: 'tx', tx, key: txKey(tx, fallbackIndex), index: fallbackIndex });
   });
 
   return (
@@ -233,6 +233,7 @@ const TransactionList = forwardRef<TransactionListHandle, Props>(({ transactions
             style={[styles.item, isPending && styles.itemPending]}
             onPress={() => setDetail(item as TransactionDetailData)}
             accessibilityLabel={`Open details for ${primary}`}
+            testID={`transaction-row-${row.index}`}
           >
             <View style={styles.avatarWrap}>
               {counterpartyAvatar ? (

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -184,13 +184,22 @@ const HomeScreen: React.FC = () => {
   // Infinite-scroll for the transactions list: when the user scrolls within
   // INFINITE_SCROLL_THRESHOLD of the bottom, ask TransactionList to reveal
   // the next batch of cached transactions.
+  //
+  // `onScroll` fires continuously while the user remains near the bottom, so
+  // we latch on entry into the bottom zone via `nearBottomRef`: each crossing
+  // from above-threshold to below-threshold triggers exactly one loadMore().
+  // Revealing a batch grows contentSize and pushes the user back above the
+  // threshold, clearing the latch so the next pull fires again.
   const txListRef = useRef<TransactionListHandle>(null);
+  const nearBottomRef = useRef(false);
   const handleTransactionsScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, layoutMeasurement, contentSize } = e.nativeEvent;
     const distanceFromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
-    if (distanceFromBottom < INFINITE_SCROLL_THRESHOLD) {
+    const nearBottom = distanceFromBottom < INFINITE_SCROLL_THRESHOLD;
+    if (nearBottom && !nearBottomRef.current) {
       txListRef.current?.loadMore();
     }
+    nearBottomRef.current = nearBottom;
   }, []);
 
   const greetingName =

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -9,6 +9,7 @@ import {
   ActivityIndicator,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  LayoutChangeEvent,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -190,10 +191,26 @@ const HomeScreen: React.FC = () => {
   // from above-threshold to below-threshold triggers exactly one loadMore().
   // Revealing a batch grows contentSize and pushes the user back above the
   // threshold, clearing the latch so the next pull fires again.
+  //
+  // `onScroll` alone isn't enough on large screens / small lists where the
+  // initial 20 rows fit without overflow — the user can't scroll, so the
+  // remaining cached rows would be unreachable. We also fire loadMore on
+  // `onContentSizeChange` whenever content height is within threshold of
+  // the visible layout height; loadMore is a no-op once visibleCount equals
+  // the cached total, so the cascade self-terminates.
   const txListRef = useRef<TransactionListHandle>(null);
   const nearBottomRef = useRef(false);
+  const scrollLayoutHeightRef = useRef(0);
+
+  // Reset the near-bottom latch when switching wallets so the first
+  // bottom-zone entry on the new list still fires a loadMore.
+  useEffect(() => {
+    nearBottomRef.current = false;
+  }, [activeWalletId]);
+
   const handleTransactionsScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, layoutMeasurement, contentSize } = e.nativeEvent;
+    scrollLayoutHeightRef.current = layoutMeasurement.height;
     const distanceFromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
     const nearBottom = distanceFromBottom < INFINITE_SCROLL_THRESHOLD;
     if (nearBottom && !nearBottomRef.current) {
@@ -201,6 +218,20 @@ const HomeScreen: React.FC = () => {
     }
     nearBottomRef.current = nearBottom;
   }, []);
+
+  const handleTransactionsLayout = useCallback((e: LayoutChangeEvent) => {
+    scrollLayoutHeightRef.current = e.nativeEvent.layout.height;
+  }, []);
+
+  const handleTransactionsContentSizeChange = useCallback(
+    (_contentWidth: number, contentHeight: number) => {
+      const layoutHeight = scrollLayoutHeightRef.current;
+      if (layoutHeight > 0 && contentHeight - layoutHeight < INFINITE_SCROLL_THRESHOLD) {
+        txListRef.current?.loadMore();
+      }
+    },
+    [],
+  );
 
   const greetingName =
     profile?.displayName?.trim() || profile?.name?.trim() || userName?.trim() || '';
@@ -293,6 +324,8 @@ const HomeScreen: React.FC = () => {
           style={styles.transactionsContainer}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
           onScroll={handleTransactionsScroll}
+          onLayout={handleTransactionsLayout}
+          onContentSizeChange={handleTransactionsContentSizeChange}
           scrollEventThrottle={100}
           testID="transactions-scroll"
         >

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -7,6 +7,8 @@ import {
   ScrollView,
   RefreshControl,
   ActivityIndicator,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -18,7 +20,7 @@ import { colors } from '../styles/theme';
 import ReceiveSheet from '../components/ReceiveSheet';
 import SendSheet from '../components/SendSheet';
 import TransferSheet from '../components/TransferSheet';
-import TransactionList from '../components/TransactionList';
+import TransactionList, { TransactionListHandle } from '../components/TransactionList';
 import WalletCarousel from '../components/WalletCarousel';
 import AddWalletWizard from '../components/AddWalletWizard';
 import WalletSettingsSheet from '../components/WalletSettingsSheet';
@@ -26,6 +28,9 @@ import TabHeader from '../components/TabHeader';
 import { ArrowDownIcon, ArrowUpIcon, ArrowLeftRightIcon } from '../components/icons/ArrowIcons';
 import { styles } from '../styles/HomeScreen.styles';
 import type { MainTabParamList } from '../navigation/types';
+
+// How close to the bottom (in px) we trigger a new batch of transactions.
+const INFINITE_SCROLL_THRESHOLD = 200;
 
 const HomeScreen: React.FC = () => {
   const {
@@ -176,6 +181,18 @@ const HomeScreen: React.FC = () => {
     setSettingsWalletId(walletId);
   }, []);
 
+  // Infinite-scroll for the transactions list: when the user scrolls within
+  // INFINITE_SCROLL_THRESHOLD of the bottom, ask TransactionList to reveal
+  // the next batch of cached transactions.
+  const txListRef = useRef<TransactionListHandle>(null);
+  const handleTransactionsScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { contentOffset, layoutMeasurement, contentSize } = e.nativeEvent;
+    const distanceFromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
+    if (distanceFromBottom < INFINITE_SCROLL_THRESHOLD) {
+      txListRef.current?.loadMore();
+    }
+  }, []);
+
   const greetingName =
     profile?.displayName?.trim() || profile?.name?.trim() || userName?.trim() || '';
 
@@ -266,6 +283,9 @@ const HomeScreen: React.FC = () => {
         <ScrollView
           style={styles.transactionsContainer}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+          onScroll={handleTransactionsScroll}
+          scrollEventThrottle={100}
+          testID="transactions-scroll"
         >
           {!hasWallets || activeWalletId === null ? (
             <View style={styles.emptyState}>
@@ -278,7 +298,7 @@ const HomeScreen: React.FC = () => {
               <ActivityIndicator size="small" color="#EC008C" />
             </View>
           ) : (
-            <TransactionList transactions={transactions} />
+            <TransactionList ref={txListRef} transactions={transactions} />
           )}
         </ScrollView>
       </View>

--- a/tests/e2e/test-transactions-infinite-scroll.yaml
+++ b/tests/e2e/test-transactions-infinite-scroll.yaml
@@ -2,8 +2,10 @@ appId: com.lightningpiggy.app
 name: Transactions Infinite Scroll
 ---
 # Verifies that the transactions list uses infinite scroll instead of the
-# legacy "Show all N transactions" button: swiping up on the list should
-# progressively reveal more transactions without ever showing that button.
+# legacy "Show all N transactions" button: scrolling the list should
+# progressively reveal more transactions without ever showing that button,
+# and the row at index 20 (which is gated behind at least one loadMore())
+# must eventually become visible.
 # Requires a wallet that is connected and has more than 20 transactions.
 # Run: maestro test tests/e2e/test-transactions-infinite-scroll.yaml
 
@@ -26,44 +28,36 @@ name: Transactions Infinite Scroll
 - assertVisible:
     id: 'transactions-scroll'
 
+# The first batch should render row 0 immediately.
+- assertVisible:
+    id: 'transaction-row-0'
+
 # Regression check: the legacy "Show all N transactions" button must be gone.
 # With infinite scroll, additional transactions load via scrolling, not a button.
 - assertNotVisible:
     text: 'Show all .* transactions'
 
-# Swipe up on the transactions list a few times to trigger the
-# infinite-scroll loadMore callback. We assert the container remains
-# visible after each swipe — confirming no crash — and that the
-# legacy button never appears as the list expands.
-- swipe:
-    from:
-      id: 'transactions-scroll'
-    direction: UP
-- waitForAnimationToEnd:
-    timeout: 2000
+# Initially row 20 is NOT in the tree — only the first 20 rows (indices 0-19)
+# have been rendered. This guards against a regression where loadMore() is
+# never gated and the full list loads up-front.
+- assertNotVisible:
+    id: 'transaction-row-20'
+
+# Positive assertion: scrolling the list down must eventually surface row 20,
+# which only exists after loadMore() has fired at least once. If infinite
+# scroll is broken (loadMore never triggers, or batching is bypassed) this
+# step times out and the test fails.
+- scrollUntilVisible:
+    element:
+      id: 'transaction-row-20'
+    direction: DOWN
+    timeout: 30000
+    speed: 40
+
+# Legacy button must still be absent after the list has expanded.
 - assertNotVisible:
     text: 'Show all .* transactions'
 
-- swipe:
-    from:
-      id: 'transactions-scroll'
-    direction: UP
-- waitForAnimationToEnd:
-    timeout: 2000
-- assertNotVisible:
-    text: 'Show all .* transactions'
-
-- swipe:
-    from:
-      id: 'transactions-scroll'
-    direction: UP
-- waitForAnimationToEnd:
-    timeout: 2000
-- assertNotVisible:
-    text: 'Show all .* transactions'
-
-# List is still alive and rendering transactions after the swipes.
+# Container is still alive after scrolling.
 - assertVisible:
     id: 'transactions-scroll'
-- assertVisible:
-    text: '.*sats'

--- a/tests/e2e/test-transactions-infinite-scroll.yaml
+++ b/tests/e2e/test-transactions-infinite-scroll.yaml
@@ -1,0 +1,69 @@
+appId: com.lightningpiggy.app
+name: Transactions Infinite Scroll
+---
+# Verifies that the transactions list uses infinite scroll instead of the
+# legacy "Show all N transactions" button: swiping up on the list should
+# progressively reveal more transactions without ever showing that button.
+# Requires a wallet that is connected and has more than 20 transactions.
+# Run: maestro test tests/e2e/test-transactions-infinite-scroll.yaml
+
+- waitForAnimationToEnd:
+    timeout: 30000
+
+# Wait for wallet to connect
+- extendedWaitUntil:
+    visible:
+      text: 'Connected'
+    timeout: 30000
+
+# Wait for transactions to load (first load may take time)
+- extendedWaitUntil:
+    visible:
+      text: '.*sats'
+    timeout: 30000
+
+# The transactions container should be present
+- assertVisible:
+    id: 'transactions-scroll'
+
+# Regression check: the legacy "Show all N transactions" button must be gone.
+# With infinite scroll, additional transactions load via scrolling, not a button.
+- assertNotVisible:
+    text: 'Show all .* transactions'
+
+# Swipe up on the transactions list a few times to trigger the
+# infinite-scroll loadMore callback. We assert the container remains
+# visible after each swipe — confirming no crash — and that the
+# legacy button never appears as the list expands.
+- swipe:
+    from:
+      id: 'transactions-scroll'
+    direction: UP
+- waitForAnimationToEnd:
+    timeout: 2000
+- assertNotVisible:
+    text: 'Show all .* transactions'
+
+- swipe:
+    from:
+      id: 'transactions-scroll'
+    direction: UP
+- waitForAnimationToEnd:
+    timeout: 2000
+- assertNotVisible:
+    text: 'Show all .* transactions'
+
+- swipe:
+    from:
+      id: 'transactions-scroll'
+    direction: UP
+- waitForAnimationToEnd:
+    timeout: 2000
+- assertNotVisible:
+    text: 'Show all .* transactions'
+
+# List is still alive and rendering transactions after the swipes.
+- assertVisible:
+    id: 'transactions-scroll'
+- assertVisible:
+    text: '.*sats'


### PR DESCRIPTION
## Summary

- Replaces the "Show all N transactions" button on the Home transactions list with scroll-triggered batch loading — you just keep scrolling and the next 20 appear inline.
- `TransactionList` now tracks `visibleCount` (initial 20, grows by 20 per batch) and exposes a `loadMore()` handle via `forwardRef` / `useImperativeHandle`.
- `HomeScreen` wires an `onScroll` listener on the wrapping `ScrollView` that calls `loadMore()` when the user is within 200px of the bottom.
- Swiping to another wallet still resets the count to the first batch (via the existing transactions-identity `useEffect`).
- Adds `transaction-list` testID on the list container and `transactions-scroll` testID on the ScrollView for deterministic Maestro selectors.

Closes #172

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes (only pre-existing `insets` warning remains)
- [x] `npx prettier --check` passes
- [ ] `maestro test tests/e2e/test-transactions-infinite-scroll.yaml` — requires a connected wallet with >20 transactions:
  - [ ] Verifies `Show all .* transactions` button is gone
  - [ ] Swipes up on `transactions-scroll` three times, asserting the list stays alive and the legacy button never appears
- [ ] Manual: on a wallet with >20 transactions, scroll to the bottom of the list repeatedly and confirm more transactions are appended each time until all are visible.
- [ ] Manual: swipe to a different wallet, confirm the list collapses back to the first batch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gt8pv9gAW2EmEsrpMdzSfN)_