### PR TITLE
docs(deployment): document local production builds + signing gotcha

### DIFF
--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -65,7 +65,7 @@ APP_VARIANT=development npx expo run:android
 npx expo run:android
 ----
 
-==== Dogfooding: local production build → owner's Pixel (fast loop)
+==== Dogfooding: local production build → physical Android device (fast loop)
 
 When you want to ship a working release to your own device **without**
 cutting a formal GitHub Release (TestFlight / Play are not yet wired,

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -58,12 +58,79 @@ Build profiles are defined in `eas.json`:
 
 [source,bash]
 ----
-# Development build for Android
+# Development build for Android — Metro-dependent, for active JS hacking
 APP_VARIANT=development npx expo run:android
 
-# Production-like build
+# Production-like build via Expo (convenience wrapper)
 npx expo run:android
 ----
+
+==== Dogfooding: local production build → owner's Pixel (fast loop)
+
+When you want to ship a working release to your own device **without**
+cutting a formal GitHub Release (TestFlight / Play are not yet wired,
+and the phone already has an EAS-signed `com.lightningpiggy.app`
+install you don't want to lose data on):
+
+[source,bash]
+----
+# Build locally but with EAS's production keystore, so the APK is
+# sig-compatible with whatever's already on the phone. APK lands at
+# android/app/build/outputs/apk/release/app-release.apk.
+#
+# EXPO_NO_DOCTOR=1 skips the pre-flight version-compatibility checker
+# which is noisy on minor-mismatch deps and not relevant to signing.
+EXPO_NO_DOCTOR=1 eas build --local --platform android --profile production --non-interactive
+
+# Install over the existing app — preserves user data (Nostr nsec,
+# wallet pairings, conversation cache).
+adb -s <device-serial> install -r android/app/build/outputs/apk/release/app-release.apk
+----
+
+Build time: ~10-15 min fresh, ~2-3 min on a warm gradle cache. No
+cloud queue, no Metro, no fresh-login required on the device.
+
+===== Verify the install actually committed
+
+`adb install -r` can print `Performing Streamed Install / Success`
+for the file-transfer phase even when the install-commit is
+rejected. Always tail the **full** adb output (not `tail -3`), and
+cross-check the on-device state:
+
+[source,bash]
+----
+# Confirm lastUpdateTime is now (not hours ago) + versionCode matches
+# what you just built. If lastUpdateTime hasn't moved, the install
+# DIDN'T land — check for INSTALL_FAILED_* lines in the adb output.
+adb -s <serial> shell dumpsys package com.lightningpiggy.app | \
+  grep -E "versionCode|lastUpdateTime"
+----
+
+==== Why `./gradlew assembleRelease` + `adb install -r` silently fails
+
+Running `cd android && ./gradlew :app:assembleRelease` directly works
+*and* produces a smaller/faster build — but the APK is signed with
+the local `android/app/debug.keystore`, NOT the EAS-managed keystore
+that produced the install currently on your Pixel. Different
+signatures → Android rejects the install as
+`INSTALL_FAILED_UPDATE_INCOMPATIBLE`, with no way to `-r` over it
+short of uninstalling (which wipes user data).
+
+Three options if you really want gradle-direct builds in the loop:
+
+1. **Use `eas build --local`** (above) — slower but keystore-correct.
+2. **Download the EAS production keystore locally once** via
+   `eas credentials -p android`, point `signingConfigs.release` at
+   it in `android/app/build.gradle`. Subsequent `./gradlew
+   :app:assembleRelease` runs produce EAS-signed APKs. Keystore file
+   must not be committed (`*.jks` is already in `.gitignore`).
+3. **Uninstall and reinstall** — loses data on the target device.
+
+Issue #194's fix took longer than it should have because I was
+running `./gradlew assembleRelease` + `adb install -r` and trusting
+the "Success" output. The APK never landed; all subsequent "tests"
+were against the pre-fix install. Moral: verify lastUpdateTime or
+use `eas build --local`.
 
 === Release workflow
 
@@ -529,8 +596,11 @@ The app uses custom Expo config plugins to modify native project settings during
 |===
 | Plugin | Purpose
 
+| `react-native-edge-to-edge`
+| Swaps AppTheme's parent to `Theme.EdgeToEdge` and attaches the root `WindowInsetsCompat` listener. Required on Android 15+ — without it, the system stops dispatching the IME inset to RN (every keyboard API silently reads 0), and the conversation composer stays hidden under the docked keyboard (#194). Paired with `<KeyboardProvider>` + RNKC's `KeyboardStickyView` in `ConversationScreen.tsx`.
+
 | `withAdjustResize`
-| Sets `android:windowSoftInputMode="adjustResize"` in AndroidManifest.xml. Required for bottom sheets to slide up correctly when the keyboard opens.
+| Sets `android:windowSoftInputMode="adjustResize"` in AndroidManifest.xml. Required for bottom sheets to slide up correctly when the keyboard opens. Retained alongside `react-native-edge-to-edge` because pre-Android-15 devices still use the classic resize path.
 
 | `withAmberQueries`
 | Adds the Amber signer package to the `<queries>` element in AndroidManifest.xml. Required on Android 11+ for the app to detect and communicate with Amber via NIP-55 intents.

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -126,11 +126,10 @@ Three options if you really want gradle-direct builds in the loop:
    must not be committed (`*.jks` is already in `.gitignore`).
 3. **Uninstall and reinstall** — loses data on the target device.
 
-Issue #194's fix took longer than it should have because I was
-running `./gradlew assembleRelease` + `adb install -r` and trusting
-the "Success" output. The APK never landed; all subsequent "tests"
-were against the pre-fix install. Moral: verify lastUpdateTime or
-use `eas build --local`.
+Running `./gradlew assembleRelease` + `adb install -r` can appear
+to succeed while leaving the previous install in place, so
+subsequent tests may still be exercising the pre-fix app. Verify
+`lastUpdateTime` after install, or use `eas build --local`.
 
 === Release workflow
 

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -84,7 +84,7 @@ EXPO_NO_DOCTOR=1 eas build --local --platform android --profile production --non
 
 # Install over the existing app — preserves user data (Nostr nsec,
 # wallet pairings, conversation cache).
-adb -s <device-serial> install -r android/app/build/outputs/apk/release/app-release.apk
+adb -s <serial> install -r android/app/build/outputs/apk/release/app-release.apk
 ----
 
 Build time: ~10-15 min fresh, ~2-3 min on a warm gradle cache. No


### PR DESCRIPTION
## Summary

Extends `docs/DEPLOYMENT.adoc` with:

- A **"Dogfooding: local production build → owner's Pixel"** section documenting the `eas build --local --profile production` + `adb install -r` workflow. That's what you actually want when iterating on an early-release version of an already-installed app without losing user data — it's not TestFlight, not cloud, not `./gradlew assembleRelease`.
- A warning about the **silent-install trap**: `./gradlew assembleRelease` + `adb install -r` *appears* to succeed but is rejected by Android when the local debug keystore doesn't match the EAS-managed keystore on the installed app. This cost real hours during #194 — documenting it so the next person (or future-me) doesn't re-burn the time.
- How to **verify** an install actually committed (cross-check `versionCode` + `lastUpdateTime` via `dumpsys package`).
- `react-native-edge-to-edge` added to the Expo Config Plugins table (introduced in #195 for Android 15+ keyboard inset dispatch).

## Test plan

- [ ] Render the AsciiDoc locally / on GitHub and eyeball
- [ ] Links resolve
- [ ] `EXPO_NO_DOCTOR=1 eas build --local ...` command runs as-documented from a clean clone