### PR TITLE
fix(wallet-settings): pin sheet to 85% snap (was filling full screen)

### DIFF
--- a/src/components/WalletSettingsSheet.tsx
+++ b/src/components/WalletSettingsSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Alert, Platform, Keyboard } from 'react-native';
 import {
   BottomSheetModal,
@@ -23,7 +23,10 @@ const WalletSettingsSheet: React.FC<Props> = ({ walletId, onClose }) => {
   const { wallets, updateWalletSettings, removeWallet } = useWallet();
   const wallet = wallets.find((w) => w.id === walletId);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
-  // No explicit snapPoints — content-height only, not user-draggable.
+  // Pin the sheet to 85% of the screen — content (alias + LUD-16 + relay
+  // + full 8-card theme grid) is long enough that dynamic sizing pushed
+  // it to 100% and the handle was tight against the status bar.
+  const snapPoints = useMemo(() => ['85%'], []);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   // Canonical keyboard-height tracking — mirrors SendSheet / NostrLoginSheet.
@@ -133,6 +136,13 @@ const WalletSettingsSheet: React.FC<Props> = ({ walletId, onClose }) => {
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
+      snapPoints={snapPoints}
+      // v5 defaults `enableDynamicSizing` to true, which overrides
+      // `snapPoints`. Disable it explicitly so the sheet honours the
+      // 85% pin. See docs/TROUBLESHOOTING.adoc
+      // "v5 modal collapses to a thin strip when its
+      // BottomSheetTextInput is focused".
+      enableDynamicSizing={false}
       enablePanDownToClose
       onChange={handleSheetChange}
       backdropComponent={renderBackdrop}


### PR DESCRIPTION
## Summary

- Wallet Settings content (alias + LUD-16 + relay + 8-card theme grid) was tall enough that gorhom v5's default `enableDynamicSizing=true` stretched the sheet to ~100% of the viewport — the drag handle sat flush against the status bar, making it feel like a full-screen modal rather than a sheet.
- Add explicit `snapPoints={['85%']}` + `enableDynamicSizing={false}` so the sheet honours the 85% pin (v5 footgun — dynamic sizing overrides `snapPoints` unless explicitly disabled; documented under *"v5 modal collapses to a thin strip when its BottomSheetTextInput is focused"* in `docs/TROUBLESHOOTING.adoc`).
- This is a deliberate exception to the normal "don't hardcode sheet heights" rule which otherwise only covers `FriendPickerSheet` / `GifPickerSheet` — the content is genuinely long enough that intrinsic sizing pushes past the status bar.

## Test plan

- [x] TypeScript clean (`npx tsc --noEmit`).
- [x] Visually verified on emulator (Account → wallet card → ⚙ Settings): sheet pins at 85%, handle has breathing room, full backdrop visible at the top.
- [ ] Verify on Pixel 8 after the next production rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)