### PR TITLE
perf(messages): NIP-04 cache + since-delta + instant-paint + defer NWC/refreshes + splash + list window (#190)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 // CRITICAL: Polyfills must be imported FIRST, before any other imports
 import './src/polyfills';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -11,6 +11,7 @@ import { WalletProvider, useWallet } from './src/contexts/WalletContext';
 import { NostrProvider } from './src/contexts/NostrContext';
 import AppNavigator from './src/navigation/AppNavigator';
 import PaymentProgressOverlay from './src/components/PaymentProgressOverlay';
+import BootSplash from './src/components/BootSplash';
 
 // Render toasts with unlimited-line body so long error messages (e.g. Electrum
 // script-verify errors) aren't truncated. Height grows to fit content.
@@ -66,6 +67,18 @@ function GlobalIncomingPaymentOverlay() {
 }
 
 export default function App() {
+  // Boot splash — keeps the pig on screen from JS-mount for a minimum
+  // 600 ms so the user never sees the plain-pink native-splash-to-JS
+  // handoff. 600 ms is well under the observed cold-launch time on
+  // Pixel/cellular (55+ s) but long enough that the splash doesn't
+  // feel like a flash. Home renders behind the splash during this
+  // window; when we fade the splash out, Home is usually ready.
+  const [bootDone, setBootDone] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setBootDone(true), 600);
+    return () => clearTimeout(t);
+  }, []);
+
   return (
     <GestureHandlerRootView style={styles.container}>
       <WalletProvider>
@@ -78,6 +91,7 @@ export default function App() {
           <GlobalIncomingPaymentOverlay />
         </NostrProvider>
       </WalletProvider>
+      <BootSplash done={bootDone} />
     </GestureHandlerRootView>
   );
 }

--- a/app.config.ts
+++ b/app.config.ts
@@ -30,10 +30,14 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   orientation: 'portrait',
   icon: './assets/icon.png',
   userInterfaceStyle: 'light',
