### PR TITLE
release: build Android in workflow + attach APK + clarify version numbering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,12 @@ on:
       platform:
         description: Platform(s) to release
         type: choice
-        default: ios   # flip to `all` once Google Play account + service account JSON are wired up via `eas credentials`
+        # iOS auto-submits to TestFlight (ASC API key on EAS). Android
+        # builds an APK that the `attach-android-apk` job downloads and
+        # attaches to the GitHub Release — no auto-submit to Play until
+        # a Google Play account + service-account JSON are wired up via
+        # `eas credentials` (see docs/DEPLOYMENT.adoc).
+        default: all
         options: [ios, android, all]
 
 concurrency:
@@ -78,17 +83,35 @@ jobs:
       - name: Resolve platform
         id: platform
         run: |
-          # On Release events the input is empty, so fall back to ios-only until
-          # we wire up Google Play credentials. Switch to 'all' when ready.
-          echo "value=${{ github.event.inputs.platform || 'ios' }}" >> "$GITHUB_OUTPUT"
+          # On Release events the input is empty, so default to building
+          # both platforms. iOS is auto-submitted to TestFlight; Android
+          # is built only (no Google Play submit until creds wired), then
+          # the attach-android-apk job downloads the APK and attaches it
+          # to the Release page for sideloading.
+          echo "value=${{ github.event.inputs.platform || 'all' }}" >> "$GITHUB_OUTPUT"
 
-      - name: EAS build + auto-submit
+      - name: EAS build — iOS (auto-submit to TestFlight)
+        if: steps.platform.outputs.value == 'ios' || steps.platform.outputs.value == 'all'
         run: |
           npx -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build \
             --profile production \
-            --platform ${{ steps.platform.outputs.value }} \
+            --platform ios \
             --non-interactive \
             --auto-submit
