### PR TITLE
fix(lnbits-patch): stop nwcprovider pay_invoice flood on failed payments

### DIFF
--- a/scripts/fix_nwcprovider_pay_loop.py
+++ b/scripts/fix_nwcprovider_pay_loop.py
@@ -1,0 +1,89 @@
+"""Fix nwcprovider `_process_invoice` tight-loop flood.
+
+Root cause in upstream `lnbits/nwcprovider` (file: `tasks.py`,
+function: `_process_invoice`): the post-pay wait-for-preimage loop
+only exits on `.success`, so any NWC `pay_invoice` that resolves to
+`.failed` (e.g. LND's FAILURE_REASON_INCORRECT_PAYMENT_DETAILS on an
+expired invoice) re-queries `check_transaction_status` every 50 ms
+indefinitely, until the client disconnects or the container restarts.
+
+Observed symptom: continuous ~20/s `LNDRest Payment failed: …` log
+lines with no `checking_id` for hours after the underlying payment
+was already persisted as `status=failed` in the DB.
+
+Upstream is unpatched as of 2026-04-24 (no issue, no PR). Vanilla
+nwcprovider `tasks.py` on lnbits/nwcprovider main has identical
+code. Local patch just adds a `.failed` break and a bounded
+300 s deadline — minimal, reversible, preserves the existing
+return shape.
+
+Run inside the lnbits-family container (same shape as
+`apply_nip20_fix.py` / `fix_lnbits_inflight.py`):
+
+    docker cp scripts/fix_nwcprovider_pay_loop.py lnbits-family:/tmp/
+    docker exec lnbits-family python3 /tmp/fix_nwcprovider_pay_loop.py
+    docker restart lnbits-family
+
+Idempotent — running it twice is a no-op.
+"""
+
+import sys
+
+PATH = "/app/lnbits/extensions/nwcprovider/tasks.py"
+
+with open(PATH, "r") as f:
+    content = f.read()
+
+# The exact vanilla-upstream block we expect to replace.
+OLD = '''    wait_for_preimage = (
+        True  # currently required by nip 47 specs, might change in future
+    )
+    payment_status: PaymentStatus | None = None
+    while wait_for_preimage:
+        payment_status = await check_transaction_status(wallet_id, payment_hash)
+        if payment_status.success:
+            break
+        await asyncio.sleep(0.05)'''
+
+# Replacement: exit on `.failed`, bound the wait to 300 s. Existing
+# return-shape below the loop already handles payment_status.paid=False
+# correctly, so a graceful `.failed` exit just drops through.
+NEW = '''    wait_for_preimage = (
+        True  # currently required by nip 47 specs, might change in future
+    )
+    payment_status: PaymentStatus | None = None
+    # Local patch: break on .failed (previously only broke on .success,
+    # causing a 20 RPS flood of get_payment_status queries against the
+    # funding source when a payment resolves to failed). Also apply a
+    # hard deadline as a defence-in-depth against any other stuck state.
+    # See scripts/fix_nwcprovider_pay_loop.py docstring.
+    import time as _time
+    _deadline = _time.monotonic() + 300
+    while wait_for_preimage:
+        payment_status = await check_transaction_status(wallet_id, payment_hash)
+        if payment_status.success:
+            break
+        if payment_status.failed:
+            break
+        if _time.monotonic() > _deadline:
+            break
+        await asyncio.sleep(0.05)'''
+
+MARKER = "Local patch: break on .failed"
+
+if MARKER in content:
+    print("Already patched — no-op.")
+    sys.exit(0)
+
+if OLD not in content:
+    print("ERROR: could not find the expected vanilla block in", PATH)
+    print(
+        "       upstream nwcprovider/tasks.py may have changed shape. "
+        "Re-derive the patch against the current source."
+    )
+    sys.exit(1)
+
+content = content.replace(OLD, NEW)
+with open(PATH, "w") as f:
+    f.write(content)
+print("Patch applied:", PATH)


### PR DESCRIPTION
## Summary

Adds a new local patch script, `scripts/fix_nwcprovider_pay_loop.py`, in the same style as `fix_lnbits_inflight.py` and `apply_nip20_fix.py`.

## The bug

`lnbits/nwcprovider` — `tasks.py::_process_invoice` waits for the payment preimage in a post-`pay_invoice` loop that only exits on `.success`:

```python
while wait_for_preimage:
    payment_status = await check_transaction_status(wallet_id, payment_hash)
    if payment_status.success:
        break
    await asyncio.sleep(0.05)
```

If the underlying backend resolves the payment to `.failed` (e.g. LND returns `FAILURE_REASON_INCORRECT_PAYMENT_DETAILS` on an expired BOLT11), the loop never terminates — it keeps calling `check_transaction_status()` 20×/s indefinitely, until the NWC client disconnects or the container is restarted.

## Observed impact

On our `lnbits-family` instance this manifested as a ~7-hour log flood of:

```
LNDRest Payment failed: FAILURE_REASON_INCORRECT_PAYMENT_DETAILS
LNDRest Payment failed: FAILURE_REASON_INCORRECT_PAYMENT_DETAILS
... (~18 per second)
```

with no `checking_id` in the log format. The underlying payment row was already persisted as `status=failed` in the DB; the flood was the NWC handler's post-pay wait loop spinning on a failed status it didn't know how to exit on.

## Root cause confirmed upstream

Checked `lnbits/nwcprovider` main — identical vanilla code, no open issue, no PR. This is a novel upstream bug.

## Patch

- Add `if payment_status.failed: break` to the loop.
- Add 300 s hard deadline (defence-in-depth).
- Existing post-loop `return` shape already handles `paid=False`, so no additional plumbing.

The delta is ~9 lines; see `scripts/fix_nwcprovider_pay_loop.py`.

## Verification

Applied to `lnbits-family` container and restarted:

- Patch is present in `/app/lnbits/extensions/nwcprovider/tasks.py` ✅
- Post-restart 30 s window: **0 `Payment failed` log lines** (previously ~540 in the same window during the flood) ✅
- Container log volume back to baseline noise levels (71 lines/30 s vs 935 lines/min during flood)

## How to apply after rebuilding / updating the container

```
docker cp scripts/fix_nwcprovider_pay_loop.py lnbits-family:/tmp/
docker exec lnbits-family python3 /tmp/fix_nwcprovider_pay_loop.py
docker restart lnbits-family
```

The script is idempotent (no-op on second run) and has a recognizable marker comment so the patched block is easy to spot.

## Follow-ups (not in this PR)

- File an upstream issue + PR to `lnbits/nwcprovider` with this diagnosis + diff, so the local patch can be retired.
- Consider adding a README entry in `scripts/` summarizing the stacked lnbits patches in one place.

## Test plan

- [ ] Script applies cleanly to a fresh `lnbits-family` container (verified)
- [ ] Container restarts cleanly with patch in place (verified)
- [ ] No `Payment failed` log flood in normal operation (verified — 0 in 30 s)
- [ ] Next time we do an NWC pay_invoice that routes-fails end-to-end, confirm the flood does NOT return (pending — needs a deliberate expired/bad invoice to trigger)