### PR TITLE
docs(deployment): document EXPO_PUBLIC_* vars must be set on EAS environments (#181)

### DIFF
--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -93,6 +93,40 @@ Manual runs skip the asset-attach steps (they need a Release to attach to); use 
 
 - **`EXPO_TOKEN`** — repo secret. Generate at https://expo.dev/accounts/bengweeks/settings/access-tokens and add under *Settings → Secrets and variables → Actions*. Everything else (iOS ASC API key, Apple distribution cert, future Google Play service account) lives on EAS's server via `eas credentials`, so the workflow never handles a `.p8` or service account JSON.
 
+==== Build-time `EXPO_PUBLIC_*` environment variables
+
+`EXPO_PUBLIC_*` values are **inlined into the JS bundle at build time** by Metro — they are not read at runtime. The local `.env` file is only consulted by `expo start` / `npm start`, not by EAS cloud/local builds.
+
+For EAS-driven builds (production, preview, development) every required `EXPO_PUBLIC_*` variable must be registered on the corresponding EAS environment:
+
+[source,bash]
+----
+# One-time, per variable, per environment
+eas env:create \
+  --environment production --environment preview --environment development \
+  --name EXPO_PUBLIC_GIPHY_API_KEY \
+  --value "<paste value from .env>" \
+  --visibility plaintext \
+  --scope project \
+  --type string \
+  --non-interactive
+
+# Verify
+eas env:list production
+----
+
+Visibility can be `plaintext` for keys that are already publicly embedded in the client bundle (which is true of every `EXPO_PUBLIC_*` value by design). Use `sensitive` for server-only secrets that must never end up in a client bundle — those should **not** be prefixed `EXPO_PUBLIC_`.
+
+**Currently required variables** (if you add a new one, extend this list and run `eas env:create` for the three environments **before** cutting the next release, otherwise the in-app feature that relies on it ships broken):
+
+[cols="1,3", options="header"]
+|===
+| Variable | Purpose
+
+| `EXPO_PUBLIC_GIPHY_API_KEY`
+| GIPHY v1 REST client key for the in-app GIF picker (`src/services/giphyService.ts`). If missing, the GIF panel shows a "key not set" empty state (`src/components/GifPickerSheet.tsx`). Get one at https://developers.giphy.com/dashboard/.
+|===
+
 === EAS Cloud Builds
 
 [source,bash]

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -111,8 +111,8 @@ eas env:create \
   --type string \
   --non-interactive
 
-# Verify
-eas env:list production
+# Verify (one env at a time; list it for each if you want to double-check)
+eas env:list --environment production
 ----
 
 Visibility can be `plaintext` for keys that are already publicly embedded in the client bundle (which is true of every `EXPO_PUBLIC_*` value by design). Use `sensitive` for server-only secrets that must never end up in a client bundle — those should **not** be prefixed `EXPO_PUBLIC_`.

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -178,6 +178,28 @@ The fix script (`apply_nip20_fix.py`) patches `router.py` to send `["OK", event_
 | EAS auto-registers only the *production* bundle ID on first iOS build. The preview / dev variants need manual registration the first time they're built. +
 *Fix:* at https://developer.apple.com/account/resources/identifiers → *+* → App IDs → App → Explicit Bundle ID → `com.lightningpiggy.app.preview` (or `.dev`). Then re-run the build.
 
+| In-app feature reads `process.env.EXPO_PUBLIC_*` as `undefined` on a release/preview build even though the emulator (Metro) has it, e.g. GIF picker shows *"The GIPHY API key hasn't been set for this build"* on the installed APK but works fine in dev
+| `EXPO_PUBLIC_*` values are **inlined into the JS bundle at build time** by Metro — they are not read at runtime. The local `.env` file is only consulted by `expo start` / `npm start`; EAS builds (cloud or `--local`) don't read it. Every `EXPO_PUBLIC_*` variable the app depends on must be registered on the matching EAS environment before `eas build` runs, or it ends up undefined in the bundle. +
+*Diagnosis:* the build log contains the smoking-gun line: +
+`No environment variables with visibility "Plain text" and "Sensitive" found for the "<profile>" environment on EAS.` +
+*Fix (one-time per variable, covers all three profiles in one command):* +
+[source,bash]
+----
+eas env:create \
+  --environment production --environment preview --environment development \
+  --name EXPO_PUBLIC_GIPHY_API_KEY \
+  --value "<paste value from .env>" \
+  --visibility plaintext \
+  --scope project \
+  --type string \
+  --non-interactive
+# verify
+eas env:list production
+----
+*Visibility:* `plaintext` is correct for `EXPO_PUBLIC_*` — the value is already embedded in the client bundle by design, so "sensitive/secret" is the wrong protection model. Server-only secrets that must never land in a client bundle should **not** be prefixed `EXPO_PUBLIC_`. +
+*Timing caveat:* EAS fetches env at build start, not at submission. For a build that's already `IN_PROGRESS`, setting the var won't apply — you need another build. For a build still `IN_QUEUE` at the time you set the var, it will pick up the new value when gradle starts. +
+*Docs:* `docs/DEPLOYMENT.adoc` → "Secrets" section keeps a living table of required `EXPO_PUBLIC_*` vars. Extend it when adding a new one and run `eas env:create` for all three environments before the next release, otherwise the dependent feature ships broken. Seen on 2026-04-23: `versionCode=10` Pixel APK shipped without `EXPO_PUBLIC_GIPHY_API_KEY` while the emulator build via `npm start` had it.
+
 | iOS build installs but the app won't launch — *"Developer Mode required"*
 | iOS 16+ requires Developer Mode to be explicitly enabled before sideloaded / ad-hoc / dev-signed apps will run. +
 *Fix on the iPhone:* tap the just-installed app icon once so iOS recognises a dev-signed app is present → *Settings → Privacy & Security → Developer Mode* → toggle on → Restart → after reboot, *"Turn On Developer Mode?"* dialog → passcode. The row doesn't appear in Settings until iOS detects a dev-signed app.

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -193,8 +193,8 @@ eas env:create \
   --scope project \
   --type string \
   --non-interactive
-# verify
-eas env:list production
+# verify (one env at a time)
+eas env:list --environment production
 ----
 *Visibility:* `plaintext` is correct for `EXPO_PUBLIC_*` — the value is already embedded in the client bundle by design, so "sensitive/secret" is the wrong protection model. Server-only secrets that must never land in a client bundle should **not** be prefixed `EXPO_PUBLIC_`. +
 *Timing caveat:* EAS fetches env at build start, not at submission. For a build that's already `IN_PROGRESS`, setting the var won't apply — you need another build. For a build still `IN_QUEUE` at the time you set the var, it will pick up the new value when gradle starts. +


### PR DESCRIPTION
## Summary

- Production APK for `versionCode=10` shipped without a GIPHY key because `EXPO_PUBLIC_GIPHY_API_KEY` lives only in the local `.env`, which EAS builds don't consult.
- Add a "Build-time `EXPO_PUBLIC_*` environment variables" subsection to `docs/DEPLOYMENT.adoc` that explains the inlining behaviour, shows the `eas env:create` recipe, and keeps a living table of currently-required vars.
- Separately (already done outside the PR): the actual key has been set on EAS (production + preview + development) via `eas env:create`, so the pending iOS cloud build (currently IN_QUEUE) will pick it up when its gradle step starts.

## Why docs-only

The fix is a one-time EAS config action (`eas env:create`), not a code change. The risk is losing tribal knowledge — next time someone adds a public var like `EXPO_PUBLIC_…_API_KEY`, they need to know that setting it in `.env` alone isn't enough for a release build. This PR captures that.

## Test plan

- [ ] `docs/DEPLOYMENT.adoc` renders correctly (AsciiDoc → PDF via `docs/generate-docs.sh` if you want to spot-check layout).
- [ ] After this PR lands, the next local Android production build picks up the GIPHY key from EAS and the in-app GIF picker works on a fresh install.
- [ ] Same for the next iOS preview build (daughter's iPhone ad-hoc flow).

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)