+
+      - name: EAS build — Android (APK only, attached to Release)
+        # Deliberately no --auto-submit: Google Play credentials aren't
+        # wired yet (pending Play Developer account + service-account
+        # JSON). The APK produced here is downloaded by the
+        # `attach-android-apk` job below and attached to the Release.
+        # Add `--auto-submit` here once `eas submit --platform android`
+        # is configured in eas.json.
+        if: steps.platform.outputs.value == 'android' || steps.platform.outputs.value == 'all'
+        run: |
+          npx -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build \
+            --profile production \
+            --platform android \
+            --non-interactive
 
   attach-android-apk:
     name: Attach Android APK to Release

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -140,6 +140,40 @@ Releases are cut by publishing a **GitHub Release** (which creates the tag serve
 3. Downloads the resulting Android APK and attaches it to the Release for sideloading.
 4. Regenerates `docs/TECHNICAL_SOLUTION_DOCUMENT.pdf` from the AsciiDoc sources and attaches that too.
 
+==== Version numbering
+
+Three separate numbers, maintained by three different actors — easy to confuse, so documenting the split explicitly:
+
+[cols="1,2,3", options="header"]
+|===
+| Number | Maintained by | Notes
+
+| `X.Y.Z` (user-visible version)
+| **Git tag**, applied by `.github/workflows/release.yml`
+| The workflow strips the leading `v` and any `-rcN` suffix from the tag, then writes the result into `version:` in `app.config.ts`. Tag `v1.0.0-rc1` → `version: '1.0.0'`. **Do NOT hand-edit `app.config.ts` before a release** — the workflow overwrites it.
+
+| Build number (iOS) / `versionCode` (Android)
+| **EAS**, via `"autoIncrement": true` in the `production` profile of `eas.json`
+| Auto-bumps on every production build. Monotonic integer, never reused, independent of `X.Y.Z`. Not tracked in-repo.
+
+| The in-repo `version:` field in `app.config.ts`
+| The last release workflow run
+| Between releases this is a stale snapshot of the most recent tag's `X.Y.Z` minus any RC suffix. Treat it as read-only; the tag is the source of truth.
+|===
+
+Reading the version of a running install:
+
+* iOS: *Settings → General → About → Lightning Piggy* shows `X.Y.Z (buildNumber)`.
+* Android: `adb -s <serial> shell dumpsys package com.lightningpiggy.app | grep -E "versionCode|versionName"`.
+
+Reading the latest build number from EAS without installing:
+
+[source,bash]
+----
+eas build:list --platform android --status finished --limit 1 \
+  | grep -E "^Version|^Build number"
+----
+
 ==== Cutting a release
 
 . Go to https://github.com/BenGWeeks/lightning-piggy-mobile/releases → *Draft a new release*.
@@ -624,6 +658,6 @@ Before releasing to production:
 * [ ] Prettier passes: `npm run format:check`
 * [ ] App tested on physical Android device
 * [ ] App tested on physical iOS device (if applicable)
-* [ ] Version number incremented in `app.config.ts`
+* [ ] New git tag chosen (`vX.Y.Z` or `vX.Y.Z-rcN`) — the release workflow writes it into `app.config.ts`; do NOT hand-edit the file
 * [ ] E2E tests pass: `maestro test tests/e2e/`
 * [ ] Git tag created for release version

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -136,8 +136,8 @@ subsequent tests may still be exercising the pre-fix app. Verify
 Releases are cut by publishing a **GitHub Release** (which creates the tag server-side and fires `.github/workflows/release.yml`). The workflow:
 
 1. Runs quality gates (typecheck / lint / format-check).
-2. Kicks off EAS production builds for both platforms with `--auto-submit` (TestFlight for iOS, Play Internal once the Google Play account is wired up).
-3. Downloads the resulting Android APK and attaches it to the Release for sideloading.
+2. Kicks off EAS production builds for both platforms. **iOS** is auto-submitted to TestFlight via EAS's ASC API key. **Android** is built only — no auto-submit to Play Internal until the Google Play Developer account + service-account JSON are wired up via `eas credentials` (see the "Android Distribution — Google Play Internal Testing" section below). The Android APK is attached to the GitHub Release instead, so testers can sideload it immediately.
+3. Downloads the resulting Android APK from EAS and attaches it as `lightning-piggy-<tag>.apk` on the Release page for sideloading.
 4. Regenerates `docs/TECHNICAL_SOLUTION_DOCUMENT.pdf` from the AsciiDoc sources and attaches that too.
 
 ==== Version numbering


### PR DESCRIPTION
## Summary

Two small gaps in `docs/DEPLOYMENT.adoc` that bit us cutting `v1.0.0-rc1`:

### 1. Explicit "Version numbering" section

Previously the release-workflow section had a single inline sentence about how the tag drives the version. That's easy to miss, and it's easy to assume "Expo maintains it" and hand-edit `app.config.ts` manually — only to have it overwritten by the next release.

The new section spells out the three-layer model:

| Number | Maintained by | Notes |
|---|---|---|
| `X.Y.Z` user-visible | Git tag (via `release.yml`) | Workflow strips `v` + `-rcN`, writes into `app.config.ts` |
| Build number / `versionCode` | EAS `autoIncrement: true` | Monotonic integer, not in-repo |
| `app.config.ts` `version:` field | Last release workflow run | Treat as read-only between releases |

Plus short snippets for "how do I read the installed version" and "how do I read the latest build number from EAS".

### 2. Checklist fix

Old line:
> Version number incremented in `app.config.ts`

That's actively wrong — hand-editing `app.config.ts` gets overwritten by the release workflow on tag. Replaced with:
> New git tag chosen (`vX.Y.Z` or `vX.Y.Z-rcN`) — the release workflow writes it into `app.config.ts`; do NOT hand-edit the file

## Test plan

- [ ] Render the AsciiDoc locally or on GitHub and eyeball
- [ ] Anchor links (if any elsewhere reference `Release workflow` subsections) still resolve
- [ ] No behaviour changes — pure doc edit