### PR TITLE
fix(qr): force black-on-white in QrSheet so dark-mode QR is scannable

### DIFF
--- a/src/components/QrSheet.tsx
+++ b/src/components/QrSheet.tsx
@@ -103,14 +103,14 @@ const QrSheet: React.FC<Props> = ({
           </View>
         )}
 
-        {/* QR Code */}
+        {/* QR Code — always black-on-white for maximum scan reliability,
+            regardless of light/dark theme. Themed colors (colors.textHeader
+            on colors.white) make the QR render light-grey-on-white in dark
+            mode, which scanners struggle with. The QR is visually wrapped
+            in styles.qrContainer (a white card with padding) so the white
+            BG plays nicely with both themes. */}
         <View style={styles.qrContainer}>
-          <QRCode
-            value={qrValue}
-            size={200}
-            backgroundColor={colors.white}
-            color={colors.textHeader}
-          />
+          <QRCode value={qrValue} size={200} backgroundColor="#FFFFFF" color="#000000" />
         </View>
 
         {/* Value + copy */}


### PR DESCRIPTION
## Summary
The Nostr Public Key + Lightning Address QR codes in `QrSheet` rendered as faint grey modules on an off-white card in dark mode — scanners struggled. Hardcoding `#000000` on `#FFFFFF` restores maximum contrast regardless of theme.

## Root cause
`src/components/QrSheet.tsx` was passing theme-aware colors to the `<QRCode>`:

```tsx
<QRCode
  value={qrValue}
  size={200}
  backgroundColor={colors.white}
  color={colors.textHeader}    // light grey in dark mode
/>
```

`colors.textHeader` resolves to a near-white grey when the theme is dark, so the QR modules were nearly invisible on the white card.

## Fix
Hardcode the QR color/background; the white BG was already inside a `styles.qrContainer` white card that looks intentional in both themes. Matches the convention already in `TipSheet` and `ReceiveSheet`, which both use the `react-native-qrcode-svg` library defaults (black-on-white).

```tsx
<QRCode value={qrValue} size={200} backgroundColor="#FFFFFF" color="#000000" />
```

## Test plan
- Open the app in dark mode → tap the npub QR icon (Profile → QR sheet) → confirm QR is solid black on white. Scan with another phone → resolves cleanly.
- Toggle to "Lightning" → same QR rendering.
- Toggle theme to light → still black-on-white, no regression.

Closes the visual bug surfaced when validating v1.0.0-rc2 on a Pixel 8 in dark mode.