+  // Splash screen: the pig + brand wordmark on brand-pink. Same asset
+  // IntroScreen uses so first-time users get a continuous pig → Home
+  // transition without the pink-spinner gap. `contain` leaves padding
+  // around the image so different device aspect ratios render cleanly.
   splash: {
-    image: './assets/splash-icon.png',
+    image: './assets/images/lightning-piggy-intro.png',
     resizeMode: 'contain',
-    backgroundColor: '#ffffff',
+    backgroundColor: '#e91e63',
   },
   scheme: 'lightningpiggy',
   ios: {

--- a/docs/PACKAGES.adoc
+++ b/docs/PACKAGES.adoc
@@ -69,4 +69,20 @@ Third-party packages used by the app. Updated when a dependency is added or its 
 | https://github.com/nicoll-douglas/react-native-svg[`react-native-svg`]
 | react-native-svg
 | SVG rendering for React Native — used for custom Lucide-style icons
+
+| https://github.com/paulmillr/noble-ciphers[`@noble/ciphers`]
+| paulmillr
+| Audited pure-JS symmetric ciphers — `aes.js` (CBC) powers `nostr-tools`' NIP-04 `nip04.decrypt` / `nip04.encrypt`. Dep of `nostr-tools`, listed here because the DM perf work in `src/contexts/NostrContext.tsx` leans on its throughput (~1 ms / decrypt on mid-range mobile) to keep batched parallel decrypt responsive.
+|===
+
+== Internal utilities (not packages)
+
+Small locally-authored modules where a third-party dep would be overkill or RN-incompatible:
+
+[cols="1,2", options="header"]
+|===
+| Path | Purpose
+
+| `src/utils/lru.ts`
+| ~25-line Map-backed LRU cache. Replaces the `lru-cache` npm package which pulls in `node:diagnostics_channel` at v11+ — Metro can't resolve that in React Native. Used for the module-level NIP-04 plaintext cache (max 1000 entries). API intentionally minimal (`get` / `set` / `delete` / `clear` / `size`) so it can be swapped for `react-native-mmkv` in future without touching callers.
 |===

--- a/docs/SOLUTION_DESIGN.adoc
+++ b/docs/SOLUTION_DESIGN.adoc
@@ -625,3 +625,95 @@ The app includes a safety tip on profile edit and account creation screens:
 > "Tip: You don't need to use your real name or photo for your profile."
 
 This is a gentle, non-intrusive reminder appropriate for a kids' app without requiring age verification.
+
+== Direct Messaging Performance Architecture (Issues #176, #177, #190)
+
+DMs are the most latency-sensitive surface in the app — they're opened repeatedly, and each open has historically required a relay round-trip plus a decrypt loop that could lock the JS thread for tens of seconds on large inboxes. The architecture below was developed over the perf sweep in PR #191 against a 986-message real-world Nostr inbox on a Pixel 8 on 4G. Target: no thread open ever feels "loading" after the first one.
+
+=== Caching layers
+
+The DM pipeline stacks four independent caches — each addressing a distinct failure mode from the pre-cache behaviour:
+
+[cols="1,1,2", options="header"]
+|===
+| Cache | Scope | What it stores / why
+
+| **NIP-04 plaintext LRU** (`src/utils/lru.ts`)
+| Module-level RAM, `max: 1000`
+| Event id → decrypted plaintext. Survives screen pops but not process kill. Refresh-then-reopen costs 0 NIP-04 decrypts. Keyed by event id (immutable) so no TTL needed.
+
+| **NIP-17 gift-wrap cache** (`AMBER_NIP17_CACHE_KEY` / `NSEC_NIP17_CACHE_KEY` in AsyncStorage)
+| Per-user pubkey, `max: 5000`, separate by signer type
+| Wrap id → `{partnerPubkey, fromMe, text, createdAt, wireKind}`. `refreshDmInbox` writes here for every successfully decrypted wrap; `fetchConversation` reads it to skip its own inbox-wide relay fetch (see "Fetch strategy" below).
+
+| **Persisted DM inbox** (`nostr_dm_inbox_v1_<user>`)
+| Per-user pubkey, `max: 1000` entries
+| Full `DmInboxEntry[]` painted INSTANTLY on Messages-tab mount; relay refresh merges fresh events in the background.
+
+| **Persisted per-peer conversation** (`nostr_dm_conv_v1_<user>_<peer>`)
+| Per (user, peer), `max: 500` messages
+| Full `ConversationMessage[]` painted within one frame on thread open; relay delta merges in the background.
+|===
+
+All four clear on logout (per-user caches are enumerated via `AsyncStorage.getAllKeys()` + prefix match). The plaintext LRU is module-level so its TTL is process lifetime; the AsyncStorage caches persist across cold starts.
+
+=== Fetch strategy
+
+Steady-state: every DM-relevant relay query carries `since = max(cached.created_at) - 120`. The `-120` is Damus's clock-drift pad (see https://github.com/damus-io/damus[`damus/Nostr/SubscriptionManager.swift`] L293-300): relays with slightly-off clocks still return the last 2 minutes of messages so we don't silently miss one. Cold cache (`max = 0`) sends no `since` filter — full history pulled.
+
+Per-peer `last_seen` is persisted alongside the conversation cache; inbox-wide `last_seen` is persisted alongside the inbox cache.
+
+`fetchConversation(peer)` also **skips `fetchInboxDmEvents` entirely** when the NIP-17 wrap cache is populated (#190). Since `refreshDmInbox` (fired on Messages-tab focus with 30s TTL) already pulls every gift-wrap and writes plaintext to the cache, re-entering a thread just filters cached entries to the peer. Removes the largest residual wall-clock cost from thread opens (~6 s → <1 s on the test inbox).
+
+=== Decrypt threading
+
+The serial `for-await` pattern was replaced with `Promise.all(batches of DECRYPT_YIELD_EVERY=15)` with explicit `setTimeout(0)` yields between batches (the `yieldToEventLoop()` helper). Rationale in `src/contexts/NostrContext.tsx`:
+
+[source,ts]
+----
+/** `await`ing an already-resolved promise only drains the microtask
+ *  queue, which still starves UI events — setTimeout(0) returns to
+ *  the task scheduler. Yield every DECRYPT_YIELD_EVERY *attempts*,
+ *  not successes, so a run of decrypt failures can't infinite-block.  */
+----
+
+For nsec, `nip04.decrypt` is pure-JS via `@noble/ciphers` (~1 ms per call on mid-range mobile), so 15 iterations is ≈1 frame's worth of JS. For Amber, each decrypt is an IPC round-trip that already yields implicitly; the explicit yield only adds scheduler respect, not raw throughput.
+
+=== Throttling & focus-defer
+
+- `refreshDmInbox` has a **30 s TTL** (`DM_INBOX_REFRESH_TTL_MS`): calls within the window are no-ops, unless the caller passes `{ force: true }` (pull-to-refresh). Protects against `useFocusEffect` tab-bouncing triggering a full relay + decrypt sweep on every return.
+- All three `useFocusEffect` refreshes (Home's `refreshProfile`, Messages' `refreshDmInbox`, Friends' `refreshProfile`) are wrapped in `InteractionManager.runAfterInteractions(...)` with `.cancel()` on cleanup so the tab-transition animation finishes before the refresh claims the JS thread.
+- `fetchConversation` checks an `isMountedRef` before firing `setMessages` / `setLoading` so back-press during a cold fetch doesn't commit state on an unmounted screen.
+
+=== Instant paint pattern
+
+ConversationScreen's `load()` callback reads the per-peer persisted cache FIRST, does `setMessages(cached)` synchronously (paint within a frame), `setLoading(false)`, THEN awaits the full `fetchConversation(peer)` which may spend seconds on a relay round-trip. Whichever result arrives first — cache or relay — is painted; the relay path overrides when it finishes.
+
+Cribbed from Arcade's `arclib/src/private.ts` + `DirectMessageScreen.tsx` `db_only=true` pattern.
+
+=== Relay coverage
+
+Every DM-relevant `fetch*` in `src/services/nostrService.ts` merges the user's own read-relays (from their kind-10002 NIP-65 event) with `DEFAULT_RELAYS`:
+
+[source,ts]
+----
+const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
+----
+
+This deliberately over-fetches so users with a sparse kind-10002 (e.g. a single-relay declaration) still see messages that landed on more popular relays. `DEFAULT_RELAYS` currently = `damus.io` / `nostr.band` / `nos.lol` / `primal.net`.
+
+=== Perf instrumentation
+
+Two log lines emitted unconditionally (not `__DEV__` gated) so they can be grepped from production APK logcat:
+
+- `[Perf] fetchConversation(<peerShort>): <ms>, k4=N (hits=A, fresh=B), k1059=M (hits=C, fresh=D, skippedFetch=bool), since=T, cached=X, merged=Y`
+- `[Perf] refreshDmInbox: <ms>, k4=N (hits=A, fresh=B), k1059=M, since=T, fresh=Z, merged=Y, rendered=R`
+
+Breakdown lets us confirm cache-hit behaviour on a real device without attaching a debugger.
+
+=== Known limitations / future work
+
+- A newly-arrived wrap that `refreshDmInbox` hasn't pulled yet (≤30 s ago) won't surface in `fetchConversation` until the next inbox refresh — acceptable for chat UX where "latest" rarely means "last second."
+- `pool.querySync` is still one-shot — real-time message arrival requires pull-to-refresh today. Filed as #188 (persistent relay subscription, architectural ~4 h).
+- BitmapFactory exception flood on unsupported avatar formats contributes to GC pressure on the Pixel. Filed as #189.
+- `react-native-mmkv` swap for the DM-cache AsyncStorage reads/writes would be ~100× faster at scale; marginal at current inbox sizes. Deferred.

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,6 +178,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8914,12 +8923,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lucide-react-native": {
@@ -10015,15 +10024,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/picocolors": {

--- a/src/components/BootSplash.tsx
+++ b/src/components/BootSplash.tsx
@@ -1,0 +1,94 @@
+/**
+ * JS-side boot splash — a full-screen pig image on brand-pink shown
+ * from the moment `<App>` mounts until the app signals it's ready.
+ * Pairs with the native splash in `app.config.ts`: the native layer
+ * covers from process start → JS bundle load, then this JS layer takes
+ * over from JS-mount → first-meaningful-paint so the user never sees
+ * the plain pink "loading" screen between them.
+ *
+ * Visual: same pig + logo IntroScreen uses, so the transition from
+ * splash → Intro (new users) or splash → Home (logged-in users) is
+ * a continuous pink background with the pig centered.
+ *
+ * The splash fades out over 250 ms once `done=true`, via React Native
+ * `Animated`. After the animation, the component returns null so it
+ * doesn't intercept touch events.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, Image, StyleSheet, View, Text } from 'react-native';
+import { colors } from '../styles/theme';
+
+interface Props {
+  /** When true, fade out over 250ms and unmount. */
+  done: boolean;
+}
+
+const FADE_MS = 250;
+
+const BootSplash: React.FC<Props> = ({ done }) => {
+  const opacity = useRef(new Animated.Value(1)).current;
+  const [unmounted, setUnmounted] = useState(false);
+
+  useEffect(() => {
+    if (done) {
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: FADE_MS,
+        useNativeDriver: true,
+      }).start(() => setUnmounted(true));
+    }
+  }, [done, opacity]);
+
+  if (unmounted) return null;
+
+  return (
+    <Animated.View style={[styles.root, { opacity }]} pointerEvents={done ? 'none' : 'auto'}>
+      <Image
+        source={require('../../assets/images/lightning-piggy-intro.png')}
+        style={styles.pig}
+        resizeMode="contain"
+      />
+      <View style={styles.brandRow}>
+        <Image
+          source={require('../../assets/images/lightning-piggy-logo.png')}
+          style={styles.logo}
+          resizeMode="contain"
+        />
+        <Text style={styles.brandText}>LIGHTNING PIGGY</Text>
+      </View>
+    </Animated.View>
+  );
+};
+
+export default BootSplash;
+
+const styles = StyleSheet.create({
+  root: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.brandPink,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  pig: {
+    width: '80%',
+    height: '50%',
+  },
+  brandRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 24,
+  },
+  logo: {
+    width: 32,
+    height: 32,
+    tintColor: '#fff',
+  },
+  brandText: {
+    color: '#fff',
+    fontSize: 24,
+    fontWeight: '800',
+    letterSpacing: 1.5,
+  },
+});

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -11,12 +11,29 @@ import React, {
 import { InteractionManager } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
+import { LRUCache } from '../utils/lru';
 import * as nip19 from 'nostr-tools/nip19';
 import * as nostrService from '../services/nostrService';
 import * as amberService from '../services/amberService';
 import type { NostrProfile, NostrContact, RelayConfig, SignerType } from '../types/nostr';
 import type { DmInboxEntry } from '../utils/conversationSummaries';
 import { partnerFromRumor, unwrapWrapNsec, unwrapWrapViaNip44 } from '../utils/nip17Unwrap';
+
+/**
+ * Module-level LRU cache for NIP-04 plaintext keyed by event id. Keeps
+ * the app-session-latest 1000 decrypted messages in RAM so re-opening
+ * the same thread (or navigating away and back) doesn't re-decrypt from
+ * scratch. Event id → plaintext mapping is immutable once decrypted
+ * (the NIP-04 payload never changes for a given id), so no TTL needed.
+ *
+ * Cribbed from Arcade's arclib/src/private.ts:9 (`LRUCache<string, …>`).
+ * Stays in RAM only — no AsyncStorage persistence — to keep the write
+ * path free and avoid serialising full-bundle JSON on every decrypt.
+ */
+const nip04PlaintextCache = new LRUCache<string, string>({ max: 1000 });
+export function __clearNip04PlaintextCacheForTests() {
+  nip04PlaintextCache.clear();
+}
 
 // Module-scope memo for the current user's secret key. Five paths in this
 // file need access to the nsec (sign, publishProfile, publishContactList,
@@ -83,6 +100,18 @@ const DECRYPT_YIELD_EVERY = 15;
 function yieldToEventLoop(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+/**
+ * Minimum gap between `refreshDmInbox` calls fired by
+ * `useFocusEffect` on the Messages tab. Without a TTL, every tab return
+ * triggered a fresh 3-query relay round-trip + full NIP-04 decrypt
+ * sweep — locking the app up for seconds on the 2nd/3rd/Nth visit.
+ * 30 s is long enough that quick tab-bouncing stays responsive, short
+ * enough that a user who genuinely wants fresh state (open app after
+ * a break) still pays normal refresh cost. Pull-to-refresh bypasses
+ * the TTL via `{ force: true }`.
+ */
+const DM_INBOX_REFRESH_TTL_MS = 30_000;
 
 const NSEC_KEY = 'nostr_nsec';
 const PUBKEY_KEY = 'nostr_pubkey';
@@ -175,7 +204,18 @@ interface NostrContextType {
   fetchConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
   dmInbox: DmInboxEntry[];
   dmInboxLoading: boolean;
-  refreshDmInbox: () => Promise<void>;
+  /**
+   * Refresh the NIP-04 + NIP-17 DM inbox from read relays.
+   *
+   * Default (no arg / `force: false`): honours a 30s TTL — calls
+   * within that window are no-ops. Safe to call from
+   * `useFocusEffect` on the Messages tab without racking up relay
+   * round-trips on every tab bounce.
+   *
+   * `force: true`: bypass the TTL and hit relays. Reserved for
+   * explicit user-initiated refreshes (pull-to-refresh).
+   */
+  refreshDmInbox: (opts?: { force?: boolean }) => Promise<void>;
   /**
    * Tri-state for the NIP-17 silent-decrypt fast path.
    *  - 'unknown': haven't tried yet in this session
@@ -230,6 +270,10 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   // useFocusEffect firing while a pull-to-refresh is still in-flight) so
   // they don't race on the AsyncStorage wrap-id cache.
   const dmInboxInFlight = useRef<Promise<void> | null>(null);
+  /** `performance.now()` of last successful `refreshDmInbox` completion.
+   * Gate for the `DM_INBOX_REFRESH_TTL_MS` throttle so that Messages-tab
+   * focus doesn't re-fire full relay queries on every tab bounce. */
+  const dmInboxLastRefreshAt = useRef<number>(0);
 
   /**
    * Set of followed pubkeys (lowercase hex). Used to gate who can land a
@@ -1042,6 +1086,8 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       const perfStart = performance.now();
       let nip17CacheHits = 0;
       let nip17FreshDecrypts = 0;
+      let nip04CacheHits = 0;
+      let nip04FreshDecrypts = 0;
 
       const readRelays = getReadRelays();
       const decrypted: ConversationMessage[] = [];
@@ -1052,18 +1098,62 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         normalized,
         readRelays,
       );
-      // Yield every DECRYPT_YIELD_EVERY *attempts*, not successes — a
-      // run of decrypt failures would otherwise never tick the counter
-      // and keep blocking the JS thread.
-      let kind4Attempts = 0;
-      for (const ev of kind4Events) {
+      // Two-pass decrypt with module-level LRU cache:
+      //  1. Pull plaintext synchronously for events already in the
+      //     cache — no decrypt round-trip, no Amber IPC, no CPU.
+      //  2. Decrypt the misses in parallel (`Promise.all`). For nsec
+      //     this drains the JS queue faster than a serial for-await
+      //     loop; for Amber the IPC round-trips pipeline. Chunk the
+      //     Promise.all in slices of DECRYPT_YIELD_EVERY to yield to
+      //     the UI thread between batches on very long threads.
+      const freshDecryptTargets: { idx: number; counterparty: string; ev: (typeof kind4Events)[0] }[] = [];
+      const cachedPlaintexts: { idx: number; fromMe: boolean; text: string; ev: (typeof kind4Events)[0] }[] = [];
+      for (let i = 0; i < kind4Events.length; i++) {
+        const ev = kind4Events[i];
         const fromMe = ev.pubkey === pubkey;
         const counterparty = fromMe ? normalized : ev.pubkey.toLowerCase();
-        const plaintext = await decryptNip04ViaSigner(counterparty, ev.content);
-        if (++kind4Attempts % DECRYPT_YIELD_EVERY === 0) await yieldToEventLoop();
-        if (plaintext === null) continue;
-        decrypted.push({ id: ev.id, fromMe, text: plaintext, createdAt: ev.created_at });
+        const hit = nip04PlaintextCache.get(ev.id);
+        if (hit !== undefined) {
+          nip04CacheHits++;
+          cachedPlaintexts.push({ idx: i, fromMe, text: hit, ev });
+        } else {
+          freshDecryptTargets.push({ idx: i, counterparty, ev });
+        }
       }
+      // Parallel decrypt of misses, in yield-able chunks.
+      const freshResults: ({ idx: number; fromMe: boolean; text: string; ev: (typeof kind4Events)[0] } | null)[] = [];
+      for (let i = 0; i < freshDecryptTargets.length; i += DECRYPT_YIELD_EVERY) {
+        const batch = freshDecryptTargets.slice(i, i + DECRYPT_YIELD_EVERY);
+        const batchResults = await Promise.all(
+          batch.map(async (t) => {
+            nip04FreshDecrypts++;
+            const plaintext = await decryptNip04ViaSigner(t.counterparty, t.ev.content);
+            if (plaintext === null) return null;
+            // Cache the successful decrypt. Event ids are immutable so
+            // we can store unconditionally — no staleness possible.
+            nip04PlaintextCache.set(t.ev.id, plaintext);
+            const fromMe = t.ev.pubkey === pubkey;
+            return { idx: t.idx, fromMe, text: plaintext, ev: t.ev };
+          }),
+        );
+        freshResults.push(...batchResults);
+        if (i + DECRYPT_YIELD_EVERY < freshDecryptTargets.length) await yieldToEventLoop();
+      }
+      // Merge cached + fresh preserving original event order.
+      const merged = new Array<ConversationMessage | null>(kind4Events.length).fill(null);
+      for (const c of cachedPlaintexts) {
+        merged[c.idx] = {
+          id: c.ev.id,
+          fromMe: c.fromMe,
+          text: c.text,
+          createdAt: c.ev.created_at,
+        };
+      }
+      for (const r of freshResults) {
+        if (!r) continue;
+        merged[r.idx] = { id: r.ev.id, fromMe: r.fromMe, text: r.text, createdAt: r.ev.created_at };
+      }
+      for (const m of merged) if (m !== null) decrypted.push(m);
 
       // NIP-17 — partner pubkey is hidden inside the encrypted rumor, so
       // we can't peer-scope at the relay. Pull all gift wraps addressed to
@@ -1198,10 +1288,8 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       console.log(
         `[Perf] fetchConversation(${normalized.slice(0, 8)}): ` +
           `${(performance.now() - perfStart).toFixed(0)}ms, ` +
-          `k4=${kind4Events.length}, ` +
-          `k1059=${nip17CacheHits + nip17FreshDecrypts}, ` +
-          `hits=${nip17CacheHits}, ` +
-          `fresh=${nip17FreshDecrypts}, ` +
+          `k4=${kind4Events.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
+          `k1059=${nip17CacheHits + nip17FreshDecrypts} (hits=${nip17CacheHits}, fresh=${nip17FreshDecrypts}), ` +
           `rendered=${decrypted.length}`,
       );
       return decrypted;
@@ -1209,17 +1297,29 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     [pubkey, isLoggedIn, signerType, getReadRelays, decryptNip04ViaSigner],
   );
 
-  const refreshDmInbox = useCallback(async (): Promise<void> => {
-    if (!pubkey || !isLoggedIn) {
-      setDmInbox([]);
-      return;
-    }
-    // Single-flight: if a refresh is already in flight, piggy-back on it
-    // rather than kicking off a second concurrent fetch that would race
-    // the AsyncStorage wrap-id cache.
-    if (dmInboxInFlight.current) {
-      return dmInboxInFlight.current;
-    }
+  const refreshDmInbox = useCallback(
+    async (opts?: { force?: boolean }): Promise<void> => {
+      if (!pubkey || !isLoggedIn) {
+        setDmInbox([]);
+        return;
+      }
+      // Freshness TTL: skip the refresh entirely if the previous one
+      // finished within DM_INBOX_REFRESH_TTL_MS, unless the caller
+      // explicitly opts into a forced refresh (pull-to-refresh). The
+      // Messages tab's `useFocusEffect` uses the default TTL path so
+      // tab-bouncing doesn't retrigger expensive relay+decrypt work.
+      if (!opts?.force) {
+        const age = performance.now() - dmInboxLastRefreshAt.current;
+        if (dmInboxLastRefreshAt.current > 0 && age < DM_INBOX_REFRESH_TTL_MS) {
+          return;
+        }
+      }
+      // Single-flight: if a refresh is already in flight, piggy-back on it
+      // rather than kicking off a second concurrent fetch that would race
+      // the AsyncStorage wrap-id cache.
+      if (dmInboxInFlight.current) {
+        return dmInboxInFlight.current;
+      }
 
     // Capture local references once so the closure isn't affected by
     // mid-flight signer / identity changes. If we detect pubkey/signerType
@@ -1233,19 +1333,26 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       setDmInboxLoading(true);
       try {
         const readRelays = getReadRelays();
+        const refreshStart = performance.now();
+        let nip04CacheHits = 0;
+        let nip04FreshDecrypts = 0;
         const { kind4, kind1059 } = await nostrService.fetchInboxDmEvents(
           refreshForPubkey,
           readRelays,
         );
         const entries: DmInboxEntry[] = [];
 
-        // NIP-04 — partner pubkey is in the envelope, so we can apply the
-        // follow filter BEFORE decrypting. A non-followed sender never
-        // gets a round-trip through Amber, let alone land in state.
-        // Yield every DECRYPT_YIELD_EVERY *attempts*, not successes — a
-        // run of decrypt failures would otherwise never tick the counter
-        // and keep blocking the JS thread.
-        let kind4Attempts = 0;
+        // NIP-04 — partner pubkey is in the envelope, so we can apply
+        // the follow filter BEFORE decrypting. A non-followed sender
+        // never gets a round-trip through Amber, let alone land in
+        // state. Same cache/parallel pattern as fetchConversation:
+        // pull cached plaintext synchronously, decrypt misses in
+        // DECRYPT_YIELD_EVERY-sized parallel batches.
+        const k4Targets: {
+          ev: (typeof kind4)[0];
+          fromMe: boolean;
+          partnerPubkey: string;
+        }[] = [];
         for (const ev of kind4) {
           const fromMe = ev.pubkey.toLowerCase() === refreshForPubkey;
           const partnerPubkey = (
@@ -1253,16 +1360,48 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           ).toLowerCase();
           if (!/^[0-9a-f]{64}$/.test(partnerPubkey)) continue;
           if (!refreshFollows.has(partnerPubkey)) continue;
-          const plaintext = await decryptNip04ViaSigner(partnerPubkey, ev.content);
-          if (++kind4Attempts % DECRYPT_YIELD_EVERY === 0) await yieldToEventLoop();
-          if (plaintext === null) continue;
-          entries.push({
-            partnerPubkey,
-            fromMe,
-            createdAt: ev.created_at,
-            text: plaintext,
-            wireKind: 4,
-          });
+          k4Targets.push({ ev, fromMe, partnerPubkey });
+        }
+        // Fast pass — cache lookup only.
+        const k4Misses: typeof k4Targets = [];
+        for (const t of k4Targets) {
+          const hit = nip04PlaintextCache.get(t.ev.id);
+          if (hit !== undefined) {
+            nip04CacheHits++;
+            entries.push({
+              partnerPubkey: t.partnerPubkey,
+              fromMe: t.fromMe,
+              createdAt: t.ev.created_at,
+              text: hit,
+              wireKind: 4,
+            });
+          } else {
+            k4Misses.push(t);
+          }
+        }
+        // Slow pass — parallel decrypt of misses in yield-able chunks.
+        for (let i = 0; i < k4Misses.length; i += DECRYPT_YIELD_EVERY) {
+          const batch = k4Misses.slice(i, i + DECRYPT_YIELD_EVERY);
+          const batchResults = await Promise.all(
+            batch.map(async (t) => {
+              nip04FreshDecrypts++;
+              const plaintext = await decryptNip04ViaSigner(t.partnerPubkey, t.ev.content);
+              if (plaintext === null) return null;
+              nip04PlaintextCache.set(t.ev.id, plaintext);
+              return { t, plaintext };
+            }),
+          );
+          for (const r of batchResults) {
+            if (!r) continue;
+            entries.push({
+              partnerPubkey: r.t.partnerPubkey,
+              fromMe: r.t.fromMe,
+              createdAt: r.t.ev.created_at,
+              text: r.plaintext,
+              wireKind: 4,
+            });
+          }
+          if (i + DECRYPT_YIELD_EVERY < k4Misses.length) await yieldToEventLoop();
         }
 
         // NIP-17 — partner pubkey is INSIDE the encrypted rumor, so we
@@ -1452,6 +1591,15 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         // different session's state.
         if (refreshForPubkey !== pubkey || refreshForSigner !== signerType) return;
 
+        // Perf summary: one line per refresh, grep with `\[Perf\] refreshDmInbox`.
+        console.log(
+          `[Perf] refreshDmInbox: ` +
+            `${(performance.now() - refreshStart).toFixed(0)}ms, ` +
+            `k4=${kind4.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
+            `k1059=${kind1059.length}, ` +
+            `entries=${entries.length}`,
+        );
+
         setDmInbox(entries);
       } catch (error) {
         if (__DEV__) console.warn('[Nostr] refreshDmInbox failed:', error);
@@ -1460,21 +1608,24 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       }
     })();
 
-    dmInboxInFlight.current = task;
-    try {
-      await task;
-    } finally {
-      dmInboxInFlight.current = null;
-    }
-  }, [
-    pubkey,
-    isLoggedIn,
-    signerType,
-    getReadRelays,
-    followPubkeys,
-    decryptNip04ViaSigner,
-    amberNip44DecryptSilent,
-  ]);
+      dmInboxInFlight.current = task;
+      try {
+        await task;
+        dmInboxLastRefreshAt.current = performance.now();
+      } finally {
+        dmInboxInFlight.current = null;
+      }
+    },
+    [
+      pubkey,
+      isLoggedIn,
+      signerType,
+      getReadRelays,
+      followPubkeys,
+      decryptNip04ViaSigner,
+      amberNip44DecryptSilent,
+    ],
+  );
 
   useEffect(() => {
     if (!isLoggedIn) setDmInbox([]);

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -272,6 +272,16 @@ interface NostrContextType {
     plaintext: string,
   ) => Promise<{ success: boolean; error?: string }>;
   fetchConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  /**
+   * Read the persisted per-peer conversation cache synchronously-ish
+   * (AsyncStorage is actually async but single `getItem` is fast).
+   * Returns `[]` when no cache exists. Use this to paint a thread's
+   * cached messages instantly on mount, *before* awaiting the slower
+   * `fetchConversation` relay round-trip — Arcade's `db_only=true`
+   * pattern. The user sees the thread fill immediately, then a fresh
+   * merge replaces it once relay returns.
+   */
+  getCachedConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
   dmInbox: DmInboxEntry[];
   dmInboxLoading: boolean;
   /**
@@ -1159,6 +1169,23 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     [pubkey],
   );
 
+  const getCachedConversation = useCallback(
+    async (otherPubkey: string): Promise<ConversationMessage[]> => {
+      if (!pubkey) return [];
+      const normalized = otherPubkey.trim().toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(normalized)) return [];
+      try {
+        const raw = await AsyncStorage.getItem(convCacheKey(pubkey, normalized));
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    },
+    [pubkey],
+  );
+
   const fetchConversation = useCallback(
     async (otherPubkey: string): Promise<ConversationMessage[]> => {
       if (!pubkey || !isLoggedIn) return [];
@@ -1888,6 +1915,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       addContact,
       sendDirectMessage,
       fetchConversation,
+      getCachedConversation,
       dmInbox,
       dmInboxLoading,
       refreshDmInbox,
@@ -1913,6 +1941,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       addContact,
       sendDirectMessage,
       fetchConversation,
+      getCachedConversation,
       dmInbox,
       dmInboxLoading,
       refreshDmInbox,

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -131,10 +131,18 @@ const DM_CONV_LAST_SEEN_PREFIX = 'nostr_dm_conv_last_seen_v1_';
 const DM_INBOX_CAP = 1000;
 const DM_CONV_CAP = 500;
 
-function inboxCacheKey(user: string) { return DM_INBOX_CACHE_PREFIX + user; }
-function inboxLastSeenKey(user: string) { return DM_INBOX_LAST_SEEN_PREFIX + user; }
-function convCacheKey(user: string, peer: string) { return DM_CONV_CACHE_PREFIX + user + '_' + peer; }
-function convLastSeenKey(user: string, peer: string) { return DM_CONV_LAST_SEEN_PREFIX + user + '_' + peer; }
+function inboxCacheKey(user: string) {
+  return DM_INBOX_CACHE_PREFIX + user;
+}
+function inboxLastSeenKey(user: string) {
+  return DM_INBOX_LAST_SEEN_PREFIX + user;
+}
+function convCacheKey(user: string, peer: string) {
+  return DM_CONV_CACHE_PREFIX + user + '_' + peer;
+}
+function convLastSeenKey(user: string, peer: string) {
+  return DM_CONV_LAST_SEEN_PREFIX + user + '_' + peer;
+}
 
 async function loadLastSeen(key: string): Promise<number | undefined> {
   const raw = await AsyncStorage.getItem(key);
@@ -1239,8 +1247,17 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       //     loop; for Amber the IPC round-trips pipeline. Chunk the
       //     Promise.all in slices of DECRYPT_YIELD_EVERY to yield to
       //     the UI thread between batches on very long threads.
-      const freshDecryptTargets: { idx: number; counterparty: string; ev: (typeof kind4Events)[0] }[] = [];
-      const cachedPlaintexts: { idx: number; fromMe: boolean; text: string; ev: (typeof kind4Events)[0] }[] = [];
+      const freshDecryptTargets: {
+        idx: number;
+        counterparty: string;
+        ev: (typeof kind4Events)[0];
+      }[] = [];
+      const cachedPlaintexts: {
+        idx: number;
+        fromMe: boolean;
+        text: string;
+        ev: (typeof kind4Events)[0];
+      }[] = [];
       for (let i = 0; i < kind4Events.length; i++) {
         const ev = kind4Events[i];
         const fromMe = ev.pubkey === pubkey;
@@ -1254,7 +1271,12 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         }
       }
       // Parallel decrypt of misses, in yield-able chunks.
-      const freshResults: ({ idx: number; fromMe: boolean; text: string; ev: (typeof kind4Events)[0] } | null)[] = [];
+      const freshResults: ({
+        idx: number;
+        fromMe: boolean;
+        text: string;
+        ev: (typeof kind4Events)[0];
+      } | null)[] = [];
       for (let i = 0; i < freshDecryptTargets.length; i += DECRYPT_YIELD_EVERY) {
         const batch = freshDecryptTargets.slice(i, i + DECRYPT_YIELD_EVERY);
         const batchResults = await Promise.all(
@@ -1340,7 +1362,9 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         ? undefined
         : await loadLastSeen(inboxLastSeenKey(pubkey));
       const { kind1059 } = skippedInboxFetch
-        ? { kind1059: [] as Awaited<ReturnType<typeof nostrService.fetchInboxDmEvents>>['kind1059'] }
+        ? {
+            kind1059: [] as Awaited<ReturnType<typeof nostrService.fetchInboxDmEvents>>['kind1059'],
+          }
         : await nostrService.fetchInboxDmEvents(pubkey, readRelays, {
             since: inboxLastSeenForWraps,
           });
@@ -1531,250 +1555,171 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         return dmInboxInFlight.current;
       }
 
-    // Capture local references once so the closure isn't affected by
-    // mid-flight signer / identity changes. If we detect pubkey/signerType
-    // has changed by the time we're about to commit, we bail without
-    // mutating state to avoid leaking entries into the wrong session.
-    const refreshForPubkey = pubkey;
-    const refreshForSigner = signerType;
-    const refreshFollows = followPubkeys;
+      // Capture local references once so the closure isn't affected by
+      // mid-flight signer / identity changes. If we detect pubkey/signerType
+      // has changed by the time we're about to commit, we bail without
+      // mutating state to avoid leaking entries into the wrong session.
+      const refreshForPubkey = pubkey;
+      const refreshForSigner = signerType;
+      const refreshFollows = followPubkeys;
 
-    const task = (async () => {
-      setDmInboxLoading(true);
-      try {
-        const readRelays = getReadRelays();
-        const refreshStart = performance.now();
-        let nip04CacheHits = 0;
-        let nip04FreshDecrypts = 0;
+      const task = (async () => {
+        setDmInboxLoading(true);
+        try {
+          const readRelays = getReadRelays();
+          const refreshStart = performance.now();
+          let nip04CacheHits = 0;
+          let nip04FreshDecrypts = 0;
 
-        // PR B: load persisted inbox + last-seen so we can (a) paint
-        // cached entries before the relay round-trip finishes and
-        // (b) only fetch events newer than the last one we saw.
-        const [cachedInboxRaw, lastSeen] = await Promise.all([
-          AsyncStorage.getItem(inboxCacheKey(refreshForPubkey)),
-          loadLastSeen(inboxLastSeenKey(refreshForPubkey)),
-        ]);
-        const cachedInbox: DmInboxEntry[] = cachedInboxRaw
-          ? (() => {
-              try {
-                const parsed = JSON.parse(cachedInboxRaw);
-                return Array.isArray(parsed) ? parsed : [];
-              } catch {
-                return [];
-              }
-            })()
-          : [];
-        // Render the cached entries immediately so the Messages tab
-        // isn't blank while the relay fetches the delta. The followers
-        // set may have changed since the cache was written; re-apply
-        // the filter here so unfollowed senders don't resurrect.
-        if (cachedInbox.length > 0) {
-          const filteredCache = cachedInbox.filter((e) =>
-            refreshFollows.has(e.partnerPubkey),
-          );
-          setDmInbox(filteredCache);
-        }
-
-        const { kind4, kind1059 } = await nostrService.fetchInboxDmEvents(
-          refreshForPubkey,
-          readRelays,
-          { since: lastSeen },
-        );
-        const entries: DmInboxEntry[] = [];
-
-        // NIP-04 — partner pubkey is in the envelope, so we can apply
-        // the follow filter BEFORE decrypting. A non-followed sender
-        // never gets a round-trip through Amber, let alone land in
-        // state. Same cache/parallel pattern as fetchConversation:
-        // pull cached plaintext synchronously, decrypt misses in
-        // DECRYPT_YIELD_EVERY-sized parallel batches.
-        const k4Targets: {
-          ev: (typeof kind4)[0];
-          fromMe: boolean;
-          partnerPubkey: string;
-        }[] = [];
-        for (const ev of kind4) {
-          const fromMe = ev.pubkey.toLowerCase() === refreshForPubkey;
-          const partnerPubkey = (
-            fromMe ? (ev.tags.find((t) => t[0] === 'p')?.[1] ?? '') : ev.pubkey
-          ).toLowerCase();
-          if (!/^[0-9a-f]{64}$/.test(partnerPubkey)) continue;
-          if (!refreshFollows.has(partnerPubkey)) continue;
-          k4Targets.push({ ev, fromMe, partnerPubkey });
-        }
-        // Fast pass — cache lookup only.
-        const k4Misses: typeof k4Targets = [];
-        for (const t of k4Targets) {
-          const hit = nip04PlaintextCache.get(t.ev.id);
-          if (hit !== undefined) {
-            nip04CacheHits++;
-            entries.push({
-              partnerPubkey: t.partnerPubkey,
-              fromMe: t.fromMe,
-              createdAt: t.ev.created_at,
-              text: hit,
-              wireKind: 4,
-            });
-          } else {
-            k4Misses.push(t);
-          }
-        }
-        // Slow pass — parallel decrypt of misses in yield-able chunks.
-        for (let i = 0; i < k4Misses.length; i += DECRYPT_YIELD_EVERY) {
-          const batch = k4Misses.slice(i, i + DECRYPT_YIELD_EVERY);
-          const batchResults = await Promise.all(
-            batch.map(async (t) => {
-              nip04FreshDecrypts++;
-              const plaintext = await decryptNip04ViaSigner(t.partnerPubkey, t.ev.content);
-              if (plaintext === null) return null;
-              nip04PlaintextCache.set(t.ev.id, plaintext);
-              return { t, plaintext };
-            }),
-          );
-          for (const r of batchResults) {
-            if (!r) continue;
-            entries.push({
-              partnerPubkey: r.t.partnerPubkey,
-              fromMe: r.t.fromMe,
-              createdAt: r.t.ev.created_at,
-              text: r.plaintext,
-              wireKind: 4,
-            });
-          }
-          if (i + DECRYPT_YIELD_EVERY < k4Misses.length) await yieldToEventLoop();
-        }
-
-        // NIP-17 — partner pubkey is INSIDE the encrypted rumor, so we
-        // have to decrypt to know who sent it. For the nsec signer this
-        // is cheap pure-JS, so iterate freely and drop non-follows after
-        // decrypt. For Amber, guard behind the opt-in toggle + silent-only
-        // decrypt path: if Amber hasn't pre-approved nip44_decrypt, we
-        // flip amberNip44Permission='denied' so Account can prompt the
-        // user for a one-time grant, and stop iterating instead of
-        // flooding dialogs.
-        const onSkip = (reason: string, wrapId: string) => {
-          if (__DEV__) console.warn(`[Nostr] NIP-17 inbox unwrap skip (${wrapId}): ${reason}`);
-        };
-
-        if (refreshForSigner === 'nsec' && kind1059.length > 0) {
-          const secretKey = await getMemoisedSecretKey(refreshForPubkey);
-          if (secretKey) {
-            // Persistent wrap-id cache mirroring the Amber branch. Only
-            // ever contains rumors from followed senders — see the
-            // filter gate below. This is the fix for #176.
-            const raw = await AsyncStorage.getItem(NSEC_NIP17_CACHE_KEY);
-            const cache = safeParseRecord<Nip17CacheEntry>(raw);
-            const newlyCached: Nip17CacheEntry[] = [];
-            let unfollowedPurged = 0;
-            let nip17Decrypted = 0;
-            for (const wrap of kind1059) {
-              const cached = cache[wrap.id];
-              if (cached) {
-                // Cache entry exists → it was from a followed sender
-                // when first stored. Re-check against the *current*
-                // follow set so unfollowed partners don't keep
-                // surfacing from cache. Purge the stale entry so we
-                // don't keep dragging it through every refresh until
-                // the 5000-cap LRU finally evicts it.
-                if (!refreshFollows.has(cached.partnerPubkey)) {
-                  delete cache[wrap.id];
-                  unfollowedPurged++;
-                  continue;
+          // PR B: load persisted inbox + last-seen so we can (a) paint
+          // cached entries before the relay round-trip finishes and
+          // (b) only fetch events newer than the last one we saw.
+          const [cachedInboxRaw, lastSeen] = await Promise.all([
+            AsyncStorage.getItem(inboxCacheKey(refreshForPubkey)),
+            loadLastSeen(inboxLastSeenKey(refreshForPubkey)),
+          ]);
+          const cachedInbox: DmInboxEntry[] = cachedInboxRaw
+            ? (() => {
+                try {
+                  const parsed = JSON.parse(cachedInboxRaw);
+                  return Array.isArray(parsed) ? parsed : [];
+                } catch {
+                  return [];
                 }
-                entries.push({
-                  partnerPubkey: cached.partnerPubkey,
-                  fromMe: cached.fromMe,
-                  createdAt: cached.createdAt,
-                  text: cached.text,
-                  wireKind: cached.wireKind,
-                });
-                continue;
-              }
-              const rumor = unwrapWrapNsec(wrap, secretKey, onSkip);
-              if (++nip17Decrypted % DECRYPT_YIELD_EVERY === 0) await yieldToEventLoop();
-              if (!rumor) continue;
-              const partnership = partnerFromRumor(rumor, refreshForPubkey);
-              if (!partnership) continue;
-              // B1 — drop non-follows at the data layer. No caching, no
-              // state. The filter is load-bearing ("parental control"),
-              // so it runs here not in the view.
-              if (!refreshFollows.has(partnership.partnerPubkey)) continue;
-              const entry: Nip17CacheEntry = {
-                wrapId: wrap.id,
-                partnerPubkey: partnership.partnerPubkey,
-                fromMe: partnership.fromMe,
-                createdAt: rumor.created_at,
-                text: rumor.content,
-                wireKind: rumor.kind,
-              };
-              cache[wrap.id] = entry;
-              newlyCached.push(entry);
+              })()
+            : [];
+          // Render the cached entries immediately so the Messages tab
+          // isn't blank while the relay fetches the delta. The followers
+          // set may have changed since the cache was written; re-apply
+          // the filter here so unfollowed senders don't resurrect.
+          if (cachedInbox.length > 0) {
+            const filteredCache = cachedInbox.filter((e) => refreshFollows.has(e.partnerPubkey));
+            setDmInbox(filteredCache);
+          }
+
+          const { kind4, kind1059 } = await nostrService.fetchInboxDmEvents(
+            refreshForPubkey,
+            readRelays,
+            { since: lastSeen },
+          );
+          const entries: DmInboxEntry[] = [];
+
+          // NIP-04 — partner pubkey is in the envelope, so we can apply
+          // the follow filter BEFORE decrypting. A non-followed sender
+          // never gets a round-trip through Amber, let alone land in
+          // state. Same cache/parallel pattern as fetchConversation:
+          // pull cached plaintext synchronously, decrypt misses in
+          // DECRYPT_YIELD_EVERY-sized parallel batches.
+          const k4Targets: {
+            ev: (typeof kind4)[0];
+            fromMe: boolean;
+            partnerPubkey: string;
+          }[] = [];
+          for (const ev of kind4) {
+            const fromMe = ev.pubkey.toLowerCase() === refreshForPubkey;
+            const partnerPubkey = (
+              fromMe ? (ev.tags.find((t) => t[0] === 'p')?.[1] ?? '') : ev.pubkey
+            ).toLowerCase();
+            if (!/^[0-9a-f]{64}$/.test(partnerPubkey)) continue;
+            if (!refreshFollows.has(partnerPubkey)) continue;
+            k4Targets.push({ ev, fromMe, partnerPubkey });
+          }
+          // Fast pass — cache lookup only.
+          const k4Misses: typeof k4Targets = [];
+          for (const t of k4Targets) {
+            const hit = nip04PlaintextCache.get(t.ev.id);
+            if (hit !== undefined) {
+              nip04CacheHits++;
               entries.push({
-                partnerPubkey: entry.partnerPubkey,
-                fromMe: entry.fromMe,
-                createdAt: entry.createdAt,
-                text: entry.text,
-                wireKind: entry.wireKind,
+                partnerPubkey: t.partnerPubkey,
+                fromMe: t.fromMe,
+                createdAt: t.ev.created_at,
+                text: hit,
+                wireKind: 4,
+              });
+            } else {
+              k4Misses.push(t);
+            }
+          }
+          // Slow pass — parallel decrypt of misses in yield-able chunks.
+          for (let i = 0; i < k4Misses.length; i += DECRYPT_YIELD_EVERY) {
+            const batch = k4Misses.slice(i, i + DECRYPT_YIELD_EVERY);
+            const batchResults = await Promise.all(
+              batch.map(async (t) => {
+                nip04FreshDecrypts++;
+                const plaintext = await decryptNip04ViaSigner(t.partnerPubkey, t.ev.content);
+                if (plaintext === null) return null;
+                nip04PlaintextCache.set(t.ev.id, plaintext);
+                return { t, plaintext };
+              }),
+            );
+            for (const r of batchResults) {
+              if (!r) continue;
+              entries.push({
+                partnerPubkey: r.t.partnerPubkey,
+                fromMe: r.t.fromMe,
+                createdAt: r.t.ev.created_at,
+                text: r.plaintext,
+                wireKind: 4,
               });
             }
-
-            if (newlyCached.length > 0 || unfollowedPurged > 0) {
-              const items = Object.values(cache);
-              const toWrite =
-                items.length > NIP17_CACHE_CAP
-                  ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
-                  : items;
-              const next: Record<string, Nip17CacheEntry> = {};
-              for (const item of toWrite) next[item.wrapId] = item;
-              await AsyncStorage.setItem(NSEC_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
-                () => {},
-              );
-            }
+            if (i + DECRYPT_YIELD_EVERY < k4Misses.length) await yieldToEventLoop();
           }
-        } else if (refreshForSigner === 'amber' && kind1059.length > 0) {
-          const amberEnabled = (await AsyncStorage.getItem(AMBER_NIP17_ENABLED_KEY)) === 'true';
-          if (!amberEnabled) {
-            if (__DEV__) {
-              console.log(
-                `[Nostr] Skipping ${kind1059.length} NIP-17 wrap(s) — Account toggle is off`,
-              );
-            }
-          } else {
-            // Persistent cache keyed by wrap id. Only ever contains rumors
-            // from *followed* senders — see the filter gate below.
-            const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);
-            const cache = safeParseRecord<Nip17CacheEntry>(raw);
-            const newlyCached: Nip17CacheEntry[] = [];
-            let permissionDenied = false;
 
-            for (const wrap of kind1059) {
-              const cached = cache[wrap.id];
-              if (cached) {
-                // Cache entry exists → it was from a followed sender when
-                // first stored. Re-check against the *current* follow set
-                // so unfollowed partners don't keep surfacing from cache.
-                if (!refreshFollows.has(cached.partnerPubkey)) continue;
-                entries.push({
-                  partnerPubkey: cached.partnerPubkey,
-                  fromMe: cached.fromMe,
-                  createdAt: cached.createdAt,
-                  text: cached.text,
-                  wireKind: cached.wireKind,
-                });
-                continue;
-              }
-              // Uncached — unwrap via Amber's silent content-resolver path.
-              // If Amber hasn't granted blanket nip44_decrypt permission,
-              // this throws PERMISSION_NOT_GRANTED and we stop iterating.
-              try {
-                const rumor = await unwrapWrapViaNip44(wrap, amberNip44DecryptSilent, onSkip);
+          // NIP-17 — partner pubkey is INSIDE the encrypted rumor, so we
+          // have to decrypt to know who sent it. For the nsec signer this
+          // is cheap pure-JS, so iterate freely and drop non-follows after
+          // decrypt. For Amber, guard behind the opt-in toggle + silent-only
+          // decrypt path: if Amber hasn't pre-approved nip44_decrypt, we
+          // flip amberNip44Permission='denied' so Account can prompt the
+          // user for a one-time grant, and stop iterating instead of
+          // flooding dialogs.
+          const onSkip = (reason: string, wrapId: string) => {
+            if (__DEV__) console.warn(`[Nostr] NIP-17 inbox unwrap skip (${wrapId}): ${reason}`);
+          };
+
+          if (refreshForSigner === 'nsec' && kind1059.length > 0) {
+            const secretKey = await getMemoisedSecretKey(refreshForPubkey);
+            if (secretKey) {
+              // Persistent wrap-id cache mirroring the Amber branch. Only
+              // ever contains rumors from followed senders — see the
+              // filter gate below. This is the fix for #176.
+              const raw = await AsyncStorage.getItem(NSEC_NIP17_CACHE_KEY);
+              const cache = safeParseRecord<Nip17CacheEntry>(raw);
+              const newlyCached: Nip17CacheEntry[] = [];
+              let unfollowedPurged = 0;
+              let nip17Decrypted = 0;
+              for (const wrap of kind1059) {
+                const cached = cache[wrap.id];
+                if (cached) {
+                  // Cache entry exists → it was from a followed sender
+                  // when first stored. Re-check against the *current*
+                  // follow set so unfollowed partners don't keep
+                  // surfacing from cache. Purge the stale entry so we
+                  // don't keep dragging it through every refresh until
+                  // the 5000-cap LRU finally evicts it.
+                  if (!refreshFollows.has(cached.partnerPubkey)) {
+                    delete cache[wrap.id];
+                    unfollowedPurged++;
+                    continue;
+                  }
+                  entries.push({
+                    partnerPubkey: cached.partnerPubkey,
+                    fromMe: cached.fromMe,
+                    createdAt: cached.createdAt,
+                    text: cached.text,
+                    wireKind: cached.wireKind,
+                  });
+                  continue;
+                }
+                const rumor = unwrapWrapNsec(wrap, secretKey, onSkip);
+                if (++nip17Decrypted % DECRYPT_YIELD_EVERY === 0) await yieldToEventLoop();
                 if (!rumor) continue;
                 const partnership = partnerFromRumor(rumor, refreshForPubkey);
                 if (!partnership) continue;
-                // B1 — never cache rumors from non-followed senders. The
-                // cost is re-decrypting them on the next refresh, but the
-                // silent path is ~1 ms per call and keeps plaintext off
-                // AsyncStorage.
+                // B1 — drop non-follows at the data layer. No caching, no
+                // state. The filter is load-bearing ("parental control"),
+                // so it runs here not in the view.
                 if (!refreshFollows.has(partnership.partnerPubkey)) continue;
                 const entry: Nip17CacheEntry = {
                   wrapId: wrap.id,
@@ -1793,89 +1738,165 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                   text: entry.text,
                   wireKind: entry.wireKind,
                 });
-              } catch (error) {
-                const code = (error as { code?: string })?.code;
-                const message = (error as Error)?.message ?? '';
-                if (code === 'PERMISSION_NOT_GRANTED' || /PERMISSION_NOT_GRANTED/.test(message)) {
-                  permissionDenied = true;
-                  if (__DEV__) {
-                    console.log(
-                      `[Nostr] Amber NIP-44 permission not granted — stopping NIP-17 unwrap for this refresh`,
-                    );
-                  }
-                  break;
-                }
-                if (__DEV__) console.warn('[Nostr] Amber NIP-17 unwrap failed:', error);
+              }
+
+              if (newlyCached.length > 0 || unfollowedPurged > 0) {
+                const items = Object.values(cache);
+                const toWrite =
+                  items.length > NIP17_CACHE_CAP
+                    ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
+                    : items;
+                const next: Record<string, Nip17CacheEntry> = {};
+                for (const item of toWrite) next[item.wrapId] = item;
+                await AsyncStorage.setItem(NSEC_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
+                  () => {},
+                );
               }
             }
+          } else if (refreshForSigner === 'amber' && kind1059.length > 0) {
+            const amberEnabled = (await AsyncStorage.getItem(AMBER_NIP17_ENABLED_KEY)) === 'true';
+            if (!amberEnabled) {
+              if (__DEV__) {
+                console.log(
+                  `[Nostr] Skipping ${kind1059.length} NIP-17 wrap(s) — Account toggle is off`,
+                );
+              }
+            } else {
+              // Persistent cache keyed by wrap id. Only ever contains rumors
+              // from *followed* senders — see the filter gate below.
+              const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);
+              const cache = safeParseRecord<Nip17CacheEntry>(raw);
+              const newlyCached: Nip17CacheEntry[] = [];
+              let permissionDenied = false;
 
-            setAmberNip44Permission(permissionDenied ? 'denied' : 'granted');
+              for (const wrap of kind1059) {
+                const cached = cache[wrap.id];
+                if (cached) {
+                  // Cache entry exists → it was from a followed sender when
+                  // first stored. Re-check against the *current* follow set
+                  // so unfollowed partners don't keep surfacing from cache.
+                  if (!refreshFollows.has(cached.partnerPubkey)) continue;
+                  entries.push({
+                    partnerPubkey: cached.partnerPubkey,
+                    fromMe: cached.fromMe,
+                    createdAt: cached.createdAt,
+                    text: cached.text,
+                    wireKind: cached.wireKind,
+                  });
+                  continue;
+                }
+                // Uncached — unwrap via Amber's silent content-resolver path.
+                // If Amber hasn't granted blanket nip44_decrypt permission,
+                // this throws PERMISSION_NOT_GRANTED and we stop iterating.
+                try {
+                  const rumor = await unwrapWrapViaNip44(wrap, amberNip44DecryptSilent, onSkip);
+                  if (!rumor) continue;
+                  const partnership = partnerFromRumor(rumor, refreshForPubkey);
+                  if (!partnership) continue;
+                  // B1 — never cache rumors from non-followed senders. The
+                  // cost is re-decrypting them on the next refresh, but the
+                  // silent path is ~1 ms per call and keeps plaintext off
+                  // AsyncStorage.
+                  if (!refreshFollows.has(partnership.partnerPubkey)) continue;
+                  const entry: Nip17CacheEntry = {
+                    wrapId: wrap.id,
+                    partnerPubkey: partnership.partnerPubkey,
+                    fromMe: partnership.fromMe,
+                    createdAt: rumor.created_at,
+                    text: rumor.content,
+                    wireKind: rumor.kind,
+                  };
+                  cache[wrap.id] = entry;
+                  newlyCached.push(entry);
+                  entries.push({
+                    partnerPubkey: entry.partnerPubkey,
+                    fromMe: entry.fromMe,
+                    createdAt: entry.createdAt,
+                    text: entry.text,
+                    wireKind: entry.wireKind,
+                  });
+                } catch (error) {
+                  const code = (error as { code?: string })?.code;
+                  const message = (error as Error)?.message ?? '';
+                  if (code === 'PERMISSION_NOT_GRANTED' || /PERMISSION_NOT_GRANTED/.test(message)) {
+                    permissionDenied = true;
+                    if (__DEV__) {
+                      console.log(
+                        `[Nostr] Amber NIP-44 permission not granted — stopping NIP-17 unwrap for this refresh`,
+                      );
+                    }
+                    break;
+                  }
+                  if (__DEV__) console.warn('[Nostr] Amber NIP-17 unwrap failed:', error);
+                }
+              }
 
-            if (newlyCached.length > 0) {
-              const items = Object.values(cache);
-              const toWrite =
-                items.length > NIP17_CACHE_CAP
-                  ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
-                  : items;
-              const next: Record<string, Nip17CacheEntry> = {};
-              for (const item of toWrite) next[item.wrapId] = item;
-              await AsyncStorage.setItem(AMBER_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
-                () => {},
-              );
+              setAmberNip44Permission(permissionDenied ? 'denied' : 'granted');
+
+              if (newlyCached.length > 0) {
+                const items = Object.values(cache);
+                const toWrite =
+                  items.length > NIP17_CACHE_CAP
+                    ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
+                    : items;
+                const next: Record<string, Nip17CacheEntry> = {};
+                for (const item of toWrite) next[item.wrapId] = item;
+                await AsyncStorage.setItem(AMBER_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
+                  () => {},
+                );
+              }
             }
           }
+
+          // Identity-change guard: if the user logged out or switched signer
+          // while we were mid-flight, don't leak these entries into a
+          // different session's state.
+          if (refreshForPubkey !== pubkey || refreshForSigner !== signerType) return;
+
+          // PR B: merge cached-with-fresh, keep at most DM_INBOX_CAP
+          // entries (newest-first), then persist + update last-seen.
+          const merged = mergeInboxEntries(cachedInbox, entries, DM_INBOX_CAP);
+          const filteredFinal = merged.filter((e) => refreshFollows.has(e.partnerPubkey));
+
+          // Perf summary: one line per refresh, grep with `\[Perf\] refreshDmInbox`.
+          console.log(
+            `[Perf] refreshDmInbox: ` +
+              `${(performance.now() - refreshStart).toFixed(0)}ms, ` +
+              `k4=${kind4.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
+              `k1059=${kind1059.length}, ` +
+              `since=${lastSeen ?? 0}, ` +
+              `fresh=${entries.length}, ` +
+              `merged=${merged.length}, ` +
+              `rendered=${filteredFinal.length}`,
+          );
+
+          setDmInbox(filteredFinal);
+
+          // Persist merged list + new last-seen (max created_at across
+          // fresh entries, kind-4 + kind-1059 both contribute). Debounced
+          // writes would be nicer but AsyncStorage setItem is async and
+          // rarely blocking at this scale; keep simple for now.
+          const newLastSeen = Math.max(
+            lastSeen ?? 0,
+            ...kind4.map((e) => e.created_at),
+            ...kind1059.map((e) => e.created_at),
+          );
+          await Promise.all([
+            AsyncStorage.setItem(inboxCacheKey(refreshForPubkey), JSON.stringify(merged)).catch(
+              () => {},
+            ),
+            newLastSeen > (lastSeen ?? 0)
+              ? AsyncStorage.setItem(inboxLastSeenKey(refreshForPubkey), String(newLastSeen)).catch(
+                  () => {},
+                )
+              : Promise.resolve(),
+          ]);
+        } catch (error) {
+          if (__DEV__) console.warn('[Nostr] refreshDmInbox failed:', error);
+        } finally {
+          setDmInboxLoading(false);
         }
-
-        // Identity-change guard: if the user logged out or switched signer
-        // while we were mid-flight, don't leak these entries into a
-        // different session's state.
-        if (refreshForPubkey !== pubkey || refreshForSigner !== signerType) return;
-
-        // PR B: merge cached-with-fresh, keep at most DM_INBOX_CAP
-        // entries (newest-first), then persist + update last-seen.
-        const merged = mergeInboxEntries(cachedInbox, entries, DM_INBOX_CAP);
-        const filteredFinal = merged.filter((e) => refreshFollows.has(e.partnerPubkey));
-
-        // Perf summary: one line per refresh, grep with `\[Perf\] refreshDmInbox`.
-        console.log(
-          `[Perf] refreshDmInbox: ` +
-            `${(performance.now() - refreshStart).toFixed(0)}ms, ` +
-            `k4=${kind4.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
-            `k1059=${kind1059.length}, ` +
-            `since=${lastSeen ?? 0}, ` +
-            `fresh=${entries.length}, ` +
-            `merged=${merged.length}, ` +
-            `rendered=${filteredFinal.length}`,
-        );
-
-        setDmInbox(filteredFinal);
-
-        // Persist merged list + new last-seen (max created_at across
-        // fresh entries, kind-4 + kind-1059 both contribute). Debounced
-        // writes would be nicer but AsyncStorage setItem is async and
-        // rarely blocking at this scale; keep simple for now.
-        const newLastSeen = Math.max(
-          lastSeen ?? 0,
-          ...kind4.map((e) => e.created_at),
-          ...kind1059.map((e) => e.created_at),
-        );
-        await Promise.all([
-          AsyncStorage.setItem(inboxCacheKey(refreshForPubkey), JSON.stringify(merged)).catch(
-            () => {},
-          ),
-          newLastSeen > (lastSeen ?? 0)
-            ? AsyncStorage.setItem(
-                inboxLastSeenKey(refreshForPubkey),
-                String(newLastSeen),
-              ).catch(() => {})
-            : Promise.resolve(),
-        ]);
-      } catch (error) {
-        if (__DEV__) console.warn('[Nostr] refreshDmInbox failed:', error);
-      } finally {
-        setDmInboxLoading(false);
-      }
-    })();
+      })();
 
       dmInboxInFlight.current = task;
       try {

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -86,20 +86,47 @@ function safeParseRecord<T>(raw: string | null): Record<string, T> {
   return {};
 }
 
+/** Persist a wrap-id cache back to AsyncStorage, enforcing the size
+ * cap in insertion order (oldest-inserted evicts first — LRU-ish, and
+ * O(overflow) instead of the O(n log n) sort-by-createdAt this
+ * replaced). Object keys in JS preserve insertion order for non-
+ * integer string keys, and wrap ids are hex, so iteration order is
+ * stable across parse/stringify round-trips. Write failures are
+ * surfaced as a warn — a corrupted storage subsystem would otherwise
+ * silently re-decrypt on every refresh with no breadcrumb. */
+async function writeNip17Cache(
+  storageKey: string,
+  cache: Record<string, Nip17CacheEntry>,
+): Promise<void> {
+  const keys = Object.keys(cache);
+  const overflow = keys.length - NIP17_CACHE_CAP;
+  if (overflow > 0) {
+    for (let i = 0; i < overflow; i++) delete cache[keys[i]];
+  }
+  try {
+    await AsyncStorage.setItem(storageKey, JSON.stringify(cache));
+  } catch (err) {
+    console.warn(`[Nostr] NIP-17 cache write failed (${storageKey}):`, err);
+  }
+}
+
 /** Yield to the JS event loop so UI interactions can tick between
  * chunks of a synchronous decrypt loop (#177). `await`ing an already-
  * resolved promise only drains the microtask queue, which still
  * starves UI events — setTimeout(0) returns to the task scheduler. */
-/** Chunk size for yielding between decrypt attempts. Tuned for nsec:
- * `nip04.decrypt` / `unwrapWrapNsec` are ~1 ms each on mid-range mobile
- * CPUs, so 15 iterations ≈ 15 ms of blocking work per batch — just
- * under a 60 fps frame budget. On Amber the actual IPC round-trip is
- * inherently async, so explicit yielding matters less there. If you
- * retune this, profile with `Profiler` in FriendsScreen as the canary. */
-const DECRYPT_YIELD_EVERY = 15;
 function yieldToEventLoop(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+/** Chunk size for yielding between decrypt attempts. Sized for the
+ * nsec path: `nip04.decrypt` / `unwrapWrapNsec` are ~1 ms each on
+ * mid-range mobile CPUs, so 15 iterations ≈ 15 ms of blocking work
+ * per batch — just under a 60 fps frame budget. The Amber path uses
+ * the same constant, but its decrypt is IPC-bound and already
+ * yields per call, so the extra `setTimeout(0)` there is effectively
+ * free. If you retune this, profile the nsec path with `Profiler`
+ * in FriendsScreen as the canary. */
+const DECRYPT_YIELD_EVERY = 15;
 
 /**
  * Minimum gap between `refreshDmInbox` calls fired by
@@ -154,12 +181,10 @@ async function loadLastSeen(key: string): Promise<number | undefined> {
 /**
  * Merge cached list with freshly-decrypted entries. Cached entries we
  * already have take precedence (they might have had properties we'd
- * need to re-decrypt to recover). Dedup key is explicit because
- * `DmInboxEntry` doesn't carry an event id — we use
- * `partnerPubkey+createdAt+wireKind` which is unique in practice
- * (a relay that returns two events with the same triple is
- * misbehaving; last one wins via Map semantics). Conversation
- * messages use `id` (event id) directly.
+ * need to re-decrypt to recover). Dedup key is `id` (kind-4 event id
+ * or kind-1059 wrap id). A fallback composite key covers persisted
+ * entries written before `id` was added to the type so loading an
+ * old cache doesn't silently drop everything to the same slot.
  */
 function mergeInboxEntries(
   cached: DmInboxEntry[],
@@ -167,12 +192,10 @@ function mergeInboxEntries(
   cap: number,
 ): DmInboxEntry[] {
   const map = new Map<string, DmInboxEntry>();
-  for (const e of cached) {
-    map.set(`${e.partnerPubkey}|${e.createdAt}|${e.wireKind}`, e);
-  }
-  for (const e of fresh) {
-    map.set(`${e.partnerPubkey}|${e.createdAt}|${e.wireKind}`, e);
-  }
+  const dedupKey = (e: DmInboxEntry): string =>
+    e.id ?? `${e.partnerPubkey}|${e.createdAt}|${e.wireKind}`;
+  for (const e of cached) map.set(dedupKey(e), e);
+  for (const e of fresh) map.set(dedupKey(e), e);
   const all = Array.from(map.values()).sort((a, b) => b.createdAt - a.createdAt);
   return all.slice(0, cap);
 }
@@ -1410,6 +1433,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               // benefit too. Filter to this thread's partner only for
               // the render-side `decrypted` array.
               const entry: Nip17CacheEntry = {
+                id: wrap.id,
                 wrapId: wrap.id,
                 partnerPubkey: partnership.partnerPubkey,
                 fromMe: partnership.fromMe,
@@ -1428,16 +1452,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               });
             }
             if (newlyCached.length > 0) {
-              const items = Object.values(cache);
-              const toWrite =
-                items.length > NIP17_CACHE_CAP
-                  ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
-                  : items;
-              const next: Record<string, Nip17CacheEntry> = {};
-              for (const item of toWrite) next[item.wrapId] = item;
-              await AsyncStorage.setItem(NSEC_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
-                () => {},
-              );
+              await writeNip17Cache(NSEC_NIP17_CACHE_KEY, cache);
             }
           }
         } else if (signerType === 'amber') {
@@ -1631,6 +1646,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             if (hit !== undefined) {
               nip04CacheHits++;
               entries.push({
+                id: t.ev.id,
                 partnerPubkey: t.partnerPubkey,
                 fromMe: t.fromMe,
                 createdAt: t.ev.created_at,
@@ -1656,6 +1672,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             for (const r of batchResults) {
               if (!r) continue;
               entries.push({
+                id: r.t.ev.id,
                 partnerPubkey: r.t.partnerPubkey,
                 fromMe: r.t.fromMe,
                 createdAt: r.t.ev.created_at,
@@ -1704,6 +1721,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                     continue;
                   }
                   entries.push({
+                    id: cached.wrapId,
                     partnerPubkey: cached.partnerPubkey,
                     fromMe: cached.fromMe,
                     createdAt: cached.createdAt,
@@ -1722,6 +1740,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                 // so it runs here not in the view.
                 if (!refreshFollows.has(partnership.partnerPubkey)) continue;
                 const entry: Nip17CacheEntry = {
+                  id: wrap.id,
                   wrapId: wrap.id,
                   partnerPubkey: partnership.partnerPubkey,
                   fromMe: partnership.fromMe,
@@ -1732,6 +1751,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                 cache[wrap.id] = entry;
                 newlyCached.push(entry);
                 entries.push({
+                  id: entry.id,
                   partnerPubkey: entry.partnerPubkey,
                   fromMe: entry.fromMe,
                   createdAt: entry.createdAt,
@@ -1741,16 +1761,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               }
 
               if (newlyCached.length > 0 || unfollowedPurged > 0) {
-                const items = Object.values(cache);
-                const toWrite =
-                  items.length > NIP17_CACHE_CAP
-                    ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
-                    : items;
-                const next: Record<string, Nip17CacheEntry> = {};
-                for (const item of toWrite) next[item.wrapId] = item;
-                await AsyncStorage.setItem(NSEC_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
-                  () => {},
-                );
+                await writeNip17Cache(NSEC_NIP17_CACHE_KEY, cache);
               }
             }
           } else if (refreshForSigner === 'amber' && kind1059.length > 0) {
@@ -1777,6 +1788,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                   // so unfollowed partners don't keep surfacing from cache.
                   if (!refreshFollows.has(cached.partnerPubkey)) continue;
                   entries.push({
+                    id: cached.wrapId,
                     partnerPubkey: cached.partnerPubkey,
                     fromMe: cached.fromMe,
                     createdAt: cached.createdAt,
@@ -1799,6 +1811,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                   // AsyncStorage.
                   if (!refreshFollows.has(partnership.partnerPubkey)) continue;
                   const entry: Nip17CacheEntry = {
+                    id: wrap.id,
                     wrapId: wrap.id,
                     partnerPubkey: partnership.partnerPubkey,
                     fromMe: partnership.fromMe,
@@ -1809,6 +1822,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                   cache[wrap.id] = entry;
                   newlyCached.push(entry);
                   entries.push({
+                    id: entry.id,
                     partnerPubkey: entry.partnerPubkey,
                     fromMe: entry.fromMe,
                     createdAt: entry.createdAt,
@@ -1834,16 +1848,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               setAmberNip44Permission(permissionDenied ? 'denied' : 'granted');
 
               if (newlyCached.length > 0) {
-                const items = Object.values(cache);
-                const toWrite =
-                  items.length > NIP17_CACHE_CAP
-                    ? items.sort((a, b) => b.createdAt - a.createdAt).slice(0, NIP17_CACHE_CAP)
-                    : items;
-                const next: Record<string, Nip17CacheEntry> = {};
-                for (const item of toWrite) next[item.wrapId] = item;
-                await AsyncStorage.setItem(AMBER_NIP17_CACHE_KEY, JSON.stringify(next)).catch(
-                  () => {},
-                );
+                await writeNip17Cache(AMBER_NIP17_CACHE_KEY, cache);
               }
             }
           }

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -113,6 +113,76 @@ function yieldToEventLoop(): Promise<void> {
  */
 const DM_INBOX_REFRESH_TTL_MS = 30_000;
 
+/**
+ * Persisted inbox + per-peer message caches (PR B).
+ *
+ * Key shape: `<prefix>_<userPubkeyHex>` — per-user so multiple nsec
+ * identities on the same device don't share or overwrite each other.
+ * On logout the three blobs are removed via `AsyncStorage.multiRemove`
+ * alongside the NIP-17 wrap caches.
+ *
+ * Storage cap: `DM_INBOX_CAP` keeps the serialised JSON under ~400 KB
+ * even with verbose messages (≈1000 entries × ~400 bytes each).
+ */
+const DM_INBOX_CACHE_PREFIX = 'nostr_dm_inbox_v1_';
+const DM_INBOX_LAST_SEEN_PREFIX = 'nostr_dm_inbox_last_seen_v1_';
+const DM_CONV_CACHE_PREFIX = 'nostr_dm_conv_v1_';
+const DM_CONV_LAST_SEEN_PREFIX = 'nostr_dm_conv_last_seen_v1_';
+const DM_INBOX_CAP = 1000;
+const DM_CONV_CAP = 500;
+
+function inboxCacheKey(user: string) { return DM_INBOX_CACHE_PREFIX + user; }
+function inboxLastSeenKey(user: string) { return DM_INBOX_LAST_SEEN_PREFIX + user; }
+function convCacheKey(user: string, peer: string) { return DM_CONV_CACHE_PREFIX + user + '_' + peer; }
+function convLastSeenKey(user: string, peer: string) { return DM_CONV_LAST_SEEN_PREFIX + user + '_' + peer; }
+
+async function loadLastSeen(key: string): Promise<number | undefined> {
+  const raw = await AsyncStorage.getItem(key);
+  if (!raw) return undefined;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Merge cached list with freshly-decrypted entries. Cached entries we
+ * already have take precedence (they might have had properties we'd
+ * need to re-decrypt to recover). Dedup key is explicit because
+ * `DmInboxEntry` doesn't carry an event id — we use
+ * `partnerPubkey+createdAt+wireKind` which is unique in practice
+ * (a relay that returns two events with the same triple is
+ * misbehaving; last one wins via Map semantics). Conversation
+ * messages use `id` (event id) directly.
+ */
+function mergeInboxEntries(
+  cached: DmInboxEntry[],
+  fresh: DmInboxEntry[],
+  cap: number,
+): DmInboxEntry[] {
+  const map = new Map<string, DmInboxEntry>();
+  for (const e of cached) {
+    map.set(`${e.partnerPubkey}|${e.createdAt}|${e.wireKind}`, e);
+  }
+  for (const e of fresh) {
+    map.set(`${e.partnerPubkey}|${e.createdAt}|${e.wireKind}`, e);
+  }
+  const all = Array.from(map.values()).sort((a, b) => b.createdAt - a.createdAt);
+  return all.slice(0, cap);
+}
+
+function mergeConversationMessages(
+  cached: ConversationMessage[],
+  fresh: ConversationMessage[],
+  cap: number,
+): ConversationMessage[] {
+  const map = new Map<string, ConversationMessage>();
+  for (const m of cached) map.set(m.id, m);
+  for (const m of fresh) map.set(m.id, m);
+  const all = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
+  if (all.length <= cap) return all;
+  // Keep the newest DM_CONV_CAP messages; drop oldest.
+  return all.slice(all.length - cap);
+}
+
 const NSEC_KEY = 'nostr_nsec';
 const PUBKEY_KEY = 'nostr_pubkey';
 const SIGNER_TYPE_KEY = 'nostr_signer_type';
@@ -685,10 +755,12 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const logout = useCallback(async () => {
     clearMemoisedSecretKey();
     setAmberNip44Permission('unknown');
+    nip04PlaintextCache.clear();
+    const loggedOutPubkey = pubkey;
     await SecureStore.deleteItemAsync(NSEC_KEY);
     await SecureStore.deleteItemAsync(PUBKEY_KEY);
     await SecureStore.deleteItemAsync(SIGNER_TYPE_KEY);
-    await AsyncStorage.multiRemove([
+    const toRemove: string[] = [
       CONTACTS_CACHE_KEY,
       CONTACTS_TIMESTAMP_KEY,
       PROFILES_CACHE_KEY,
@@ -703,7 +775,21 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       AMBER_NIP17_CACHE_KEY,
       AMBER_NIP17_ENABLED_KEY,
       NSEC_NIP17_CACHE_KEY,
-    ]);
+    ];
+    // PR B caches are per-user-keyed — only clear the ones for the
+    // user we're logging out of. Per-peer conversation caches share
+    // the same prefix; we grep AsyncStorage keys for them.
+    if (loggedOutPubkey) {
+      toRemove.push(inboxCacheKey(loggedOutPubkey));
+      toRemove.push(inboxLastSeenKey(loggedOutPubkey));
+      const allKeys = await AsyncStorage.getAllKeys();
+      const convPrefix = DM_CONV_CACHE_PREFIX + loggedOutPubkey + '_';
+      const lastSeenPrefix = DM_CONV_LAST_SEEN_PREFIX + loggedOutPubkey + '_';
+      for (const k of allKeys) {
+        if (k.startsWith(convPrefix) || k.startsWith(lastSeenPrefix)) toRemove.push(k);
+      }
+    }
+    await AsyncStorage.multiRemove(toRemove);
 
     setPubkey(null);
     setProfile(null);
@@ -1092,11 +1178,31 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       const readRelays = getReadRelays();
       const decrypted: ConversationMessage[] = [];
 
-      // NIP-04 — peer-scoped fetch, two directions.
+      // PR B: load persisted per-peer conversation + per-peer last-seen.
+      // Merge cached-and-fresh at the end; keep the cache for the next
+      // open so we only ever re-decrypt the (typically 0-few) events
+      // that arrived since last open.
+      const [convRaw, convLastSeen] = await Promise.all([
+        AsyncStorage.getItem(convCacheKey(pubkey, normalized)),
+        loadLastSeen(convLastSeenKey(pubkey, normalized)),
+      ]);
+      const cachedConv: ConversationMessage[] = convRaw
+        ? (() => {
+            try {
+              const parsed = JSON.parse(convRaw);
+              return Array.isArray(parsed) ? parsed : [];
+            } catch {
+              return [];
+            }
+          })()
+        : [];
+
+      // NIP-04 — peer-scoped fetch, two directions, filtered by since.
       const kind4Events = await nostrService.fetchDirectMessageEvents(
         pubkey,
         normalized,
         readRelays,
+        { since: convLastSeen },
       );
       // Two-pass decrypt with module-level LRU cache:
       //  1. Pull plaintext synchronously for events already in the
@@ -1140,9 +1246,9 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         if (i + DECRYPT_YIELD_EVERY < freshDecryptTargets.length) await yieldToEventLoop();
       }
       // Merge cached + fresh preserving original event order.
-      const merged = new Array<ConversationMessage | null>(kind4Events.length).fill(null);
+      const orderedByIndex = new Array<ConversationMessage | null>(kind4Events.length).fill(null);
       for (const c of cachedPlaintexts) {
-        merged[c.idx] = {
+        orderedByIndex[c.idx] = {
           id: c.ev.id,
           fromMe: c.fromMe,
           text: c.text,
@@ -1151,16 +1257,29 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       }
       for (const r of freshResults) {
         if (!r) continue;
-        merged[r.idx] = { id: r.ev.id, fromMe: r.fromMe, text: r.text, createdAt: r.ev.created_at };
+        orderedByIndex[r.idx] = {
+          id: r.ev.id,
+          fromMe: r.fromMe,
+          text: r.text,
+          createdAt: r.ev.created_at,
+        };
       }
-      for (const m of merged) if (m !== null) decrypted.push(m);
+      for (const m of orderedByIndex) if (m !== null) decrypted.push(m);
 
       // NIP-17 — partner pubkey is hidden inside the encrypted rumor, so
       // we can't peer-scope at the relay. Pull all gift wraps addressed to
       // me, unwrap, keep only rumors whose partner matches the current
       // peer. Amber path reuses the persistent wrap-id cache populated by
       // refreshDmInbox so re-entering a thread doesn't re-round-trip.
-      const { kind1059 } = await nostrService.fetchInboxDmEvents(pubkey, readRelays);
+      // For NIP-17 gift-wraps we can't peer-scope at the relay (partner
+      // pubkey is inside the encrypted rumor), so we use the inbox-wide
+      // last-seen (not the per-peer one) to narrow the gift-wrap query.
+      // Reading the inbox last-seen is cheap; it's a few bytes of
+      // AsyncStorage.
+      const inboxLastSeenForWraps = await loadLastSeen(inboxLastSeenKey(pubkey));
+      const { kind1059 } = await nostrService.fetchInboxDmEvents(pubkey, readRelays, {
+        since: inboxLastSeenForWraps,
+      });
       if (kind1059.length > 0) {
         const onSkip = (reason: string, wrapId: string) => {
           if (__DEV__) console.warn(`[Nostr] NIP-17 thread unwrap skip (${wrapId}): ${reason}`);
@@ -1280,7 +1399,11 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         }
       }
 
-      decrypted.sort((a, b) => a.createdAt - b.createdAt);
+      // PR B: merge fresh decrypt results with what we had cached
+      // from previous opens. Fresh takes precedence via `mergeConversationMessages`
+      // Map semantics so re-ordered or edited events (rare) land right.
+      const merged = mergeConversationMessages(cachedConv, decrypted, DM_CONV_CAP);
+
       // Single-line perf summary — grep `[Perf] fetchConversation` out
       // of logcat to compare cold-cache vs warm-cache thread opens.
       // Cold cache shows `hits=0, fresh=N` — whole inbox decrypted.
@@ -1290,9 +1413,32 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           `${(performance.now() - perfStart).toFixed(0)}ms, ` +
           `k4=${kind4Events.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
           `k1059=${nip17CacheHits + nip17FreshDecrypts} (hits=${nip17CacheHits}, fresh=${nip17FreshDecrypts}), ` +
-          `rendered=${decrypted.length}`,
+          `since=${convLastSeen ?? 0}, ` +
+          `cached=${cachedConv.length}, ` +
+          `merged=${merged.length}`,
       );
-      return decrypted;
+
+      // Persist merged list + new per-peer last-seen so next open of
+      // THIS thread sees only the delta. Fire-and-forget; the caller
+      // gets its data immediately via `merged`.
+      const newConvLastSeen = Math.max(
+        convLastSeen ?? 0,
+        ...kind4Events.map((e) => e.created_at),
+        ...kind1059.map((e) => e.created_at),
+      );
+      Promise.all([
+        AsyncStorage.setItem(convCacheKey(pubkey, normalized), JSON.stringify(merged)).catch(
+          () => {},
+        ),
+        newConvLastSeen > (convLastSeen ?? 0)
+          ? AsyncStorage.setItem(
+              convLastSeenKey(pubkey, normalized),
+              String(newConvLastSeen),
+            ).catch(() => {})
+          : Promise.resolve(),
+      ]).catch(() => {});
+
+      return merged;
     },
     [pubkey, isLoggedIn, signerType, getReadRelays, decryptNip04ViaSigner],
   );
@@ -1336,9 +1482,39 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         const refreshStart = performance.now();
         let nip04CacheHits = 0;
         let nip04FreshDecrypts = 0;
+
+        // PR B: load persisted inbox + last-seen so we can (a) paint
+        // cached entries before the relay round-trip finishes and
+        // (b) only fetch events newer than the last one we saw.
+        const [cachedInboxRaw, lastSeen] = await Promise.all([
+          AsyncStorage.getItem(inboxCacheKey(refreshForPubkey)),
+          loadLastSeen(inboxLastSeenKey(refreshForPubkey)),
+        ]);
+        const cachedInbox: DmInboxEntry[] = cachedInboxRaw
+          ? (() => {
+              try {
+                const parsed = JSON.parse(cachedInboxRaw);
+                return Array.isArray(parsed) ? parsed : [];
+              } catch {
+                return [];
+              }
+            })()
+          : [];
+        // Render the cached entries immediately so the Messages tab
+        // isn't blank while the relay fetches the delta. The followers
+        // set may have changed since the cache was written; re-apply
+        // the filter here so unfollowed senders don't resurrect.
+        if (cachedInbox.length > 0) {
+          const filteredCache = cachedInbox.filter((e) =>
+            refreshFollows.has(e.partnerPubkey),
+          );
+          setDmInbox(filteredCache);
+        }
+
         const { kind4, kind1059 } = await nostrService.fetchInboxDmEvents(
           refreshForPubkey,
           readRelays,
+          { since: lastSeen },
         );
         const entries: DmInboxEntry[] = [];
 
@@ -1591,16 +1767,45 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         // different session's state.
         if (refreshForPubkey !== pubkey || refreshForSigner !== signerType) return;
 
+        // PR B: merge cached-with-fresh, keep at most DM_INBOX_CAP
+        // entries (newest-first), then persist + update last-seen.
+        const merged = mergeInboxEntries(cachedInbox, entries, DM_INBOX_CAP);
+        const filteredFinal = merged.filter((e) => refreshFollows.has(e.partnerPubkey));
+
         // Perf summary: one line per refresh, grep with `\[Perf\] refreshDmInbox`.
         console.log(
           `[Perf] refreshDmInbox: ` +
             `${(performance.now() - refreshStart).toFixed(0)}ms, ` +
             `k4=${kind4.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
             `k1059=${kind1059.length}, ` +
-            `entries=${entries.length}`,
+            `since=${lastSeen ?? 0}, ` +
+            `fresh=${entries.length}, ` +
+            `merged=${merged.length}, ` +
+            `rendered=${filteredFinal.length}`,
         );
 
-        setDmInbox(entries);
+        setDmInbox(filteredFinal);
+
+        // Persist merged list + new last-seen (max created_at across
+        // fresh entries, kind-4 + kind-1059 both contribute). Debounced
+        // writes would be nicer but AsyncStorage setItem is async and
+        // rarely blocking at this scale; keep simple for now.
+        const newLastSeen = Math.max(
+          lastSeen ?? 0,
+          ...kind4.map((e) => e.created_at),
+          ...kind1059.map((e) => e.created_at),
+        );
+        await Promise.all([
+          AsyncStorage.setItem(inboxCacheKey(refreshForPubkey), JSON.stringify(merged)).catch(
+            () => {},
+          ),
+          newLastSeen > (lastSeen ?? 0)
+            ? AsyncStorage.setItem(
+                inboxLastSeenKey(refreshForPubkey),
+                String(newLastSeen),
+              ).catch(() => {})
+            : Promise.resolve(),
+        ]);
       } catch (error) {
         if (__DEV__) console.warn('[Nostr] refreshDmInbox failed:', error);
       } finally {

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -1293,20 +1293,57 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       }
       for (const m of orderedByIndex) if (m !== null) decrypted.push(m);
 
-      // NIP-17 — partner pubkey is hidden inside the encrypted rumor, so
-      // we can't peer-scope at the relay. Pull all gift wraps addressed to
-      // me, unwrap, keep only rumors whose partner matches the current
-      // peer. Amber path reuses the persistent wrap-id cache populated by
-      // refreshDmInbox so re-entering a thread doesn't re-round-trip.
-      // For NIP-17 gift-wraps we can't peer-scope at the relay (partner
-      // pubkey is inside the encrypted rumor), so we use the inbox-wide
-      // last-seen (not the per-peer one) to narrow the gift-wrap query.
-      // Reading the inbox last-seen is cheap; it's a few bytes of
-      // AsyncStorage.
-      const inboxLastSeenForWraps = await loadLastSeen(inboxLastSeenKey(pubkey));
-      const { kind1059 } = await nostrService.fetchInboxDmEvents(pubkey, readRelays, {
-        since: inboxLastSeenForWraps,
-      });
+      // NIP-17 — partner pubkey is hidden inside the encrypted rumor,
+      // so we can't peer-scope at the relay. `refreshDmInbox` (which
+      // the Messages tab fires on focus with a 30s TTL) already
+      // decrypts every wrap addressed to us and writes the plaintext
+      // keyed by wrap id to the persistent cache. Serve the NIP-17
+      // portion of THIS thread from that cache first — if the cache
+      // has ANY entries, we skip the expensive inbox-wide relay
+      // fetch entirely (#190).
+      //
+      // Cold-cache fallback: if the cache has no entries at all (first
+      // app run post-login, or just-logged-out-logged-back-in) we
+      // still hit the relay so the thread renders even before any
+      // refreshDmInbox has fired. Subsequent opens short-circuit.
+      //
+      // Staleness tradeoff: a wrap that arrived in the last <30s and
+      // hasn't been pulled by refreshDmInbox yet won't show until the
+      // next tab focus. For a chat UX that's a non-issue.
+      const signerWrapCacheKey =
+        signerType === 'nsec'
+          ? NSEC_NIP17_CACHE_KEY
+          : signerType === 'amber'
+            ? AMBER_NIP17_CACHE_KEY
+            : null;
+      const wrapCacheRaw = signerWrapCacheKey
+        ? await AsyncStorage.getItem(signerWrapCacheKey)
+        : null;
+      const wrapCache = safeParseRecord<Nip17CacheEntry>(wrapCacheRaw);
+      const cachedWrapEntries = Object.values(wrapCache);
+      let skippedInboxFetch = false;
+      if (cachedWrapEntries.length > 0) {
+        // Cache populated — serve peer-matching wraps directly, skip relay fetch.
+        for (const entry of cachedWrapEntries) {
+          nip17CacheHits++;
+          if (entry.partnerPubkey !== normalized) continue;
+          decrypted.push({
+            id: entry.wrapId,
+            fromMe: entry.fromMe,
+            text: entry.text,
+            createdAt: entry.createdAt,
+          });
+        }
+        skippedInboxFetch = true;
+      }
+      const inboxLastSeenForWraps = skippedInboxFetch
+        ? undefined
+        : await loadLastSeen(inboxLastSeenKey(pubkey));
+      const { kind1059 } = skippedInboxFetch
+        ? { kind1059: [] as Awaited<ReturnType<typeof nostrService.fetchInboxDmEvents>>['kind1059'] }
+        : await nostrService.fetchInboxDmEvents(pubkey, readRelays, {
+            since: inboxLastSeenForWraps,
+          });
       if (kind1059.length > 0) {
         const onSkip = (reason: string, wrapId: string) => {
           if (__DEV__) console.warn(`[Nostr] NIP-17 thread unwrap skip (${wrapId}): ${reason}`);
@@ -1439,7 +1476,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         `[Perf] fetchConversation(${normalized.slice(0, 8)}): ` +
           `${(performance.now() - perfStart).toFixed(0)}ms, ` +
           `k4=${kind4Events.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
-          `k1059=${nip17CacheHits + nip17FreshDecrypts} (hits=${nip17CacheHits}, fresh=${nip17FreshDecrypts}), ` +
+          `k1059=${nip17CacheHits + nip17FreshDecrypts} (hits=${nip17CacheHits}, fresh=${nip17FreshDecrypts}, skippedFetch=${skippedInboxFetch}), ` +
           `since=${convLastSeen ?? 0}, ` +
           `cached=${cachedConv.length}, ` +
           `merged=${merged.length}`,

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -307,11 +307,20 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
           setActiveWalletId(walletStates[0].id);
         }
 
-        // Connect wallets in parallel — each NWC handshake is ~5s of relay
-        // RTT, so serial init of N wallets was ~5N seconds. For typical
-        // installs (1-3 wallets) the relays handle concurrent connects
-        // fine; state updates are individual so per-wallet races are safe.
-        await Promise.all(
+        // Wallets are usable immediately with cached balance + tx
+        // history from AsyncStorage, so we can flip the app into
+        // "loaded" state BEFORE the (slow) NWC connect handshakes
+        // finish. Each handshake does `provider.enable()` with up to
+        // 3 retries × 2 s backoff + a 500 ms stabilise wait = 2-14 s
+        // per wallet. Serialising them behind the UI boot meant a
+        // user with 2 NWC wallets waited 10+ s on a pink screen.
+        // Kick connects off in parallel but DON'T await — state
+        // updates inside each `.then` patch the wallet individually
+        // as it comes online, and any `pay / makeInvoice / getBalance`
+        // call will auto-await the connect because `nwcService.connect`
+        // is idempotent and provider-map-keyed.
+        setIsLoading(false);
+        void Promise.all(
           walletList.map(async (wallet) => {
             try {
               if (wallet.walletType === 'onchain') {
@@ -366,7 +375,9 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         });
       } catch (error) {
         console.warn('Wallet startup failed:', error);
-      } finally {
+        // Safety net: if something threw BEFORE we reached the
+        // early `setIsLoading(false)` above, make sure the UI still
+        // unblocks. Idempotent; React bails on no-op state sets.
         setIsLoading(false);
       }
     })();

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -231,8 +231,15 @@ const ConversationScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
   const { pubkey, name, picture, lightningAddress } = route.params;
 
-  const { isLoggedIn, fetchConversation, getCachedConversation, sendDirectMessage, signEvent, contacts, relays } =
-    useNostr();
+  const {
+    isLoggedIn,
+    fetchConversation,
+    getCachedConversation,
+    sendDirectMessage,
+    signEvent,
+    contacts,
+    relays,
+  } = useNostr();
   const { wallets, activeWalletId, activeWallet } = useWallet();
 
   const [messages, setMessages] = useState<

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -365,6 +365,20 @@ const ConversationScreen: React.FC = () => {
     return withHeaders;
   }, [messages, zapItems]);
 
+  // Mount/unmount tracker so the async `load()` below can bail when
+  // the user navigates back mid-fetch. Without this, every back-press
+  // during the 6-12 s cold fetchConversation still runs the full
+  // decrypt + persist chain on the unmounted component, wasting JS
+  // thread time that could have been responding to input.
+  // Declared BEFORE `load` because `load`'s body closes over it.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const load = useCallback(
     async (showSpinner: boolean) => {
       if (!isLoggedIn) {
@@ -400,19 +414,6 @@ const ConversationScreen: React.FC = () => {
     },
     [isLoggedIn, fetchConversation, getCachedConversation, pubkey],
   );
-
-  // Mount/unmount tracker so the async `load()` above can bail when
-  // the user navigates back mid-fetch. Without this, every back-press
-  // during the 6-12 s cold fetchConversation still runs the full
-  // decrypt + persist chain on the unmounted component, wasting JS
-  // thread time that could have been responding to input.
-  const isMountedRef = useRef(true);
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     load(true);

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -369,21 +369,43 @@ const ConversationScreen: React.FC = () => {
       // the 6-8 s relay round-trip. Arcade `db_only=true` pattern.
       // Only show the spinner if the cache was empty (true cold open).
       const cached = await getCachedConversation(pubkey);
-      if (cached.length > 0) {
+      if (isMountedRef.current && cached.length > 0) {
         setMessages(cached);
         setLoading(false);
-      } else if (showSpinner) {
+      } else if (isMountedRef.current && showSpinner) {
         setLoading(true);
       }
       try {
         const conv = await fetchConversation(pubkey);
-        setMessages(conv);
+        // If the user navigated away while the fetch was in flight,
+        // don't fire state updates — those would either trigger a
+        // re-render on an unmounted component (React warning) or land
+        // on the *next* thread that inherits this instance. Check the
+        // ref and bail.
+        if (isMountedRef.current) {
+          setMessages(conv);
+        }
       } finally {
-        setLoading(false);
+        if (isMountedRef.current) {
+          setLoading(false);
+        }
       }
     },
     [isLoggedIn, fetchConversation, getCachedConversation, pubkey],
   );
+
+  // Mount/unmount tracker so the async `load()` above can bail when
+  // the user navigates back mid-fetch. Without this, every back-press
+  // during the 6-12 s cold fetchConversation still runs the full
+  // decrypt + persist chain on the unmounted component, wasting JS
+  // thread time that could have been responding to input.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     load(true);

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -7,7 +7,6 @@ import {
   Pressable,
   Modal,
   FlatList,
-  KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
   RefreshControl,
@@ -15,6 +14,7 @@ import {
   AppState,
   Image,
   Linking,
+  Keyboard,
   StyleSheet,
 } from 'react-native';
 import Svg, { Circle, Path } from 'react-native-svg';
@@ -231,7 +231,7 @@ const ConversationScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
   const { pubkey, name, picture, lightningAddress } = route.params;
 
-  const { isLoggedIn, fetchConversation, sendDirectMessage, signEvent, contacts, relays } =
+  const { isLoggedIn, fetchConversation, getCachedConversation, sendDirectMessage, signEvent, contacts, relays } =
     useNostr();
   const { wallets, activeWalletId, activeWallet } = useWallet();
 
@@ -247,6 +247,11 @@ const ConversationScreen: React.FC = () => {
   const [invoiceToPay, setInvoiceToPay] = useState<string | null>(null);
   const [avatarError, setAvatarError] = useState(false);
   const [detailTx, setDetailTx] = useState<TransactionDetailData | null>(null);
+  // Keyboard height — tracked explicitly so we can push the composer
+  // up manually. KeyboardAvoidingView with `behavior="padding"` is
+  // unreliable on Android 15+ edge-to-edge where `adjustResize`
+  // doesn't shrink past the IME. Same pattern as SendSheet/ReceiveSheet.
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [profileContact, setProfileContact] = useState<CounterpartyContact | null>(null);
   // Profiles resolved from `nostr:` contact references the other party
   // has shared in this conversation. Keyed by hex pubkey; a `null` value
@@ -359,20 +364,48 @@ const ConversationScreen: React.FC = () => {
         setLoading(false);
         return;
       }
-      if (showSpinner) setLoading(true);
+      // Paint cached messages instantly if we have any — user sees a
+      // populated thread within one frame instead of "Loading…" for
+      // the 6-8 s relay round-trip. Arcade `db_only=true` pattern.
+      // Only show the spinner if the cache was empty (true cold open).
+      const cached = await getCachedConversation(pubkey);
+      if (cached.length > 0) {
+        setMessages(cached);
+        setLoading(false);
+      } else if (showSpinner) {
+        setLoading(true);
+      }
       try {
         const conv = await fetchConversation(pubkey);
         setMessages(conv);
       } finally {
-        if (showSpinner) setLoading(false);
+        setLoading(false);
       }
     },
-    [isLoggedIn, fetchConversation, pubkey],
+    [isLoggedIn, fetchConversation, getCachedConversation, pubkey],
   );
 
   useEffect(() => {
     load(true);
   }, [load]);
+
+  // Track keyboard height so the composer sits above the IME on
+  // Android 15+ edge-to-edge, where KeyboardAvoidingView's built-in
+  // behaviors are unreliable. iOS uses `keyboardWillShow/Hide` for
+  // a smooth animated transition; Android uses `DidShow/Hide` because
+  // `WillShow` isn't emitted there.
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   // Jump to the newest message on first content load, and when the user is
   // already near the bottom and a new message arrives. The list is
@@ -1237,11 +1270,13 @@ const ConversationScreen: React.FC = () => {
         </TouchableOpacity>
       </View>
 
-      <KeyboardAvoidingView
-        style={styles.flex}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? insets.top : 0}
-      >
+      {/* Use a plain View instead of KeyboardAvoidingView — on
+          Android 15+ edge-to-edge, neither the `padding` nor `height`
+          behaviors of KAV reliably lift content above the IME. We
+          track `keyboardHeight` via `Keyboard.addListener` above and
+          apply it as `paddingBottom` on the composer directly. Same
+          pattern as SendSheet / ReceiveSheet in this repo. */}
+      <View style={styles.flex}>
         {loading ? (
           <View style={styles.loading}>
             <ActivityIndicator color={colors.brandPink} />
@@ -1306,7 +1341,19 @@ const ConversationScreen: React.FC = () => {
           </View>
         ) : null}
 
-        <View style={[styles.composer, { paddingBottom: Math.max(insets.bottom, 8) }]}>
+        <View
+          style={[
+            styles.composer,
+            {
+              // When the keyboard is up: push the composer up by its
+              // full height (no safe-area pad needed; the keyboard
+              // covers that region). When it's down: keep the usual
+              // bottom safe-area inset so the composer doesn't touch
+              // the gesture bar.
+              paddingBottom: keyboardHeight > 0 ? keyboardHeight : Math.max(insets.bottom, 8),
+            },
+          ]}
+        >
           <TouchableOpacity
             style={styles.composerAttachButton}
             onPress={() => setAttachSheetOpen(true)}
@@ -1345,7 +1392,7 @@ const ConversationScreen: React.FC = () => {
             )}
           </TouchableOpacity>
         </View>
-      </KeyboardAvoidingView>
+      </View>
 
       <AttachSheet
         visible={attachSheetOpen}

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -1255,6 +1255,17 @@ const ConversationScreen: React.FC = () => {
             renderItem={renderItem}
             contentContainerStyle={styles.listContent}
             inverted
+            // Window the list so a thread with hundreds of messages
+            // doesn't mount every row up front — first-frame work goes
+            // from "render all N bubbles + avatars" to "render the
+            // 20 newest then lazy-mount as the user scrolls". These
+            // defaults are chosen for chat-style threads: one screen
+            // fits ~8-10 bubbles, so 20 covers the visible viewport
+            // plus one screen of pre-roll for smooth momentum scrolls.
+            initialNumToRender={20}
+            maxToRenderPerBatch={10}
+            windowSize={10}
+            removeClippedSubviews
             ListEmptyComponent={
               <View style={styles.empty}>
                 <Text style={styles.emptyTitle}>No messages yet</Text>

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -1319,10 +1319,15 @@ const ConversationScreen: React.FC = () => {
             // defaults are chosen for chat-style threads: one screen
             // fits ~8-10 bubbles, so 20 covers the visible viewport
             // plus one screen of pre-roll for smooth momentum scrolls.
+            //
+            // NOTE: `removeClippedSubviews` is deliberately OFF. It's
+            // broken with `inverted` on Android — breaks the contentOffset
+            // reporting so onScroll's `y < 200` check flips when the user
+            // is visually at the bottom, making the scroll-to-bottom FAB
+            // show spuriously. See facebook/react-native#30521 / #26061.
             initialNumToRender={20}
             maxToRenderPerBatch={10}
             windowSize={10}
-            removeClippedSubviews
             ListEmptyComponent={
               <View style={styles.empty}>
                 <Text style={styles.emptyTitle}>No messages yet</Text>

--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -8,6 +8,7 @@ import {
   RefreshControl,
   Alert,
 } from 'react-native';
+import { InteractionManager } from 'react-native';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { Users } from 'lucide-react-native';
@@ -96,9 +97,17 @@ const FriendsScreen: React.FC = () => {
   // Force-refresh the own-profile kind-0 on focus so the top-right
   // profile icon picks up external renames (e.g. via Amber or another
   // client) without waiting for the 24h cache to expire. See #148.
+  //
+  // Deferred via InteractionManager so the tab-transition animation
+  // and first-paint of the Friends list finish *before* the (3-5 s)
+  // refresh kicks off — otherwise the JS thread's busy on the refresh
+  // while React is trying to render, and navigating away then feels
+  // laggy until the refresh completes.
   useFocusEffect(
     useCallback(() => {
-      if (isLoggedIn) refreshProfile();
+      if (!isLoggedIn) return;
+      const handle = InteractionManager.runAfterInteractions(() => refreshProfile());
+      return () => handle.cancel();
     }, [isLoggedIn, refreshProfile]),
   );
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -189,7 +189,13 @@ const HomeScreen: React.FC = () => {
 
   const isOnchainWallet = activeWallet?.walletType === 'onchain';
   const isWatchOnly = isOnchainWallet && activeWallet?.onchainImportMethod !== 'mnemonic';
-  const hasActiveConnection = isOnchainWallet ? true : (activeWallet?.isConnected ?? false);
+  // Don't gate Send/Receive on the transient `isConnected` flag: post-PR-D
+  // NWC wallets land in state with `isConnected: false` and flip true in
+  // background, so gating here would dead-lock the buttons for the 2-14 s
+  // enable() window, or indefinitely if the WebSocket blips. `pay` /
+  // `makeInvoice` auto-await the in-flight connect, so "in state" is
+  // enough.
+  const hasActiveConnection = !!activeWallet;
   const canSend = hasActiveConnection && !isWatchOnly;
   // Transfer requires at least 1 wallet that can send + 1 other wallet
   const hasSendableWallet = wallets.some(

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   RefreshControl,
   ActivityIndicator,
+  InteractionManager,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -66,7 +67,14 @@ const HomeScreen: React.FC = () => {
   // `profile` — aligning those is tracked separately under #150.)
   useFocusEffect(
     useCallback(() => {
-      if (isLoggedIn) refreshProfile();
+      if (!isLoggedIn) return;
+      // Defer to after the tab-transition animation finishes — same
+      // rationale as Friends/Messages: refreshProfile can hold the JS
+      // thread briefly while it walks the profile cache and (on miss)
+      // hits a relay, and running it during the focus callback
+      // synchronously makes the tab feel laggy.
+      const handle = InteractionManager.runAfterInteractions(() => refreshProfile());
+      return () => handle.cancel();
     }, [isLoggedIn, refreshProfile]),
   );
 

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -128,11 +128,16 @@ const MessagesScreen: React.FC = () => {
     // own-profile cache so renames published elsewhere surface now,
     // and also bypass the 30s DM-inbox TTL so the relay query actually
     // runs (the TTL's default path is for useFocusEffect tab bounces).
-    await Promise.all([
-      refreshContacts(),
-      refreshDmInbox({ force: true }),
-      refreshProfile({ force: true }),
-    ]);
+    //
+    // Important: `refreshContacts` must complete BEFORE
+    // `refreshDmInbox`. The DM refresh filters by the logged-in user's
+    // current follow set, and if we run them in parallel the DM query
+    // captures the stale closure before the new contacts state lands,
+    // so any new-since-last-refresh followers' messages get dropped
+    // by the follow gate. Profile refresh is independent and can run
+    // in parallel.
+    await Promise.all([refreshContacts(), refreshProfile({ force: true })]);
+    await refreshDmInbox({ force: true });
     setRefreshing(false);
   }, [refreshContacts, refreshDmInbox, refreshProfile]);
 

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -125,8 +125,14 @@ const MessagesScreen: React.FC = () => {
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     // Pull-to-refresh is explicit user intent — force-bypass the 24h
-    // own-profile cache so renames published elsewhere surface now.
-    await Promise.all([refreshContacts(), refreshDmInbox(), refreshProfile({ force: true })]);
+    // own-profile cache so renames published elsewhere surface now,
+    // and also bypass the 30s DM-inbox TTL so the relay query actually
+    // runs (the TTL's default path is for useFocusEffect tab bounces).
+    await Promise.all([
+      refreshContacts(),
+      refreshDmInbox({ force: true }),
+      refreshProfile({ force: true }),
+    ]);
     setRefreshing(false);
   }, [refreshContacts, refreshDmInbox, refreshProfile]);
 

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -154,9 +154,15 @@ const MessagesScreen: React.FC = () => {
     // so any new-since-last-refresh followers' messages get dropped
     // by the follow gate. Profile refresh is independent and can run
     // in parallel.
-    await Promise.all([refreshContacts(), refreshProfile({ force: true })]);
-    await refreshDmInbox({ force: true });
-    setRefreshing(false);
+    //
+    // try/finally so a relay timeout / decrypt throw doesn't leave the
+    // UI stuck in the "refreshing" spinner state.
+    try {
+      await Promise.all([refreshContacts(), refreshProfile({ force: true })]);
+      await refreshDmInbox({ force: true });
+    } finally {
+      setRefreshing(false);
+    }
   }, [refreshContacts, refreshDmInbox, refreshProfile]);
 
   const handleConversationPress = useCallback(

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { View, Text, TextInput, TouchableOpacity, Image, RefreshControl } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Image,
+  RefreshControl,
+  InteractionManager,
+} from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { Users, Clock } from 'lucide-react-native';
@@ -77,9 +85,19 @@ const MessagesScreen: React.FC = () => {
     });
   }, []);
 
+  // Defer the refresh until the Messages tab's transition animation
+  // and first-paint have finished. The refresh itself (relay fetches
+  // + decrypt loop) holds the JS thread for 3-5 s; running it inside
+  // the focus-effect callback synchronously meant navigating away
+  // from Messages felt laggy because the NEXT tab's render queued
+  // behind it. InteractionManager yields to the scheduler and runs
+  // the work once the UI is idle. `.cancel()` in cleanup avoids
+  // firing the refresh on a focus that was already abandoned.
   useFocusEffect(
     useCallback(() => {
-      if (isLoggedIn) refreshDmInbox();
+      if (!isLoggedIn) return;
+      const handle = InteractionManager.runAfterInteractions(() => refreshDmInbox());
+      return () => handle.cancel();
     }, [isLoggedIn, refreshDmInbox]),
   );
 

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -5,6 +5,7 @@ import {
   finalizeEvent,
   type VerifiedEvent,
 } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
 import * as nip19 from 'nostr-tools/nip19';
 import * as nip04 from 'nostr-tools/nip04';
 import * as nip59 from 'nostr-tools/nip59';
@@ -565,31 +566,37 @@ export async function fetchDirectMessageEvents(
   myPubkey: string,
   otherPubkey: string,
   relays: string[],
-  options: { limit?: number } = {},
+  options: { limit?: number; since?: number } = {},
 ): Promise<RawDmEvent[]> {
   const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
   trackRelays(allRelays);
   const limit = options.limit ?? 200;
+  // Damus's trick (SubscriptionManager.swift:293-300): pad `since` back
+  // by 2 minutes so relays with slightly-off clocks still return the
+  // last few events we might have missed on the previous fetch. On
+  // first fetch (no cached last-seen) the caller passes undefined, so
+  // the filter has no `since` and the relay returns full history.
+  const since = options.since !== undefined ? Math.max(0, options.since - 120) : undefined;
+  const fromMeFilter: Filter = {
+    kinds: [4],
+    authors: [myPubkey],
+    '#p': [otherPubkey],
+    limit,
+  };
+  const toMeFilter: Filter = {
+    kinds: [4],
+    authors: [otherPubkey],
+    '#p': [myPubkey],
+    limit,
+  };
+  if (since !== undefined) {
+    fromMeFilter.since = since;
+    toMeFilter.since = since;
+  }
   try {
     const [fromMe, toMe] = await Promise.all([
-      withTimeout(
-        pool.querySync(allRelays, {
-          kinds: [4],
-          authors: [myPubkey],
-          '#p': [otherPubkey],
-          limit,
-        }),
-        15000,
-      ),
-      withTimeout(
-        pool.querySync(allRelays, {
-          kinds: [4],
-          authors: [otherPubkey],
-          '#p': [myPubkey],
-          limit,
-        }),
-        15000,
-      ),
+      withTimeout(pool.querySync(allRelays, fromMeFilter), 15000),
+      withTimeout(pool.querySync(allRelays, toMeFilter), 15000),
     ]);
     const byId = new Map<string, RawDmEvent>();
     for (const ev of fromMe ?? []) byId.set(ev.id, ev as RawDmEvent);
@@ -631,16 +638,28 @@ export interface FetchedInboxEvents {
 export async function fetchInboxDmEvents(
   myPubkey: string,
   relays: string[],
-  options: { limit?: number } = {},
+  options: { limit?: number; since?: number } = {},
 ): Promise<FetchedInboxEvents> {
   const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
   trackRelays(allRelays);
   const limit = options.limit ?? 500;
+  // `since` shifted back 2 minutes (Damus clock-drift pad). All three
+  // inbox sub-queries share the same since floor: any relay that
+  // stamped an event slightly-in-our-past still returns it.
+  const since = options.since !== undefined ? Math.max(0, options.since - 120) : undefined;
+  const sentK4Filter: Filter = { kinds: [4], authors: [myPubkey], limit };
+  const recvK4Filter: Filter = { kinds: [4], '#p': [myPubkey], limit };
+  const wrapsFilter: Filter = { kinds: [1059], '#p': [myPubkey], limit };
+  if (since !== undefined) {
+    sentK4Filter.since = since;
+    recvK4Filter.since = since;
+    wrapsFilter.since = since;
+  }
   try {
     const [sentK4, receivedK4, wraps] = await Promise.all([
-      withTimeout(pool.querySync(allRelays, { kinds: [4], authors: [myPubkey], limit }), 15000),
-      withTimeout(pool.querySync(allRelays, { kinds: [4], '#p': [myPubkey], limit }), 15000),
-      withTimeout(pool.querySync(allRelays, { kinds: [1059], '#p': [myPubkey], limit }), 15000),
+      withTimeout(pool.querySync(allRelays, sentK4Filter), 15000),
+      withTimeout(pool.querySync(allRelays, recvK4Filter), 15000),
+      withTimeout(pool.querySync(allRelays, wrapsFilter), 15000),
     ]);
     const k4 = new Map<string, RawDmEvent>();
     for (const ev of sentK4 ?? []) k4.set(ev.id, ev as RawDmEvent);

--- a/src/utils/conversationSummaries.ts
+++ b/src/utils/conversationSummaries.ts
@@ -142,6 +142,11 @@ export function conversationPreview(s: ConversationSummary): string {
  * for legacy, 14 for NIP-17 chat, 15 for NIP-17 file.
  */
 export interface DmInboxEntry {
+  /** Event id (kind-4 event id, or kind-1059 wrap id for NIP-17). Load-
+   * bearing for inbox merge dedup — created_at is only second-resolution
+   * so two events from the same peer in the same second would collide
+   * on a (partnerPubkey, createdAt, wireKind) key. */
+  id: string;
   partnerPubkey: string;
   fromMe: boolean;
   createdAt: number;

--- a/src/utils/lru.ts
+++ b/src/utils/lru.ts
@@ -22,10 +22,24 @@ export class LRUCache<K, V> {
   private readonly map = new Map<K, V>();
 
   constructor(opts: LRUCacheOptions) {
+    // Reject malformed sizes up-front — `max=0` would evict on every
+    // set (making the cache useless); negatives would wrap via `>=`
+    // comparison and never evict. Fail loud so misconfigurations
+    // show up at construction, not silently degrade at runtime.
+    if (!Number.isInteger(opts.max) || opts.max < 1) {
+      throw new Error(`LRUCache: max must be a positive integer, got ${opts.max}`);
+    }
     this.max = opts.max;
     this.touchOnGet = opts.touchOnGet ?? true;
   }
 
+  /**
+   * Return the value for `key`, or `undefined` if absent. Use `has()`
+   * to disambiguate if a caller genuinely stores `undefined` values
+   * (this cache's current consumer — the NIP-04 plaintext pipeline —
+   * never stores `undefined`, since `null`-plaintext from a failed
+   * decrypt is filtered out before `set()`).
+   */
   get(key: K): V | undefined {
     const v = this.map.get(key);
     if (v === undefined) return undefined;
@@ -35,6 +49,10 @@ export class LRUCache<K, V> {
       this.map.set(key, v);
     }
     return v;
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
   }
 
   set(key: K, value: V): void {

--- a/src/utils/lru.ts
+++ b/src/utils/lru.ts
@@ -1,0 +1,62 @@
+/**
+ * Tiny Map-backed LRU cache. ~25 lines, zero dependencies, RN-safe
+ * (no `node:*` imports — the real `lru-cache` package pulls in
+ * `node:diagnostics_channel` since v11 which Metro can't resolve).
+ *
+ * Keeps the API minimal: get, set, delete, clear, size. Uses Map's
+ * insertion-order iteration for O(1) eviction of the oldest entry
+ * when `max` is hit (re-inserting on access to mark "recently used").
+ *
+ * Call `set(k, v)` on the read path to "touch" an existing entry —
+ * the standard `get` pattern does this when `touchOnGet` is true.
+ */
+export interface LRUCacheOptions {
+  max: number;
+  /** Re-insert the entry on `get` to mark it most-recently-used. Default: true. */
+  touchOnGet?: boolean;
+}
+
+export class LRUCache<K, V> {
+  private readonly max: number;
+  private readonly touchOnGet: boolean;
+  private readonly map = new Map<K, V>();
+
+  constructor(opts: LRUCacheOptions) {
+    this.max = opts.max;
+    this.touchOnGet = opts.touchOnGet ?? true;
+  }
+
+  get(key: K): V | undefined {
+    const v = this.map.get(key);
+    if (v === undefined) return undefined;
+    if (this.touchOnGet) {
+      // Re-insert to move to the end (most-recently-used position).
+      this.map.delete(key);
+      this.map.set(key, v);
+    }
+    return v;
+  }
+
+  set(key: K, value: V): void {
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    } else if (this.map.size >= this.max) {
+      // Evict least-recently-used (first inserted).
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) this.map.delete(oldest);
+    }
+    this.map.set(key, value);
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}

--- a/tests/perf/README.adoc
+++ b/tests/perf/README.adoc
@@ -24,7 +24,7 @@ Maestro-driven timing harness for three user-visible perf surfaces:
 1. Install Maestro: `curl -Ls "https://get.maestro.mobile.dev" \| bash`
 2. Plug in an Android device OR start an emulator (iOS not wired up yet — `adb` is assumed throughout).
 3. Install the app and sign in. The scripts expect your test identity to be following at least one friend (default: `Little Piggy`).
-4. If you want `thread-open.sh` to find a message reliably, the thread needs to contain text matching `$SEED` (default `[seed-`, which matches the `scripts/seed-dms.mjs` rumors). For real-world DMs override e.g. `SEED='Hello'`.
+4. `thread-open.sh` waits for the conversation to render at least one message body. By default it matches any non-empty body (the thread just needs to have messages); override `SEED` with a regex fragment if you want to pin on a specific string, e.g. `SEED='Hello'`. Maestro 2.3's text matcher is full-regex, so escape `[`, `.`, etc. as needed.
 
 The canonical test identities are `Little Piggy` and `Big Piggy`. `Big Piggy` follows `Little Piggy` and vice-versa; both have 200 seeded DMs in their thread. Use Big Piggy as the logged-in user and `PEER='Little Piggy'` to exercise the inbound-decrypt path.
 

--- a/tests/perf/README.adoc
+++ b/tests/perf/README.adoc
@@ -1,0 +1,71 @@
+= Perf scripts
+
+Maestro-driven timing harness for three user-visible perf surfaces:
+
+[cols="1,3"]
+|===
+|Script |Measures
+
+|`cold-launch.sh`
+|Force-stop → launch → Home visible. BootSplash dwell + WalletContext boot + first render.
+
+|`tab-nav.sh`
+|Home ↔ Messages ↔ Learn ↔ Friends transitions. Tap → content-visible latency per tab; logs GC pressure and `[Perf]` markers during the walk.
+
+|`thread-open.sh`
+|Cold-cache vs warm-cache conversation open. Reports `[Perf] fetchConversation` lines so you can confirm `hits`/`fresh` decrypt counters.
+
+|`run-all.sh`
+|Chains the three above.
+|===
+
+== Setup
+
+1. Install Maestro: `curl -Ls "https://get.maestro.mobile.dev" \| bash`
+2. Plug in an Android device OR start an emulator (iOS not wired up yet — `adb` is assumed throughout).
+3. Install the app and sign in. The scripts expect your test identity to be following at least one friend (default: `Little Piggy`).
+4. If you want `thread-open.sh` to find a message reliably, the thread needs to contain text matching `$SEED` (default `[seed-`, which matches the `scripts/seed-dms.mjs` rumors). For real-world DMs override e.g. `SEED='Hello'`.
+
+The canonical test identities are `Little Piggy` and `Big Piggy`. `Big Piggy` follows `Little Piggy` and vice-versa; both have 200 seeded DMs in their thread. Use Big Piggy as the logged-in user and `PEER='Little Piggy'` to exercise the inbound-decrypt path.
+
+== Usage
+
+[source,bash]
+----
+# Defaults: DEVICE=<first attached>, PKG=com.lightningpiggy.app, PEER="Little Piggy", GREETING="Hello", SEED="[seed-"
+bash tests/perf/run-all.sh
+
+# Override for a dev build
+PKG=com.lightningpiggy.app.dev bash tests/perf/tab-nav.sh
+
+# Different peer (must be visible in your Messages list)
+PEER="Alice" SEED="gm" bash tests/perf/thread-open.sh
+
+# Pin a specific device when you have multiple attached
+DEVICE=emulator-5554 bash tests/perf/cold-launch.sh
+----
+
+== Output
+
+Each step prints `<label> <elapsed ms> <OK|FAIL>`.
+
+`tab-nav.sh` and `thread-open.sh` additionally capture logcat and dump any `[Perf]` markers at the end. On a cold cache you should see:
+
+[source]
+----
+[Perf] fetchConversation(abcd1234): 2341ms, k4=5, k1059=50, hits=0, fresh=50, rendered=55
+----
+
+On a second open of the same thread:
+
+[source]
+----
+[Perf] fetchConversation(abcd1234): 38ms, k4=5, k1059=50, hits=50, fresh=0, rendered=55
+----
+
+== When a step FAILs
+
+The Maestro output is dumped to `/tmp/piggy-perf/_maestro.out` (override the dir with `LOGDIR=`). Typical failures:
+
+* `extendedWaitUntil timed out` — the app didn't reach the expected state within the budget. Usually means a regression (step took longer than 30 s) or the wrong text/testID is being waited on. Check whether the screen actually renders the text you're looking for.
+* `tapOn: element not visible` — the selector didn't match. Verify `$PEER` / `$GREETING` / `$SEED` match what's on-screen.

--- a/tests/perf/cold-launch.sh
+++ b/tests/perf/cold-launch.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Cold-launch perf: force-stop → launch → Home tab content visible.
+# Exercises BootSplash dwell, WalletContext boot, NWC enable deferral,
+# and the first render of the Home carousel.
+set +e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+echo "=== COLD LAUNCH ($PKG on $DEVICE) ==="
+adb -s "$DEVICE" shell am force-stop "$PKG"
+sleep 1
+
+cat > "$LOGDIR/_cold.yaml" <<EOF
+appId: $PKG
+---
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'tab-home'
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      text: '$GREETING'
+    timeout: 30000
+EOF
+
+time_step "cold-launch → $GREETING" "$LOGDIR/_cold.yaml"

--- a/tests/perf/cold-launch.sh
+++ b/tests/perf/cold-launch.sh
@@ -21,7 +21,7 @@ appId: $PKG
     timeout: 30000
 - extendedWaitUntil:
     visible:
-      text: '$GREETING'
+      text: '${GREETING}.*'
     timeout: 30000
 EOF
 

--- a/tests/perf/lib.sh
+++ b/tests/perf/lib.sh
@@ -6,8 +6,10 @@
 #   PKG      - Android package id (default: com.lightningpiggy.app)
 #   PEER     - display name of a followed test peer, e.g. "Little Piggy"
 #   GREETING - text guaranteed to render on Home (e.g. "Hello" from greeting)
-#   SEED     - a substring unique to a message in the chosen thread
-#              (default "[seed-" — matches the in-repo seed-script rumors)
+#   SEED     - regex fragment matching text unique to a message body in
+#              the chosen thread (default empty → matches any rendered
+#              body). Must be regex-safe: Maestro 2.3's text matcher
+#              is full-regex, so escape `[`, `.`, etc. as needed.
 #
 # Requires: adb, maestro, awk, date(+%s%N).
 
@@ -17,7 +19,7 @@ DEVICE="${DEVICE:-$(adb devices | awk 'NR>1 && $2=="device" { print $1; exit }')
 PKG="${PKG:-com.lightningpiggy.app}"
 PEER="${PEER:-Little Piggy}"
 GREETING="${GREETING:-Hello}"
-SEED="${SEED:-[seed-}"
+SEED="${SEED:-}"
 
 if [ -z "$DEVICE" ]; then
   echo "No adb device attached. Plug in / start an emulator and retry." >&2

--- a/tests/perf/lib.sh
+++ b/tests/perf/lib.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Shared helpers for Maestro-driven perf scripts. Sourced, not executed.
+#
+# Env knobs (override at the call site):
+#   DEVICE   - adb device serial (default: first attached device)
+#   PKG      - Android package id (default: com.lightningpiggy.app)
+#   PEER     - display name of a followed test peer, e.g. "Little Piggy"
+#   GREETING - text guaranteed to render on Home (e.g. "Hello" from greeting)
+#   SEED     - a substring unique to a message in the chosen thread
+#              (default "[seed-" — matches the in-repo seed-script rumors)
+#
+# Requires: adb, maestro, awk, date(+%s%N).
+
+set +e
+
+DEVICE="${DEVICE:-$(adb devices | awk 'NR>1 && $2=="device" { print $1; exit }')}"
+PKG="${PKG:-com.lightningpiggy.app}"
+PEER="${PEER:-Little Piggy}"
+GREETING="${GREETING:-Hello}"
+SEED="${SEED:-[seed-}"
+
+if [ -z "$DEVICE" ]; then
+  echo "No adb device attached. Plug in / start an emulator and retry." >&2
+  exit 1
+fi
+
+LOGDIR="${LOGDIR:-/tmp/piggy-perf}"
+mkdir -p "$LOGDIR"
+
+now_ns() { date +%s%N; }
+now_hms() { date '+%H:%M:%S'; }
+
+run_maestro() {
+  # Usage: run_maestro <yaml>. Returns maestro's exit code.
+  maestro --device "$DEVICE" test "$1" > "$LOGDIR/_maestro.out" 2>&1
+}
+
+require_app_running() {
+  local pid
+  pid=$(adb -s "$DEVICE" shell pidof "$PKG" | tr -d '\r')
+  if [ -z "$pid" ]; then
+    echo "App $PKG not running on $DEVICE. Launch it manually and retry." >&2
+    exit 1
+  fi
+  echo "$pid"
+}
+
+start_logcat() {
+  # Usage: start_logcat <pid> <logfile>. Sets LOGCAT_PID.
+  local pid="$1" logfile="$2"
+  adb -s "$DEVICE" logcat -c
+  adb -s "$DEVICE" logcat --pid="$pid" -v time > "$logfile" 2>&1 &
+  LOGCAT_PID=$!
+}
+
+stop_logcat() {
+  [ -n "${LOGCAT_PID:-}" ] && kill "$LOGCAT_PID" 2>/dev/null
+}
+
+# Emit one timed step row: "<label> <ms> <OK/FAIL>".
+# Args: <label> <yaml-path>
+time_step() {
+  local label="$1" yaml="$2"
+  local t0 t1 ms rc
+  t0=$(now_ns)
+  run_maestro "$yaml"; rc=$?
+  t1=$(now_ns)
+  ms=$(( (t1 - t0) / 1000000 ))
+  local status=OK
+  [ $rc -ne 0 ] && status=FAIL
+  printf "%-22s  %6d ms  %s\n" "$label" "$ms" "$status"
+}

--- a/tests/perf/run-all.sh
+++ b/tests/perf/run-all.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Convenience wrapper: cold-launch → tab-nav → thread-open.
+# Each sub-script is self-contained; this one just chains them and
+# prints a header between runs.
+set +e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+banner() { printf "\n\n##### %s #####\n\n" "$1"; }
+
+banner "1/3 COLD LAUNCH"
+bash "$SCRIPT_DIR/cold-launch.sh"
+
+banner "2/3 TAB NAV"
+bash "$SCRIPT_DIR/tab-nav.sh"
+
+banner "3/3 THREAD OPEN"
+bash "$SCRIPT_DIR/thread-open.sh"

--- a/tests/perf/tab-nav.sh
+++ b/tests/perf/tab-nav.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Warm tab-navigation perf: drives Home → Messages → Learn → Friends → Messages,
+# timing each transition end-to-end (tap → content visible) and correlating
+# logcat GC + [Perf] markers to each window.
+#
+# Prereq: app is running, user is logged in, at least one friend named $PEER
+# is visible in Messages.
+set +e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+echo "=== WARM TAB NAV ($PKG on $DEVICE, peer=$PEER) ==="
+PID=$(require_app_running)
+
+LOG="$LOGDIR/tab-nav.log"
+start_logcat "$PID" "$LOG"
+trap stop_logcat EXIT
+
+printf "\n%-22s  %-10s  %s\n" "STEP" "ELAPSED" "STATUS"
+printf "%-22s  %-10s  %s\n"   "----"  "-------"  "------"
+
+# Return the app to Home first so the walk starts from a known state.
+cat > "$LOGDIR/_home.yaml" <<EOF
+appId: $PKG
+---
+- tapOn:
+    id: 'tab-home'
+- extendedWaitUntil:
+    visible:
+      text: '$GREETING'
+    timeout: 10000
+EOF
+time_step "reset → home"         "$LOGDIR/_home.yaml"
+
+for step in "messages:Messages" "learn:Learn" "friends:Friends" "messages:Messages" "home:$GREETING"; do
+  tab="${step%%:*}"
+  text="${step##*:}"
+  cat > "$LOGDIR/_t.yaml" <<EOF
+appId: $PKG
+---
+- tapOn:
+    id: 'tab-$tab'
+- extendedWaitUntil:
+    visible:
+      text: '$text'
+    timeout: 30000
+EOF
+  time_step "tab → $tab" "$LOGDIR/_t.yaml"
+done
+
+echo
+echo "=== [Perf] markers during run ==="
+grep "\[Perf\]" "$LOG" | tail -20
+echo
+echo "=== GC count during run ==="
+grep -c "Background .* GC" "$LOG"

--- a/tests/perf/tab-nav.sh
+++ b/tests/perf/tab-nav.sh
@@ -21,6 +21,8 @@ printf "\n%-22s  %-10s  %s\n" "STEP" "ELAPSED" "STATUS"
 printf "%-22s  %-10s  %s\n"   "----"  "-------"  "------"
 
 # Return the app to Home first so the walk starts from a known state.
+# Maestro 2.3 treats `text:` as a full-regex match (not substring), so
+# dynamic greetings like "Hello, <name>!" need a `.*` suffix.
 cat > "$LOGDIR/_home.yaml" <<EOF
 appId: $PKG
 ---
@@ -28,12 +30,14 @@ appId: $PKG
     id: 'tab-home'
 - extendedWaitUntil:
     visible:
-      text: '$GREETING'
+      text: '${GREETING}.*'
     timeout: 10000
 EOF
 time_step "reset → home"         "$LOGDIR/_home.yaml"
 
-for step in "messages:Messages" "learn:Learn" "friends:Friends" "messages:Messages" "home:$GREETING"; do
+# Each pair: tab-id : text-pattern (full-regex, so tab labels are exact
+# matches and the Home greeting gets a `.*`).
+for step in "messages:Messages" "learn:Learn" "friends:Friends" "messages:Messages" "home:${GREETING}.*"; do
   tab="${step%%:*}"
   text="${step##*:}"
   cat > "$LOGDIR/_t.yaml" <<EOF

--- a/tests/perf/thread-open.sh
+++ b/tests/perf/thread-open.sh
@@ -17,6 +17,8 @@ LOG="$LOGDIR/thread-open.log"
 start_logcat "$PID" "$LOG"
 trap stop_logcat EXIT
 
+# Maestro 2.3 treats `text:` as a full-regex match, not substring, so
+# partner / seed markers get a `.*` suffix to match longer body text.
 # Navigate to Messages first (idempotent).
 cat > "$LOGDIR/_msgs.yaml" <<EOF
 appId: $PKG
@@ -25,7 +27,7 @@ appId: $PKG
     id: 'tab-messages'
 - extendedWaitUntil:
     visible:
-      text: '$PEER'
+      text: '${PEER}.*'
     timeout: 15000
 EOF
 time_step "goto messages" "$LOGDIR/_msgs.yaml"
@@ -34,10 +36,10 @@ cat > "$LOGDIR/_open.yaml" <<EOF
 appId: $PKG
 ---
 - tapOn:
-    text: '$PEER'
+    text: '${PEER}.*'
 - extendedWaitUntil:
     visible:
-      text: '$SEED'
+      text: '.*${SEED}.*'
     timeout: 60000
 EOF
 

--- a/tests/perf/thread-open.sh
+++ b/tests/perf/thread-open.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Conversation-open perf: cold cache vs warm cache thread open.
+# Open 1 = tap peer row → wait for $SEED text (first decrypt round-trip).
+# Open 2 = back to Messages, tap again → wait for $SEED (cache hit).
+#
+# The [Perf] fetchConversation log line shows hits= / fresh= counters —
+# cold should be hits=0 fresh=N, warm should be hits≈N fresh=0.
+set +e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+echo "=== THREAD OPEN ($PKG on $DEVICE, peer=$PEER) ==="
+PID=$(require_app_running)
+
+LOG="$LOGDIR/thread-open.log"
+start_logcat "$PID" "$LOG"
+trap stop_logcat EXIT
+
+# Navigate to Messages first (idempotent).
+cat > "$LOGDIR/_msgs.yaml" <<EOF
+appId: $PKG
+---
+- tapOn:
+    id: 'tab-messages'
+- extendedWaitUntil:
+    visible:
+      text: '$PEER'
+    timeout: 15000
+EOF
+time_step "goto messages" "$LOGDIR/_msgs.yaml"
+
+cat > "$LOGDIR/_open.yaml" <<EOF
+appId: $PKG
+---
+- tapOn:
+    text: '$PEER'
+- extendedWaitUntil:
+    visible:
+      text: '$SEED'
+    timeout: 60000
+EOF
+
+cat > "$LOGDIR/_back.yaml" <<EOF
+appId: $PKG
+---
+- pressKey: back
+- extendedWaitUntil:
+    visible:
+      text: 'Messages'
+    timeout: 10000
+EOF
+
+echo
+time_step "open 1 (cold)"  "$LOGDIR/_open.yaml"
+time_step "back to inbox"  "$LOGDIR/_back.yaml"
+time_step "open 2 (warm)"  "$LOGDIR/_open.yaml"
+
+echo
+echo "=== [Perf] fetchConversation lines ==="
+grep "\[Perf\] fetchConversation" "$LOG" | tail -5


### PR DESCRIPTION
Rolls up the DM / app-boot / list-render perf work investigated against a 200-DM test inbox and my real Nostr inbox of 986 messages on a Pixel 8 over 4G. Ships 13 commits with empirical before/after numbers captured in logcat via the new `[Perf]` markers.

## Headline numbers (real Pixel 8, 4G, 986-message inbox)

| Action | Before | After | Change |
|---|---|---|---|
| `refreshDmInbox` (warm cache) | 7011 ms | **3073 ms** | −56% |
| Relay payload (kind-4 returned) | 227 events | **13 events** | −94% via `since` delta |
| `fetchConversation` on a warm-cache thread | ~6.3 s | **~1 s** (`skippedFetch=true`) | gift-wrap inbox poll removed when cache covers it |
| Fresh decrypts on 2nd thread open | 25 | **0** | LRU hits 100% |
| Messages tab: rows in inbox | 26 rendered | 986 rendered | load-bearing follow filter preserved |

## Commits

1. `020e827` **perf(nostr): NIP-04 plaintext LRU cache + parallel decrypt + inbox TTL** — module-level `LRUCache<eventId, plaintext>` (`max:1000`), swap the serial `for-await-decrypt` loop for `Promise.all(batches of 15)` with `setTimeout(0)` yields, and 30-second TTL on `refreshDmInbox` so Messages-tab bouncing doesn't re-fire relay queries. Uses a 25-line `src/utils/lru.ts` instead of the `lru-cache` npm package (v11 imports `node:diagnostics_channel` which Metro can't resolve).
2. `890e53c` **perf(nostr): persist inbox + conversation + since-delta relay fetch** — keys the DM inbox and every per-peer conversation into AsyncStorage (user-scoped), caps 1000/500 newest, injects `since = max(cached) - 120` (Damus's 2-min clock-drift pad) into every relay filter. Steady-state payload shrinks from "up to `limit=200` per direction" to "just the delta since last open."
3. `5e806ea` **perf(app-open): pig splash + 600ms hold** — `app.config.ts` splash asset swapped to the Lightning Piggy pig + brand-pink background; plus a JS `BootSplash` overlay held for 600 ms from JS-mount so the native-splash → JS handoff never shows the plain-pink loading frame.
4. `fe392ce` **perf(wallet): unblock UI boot on cached balances** — `WalletProvider` flips `isLoading=false` BEFORE awaiting the `Promise.all(nwcService.connect(...))`. Wallets hydrate from AsyncStorage cache; each NWC handshake runs in the background and patches state individually as it completes. Saves up to 14 s × N-wallets of pink-loading screen on cold launch.
5. `e27b885` **perf(messages): window conversation FlatList** — `initialNumToRender={20}` + `maxToRenderPerBatch={10}` + `windowSize={10}` so a thread with hundreds of messages doesn't mount every bubble at first paint.
6. `3b36e66` **perf(messages): instant-paint cached conversation + explicit keyboard-height padding** — new `getCachedConversation(peer)` on NostrContext lets ConversationScreen `setMessages(cached)` synchronously on mount so threads render within one frame instead of waiting on the relay round-trip. Also replaces KeyboardAvoidingView with the explicit `Keyboard.addListener` + `paddingBottom` pattern because Android 15+ edge-to-edge breaks all three KAV behaviors.
7. `dc6c6bf` **fix(messages): await refreshContacts before refreshDmInbox on pull-to-refresh** — the old `Promise.all` raced: the DM fetch captured a stale `followPubkeys` closure before the contacts fetch updated state, and any new-since-last-refresh followers' messages were dropped by the follow gate.
8. `64fbd81` **perf(messages): bail out of fetchConversation state updates when screen unmounts** — `isMountedRef` gate so back-press during a 6-12 s cold fetch stops state updates on the unmounted component. Tap events don't queue behind wasted work any more.
9. `0b4f229` **fix(messages): remove removeClippedSubviews from inverted conversation list** — known RN bug: that prop + `inverted` mis-reports `contentOffset.y` on Android, so the scroll-to-bottom FAB flashed on when the user was already at the newest message.
10. `425d4c2` **perf(messages): skip fetchInboxDmEvents inside fetchConversation when NIP-17 wrap cache is populated** — `refreshDmInbox` already writes decrypted wraps to the per-signer cache; fetchConversation reads that cache, serves peer-matching wraps directly, and skips the 6-s inbox-wide relay fetch entirely. **Closes #190.**
11. `44e3cbf` **perf(nav): defer useFocusEffect refreshes via InteractionManager** — Home / Messages / Friends each fire a refresh on focus; wrapping each in `InteractionManager.runAfterInteractions(...)` with `.cancel()` on cleanup lets the tab transition animation complete before the refresh claims the JS thread.

## Also in the branch

- `docs/TROUBLESHOOTING.adoc` updates from earlier sibling PRs already landed on main.
- New perf instrumentation: `[Perf] fetchConversation` and `[Perf] refreshDmInbox` lines unconditionally logged (no `__DEV__` guard) so logcat-grepping a production APK shows cache-hit vs fresh-decrypt counts directly.
- Research sub-agents crib patterns from Damus (`HomeModel.swift` `sinceOptimization`) and Arcade's `arclib` (`since = db.latest`, module-level LRU, `db_only=true` instant-render). See #188 / #189 / #190 for the patterns not (yet) applied.

## Closes

- Closes #190

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] Verified on emulator (dev APK, Metro live-reload) — all `[Perf]` markers populated, cache warm/cold behaviour matches the numbers above.
- [x] Verified on Pixel 8 / 4G (versionCode 12) — 986-DM real inbox rendered; second Messages-tab visit 3 s steady-state; no regressions in existing flows.
- [ ] Maestro suite (`tests/e2e/`) pass — hasn't been rerun against this branch yet (previous branch runs passed prior to these 13 commits).
- [ ] Native rebuild required to pick up the splash asset change (JS overlay works immediately).

## Known follow-ups (filed as separate issues)

- #188 — replace `pool.querySync` with persistent relay subscription (~4 h architectural)
- #189 — BitmapFactory `unimplemented` decode flood on unsupported avatar formats (~1 h)
- Potential follow-up: `react-native-mmkv` swap for AsyncStorage on DM caches (~2 h, marginal at current inbox sizes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)