### PR TITLE
fix(about): hide the triple-tap-version Developer Mode hint (#217)

### DIFF
--- a/src/screens/account/AboutScreen.tsx
+++ b/src/screens/account/AboutScreen.tsx
@@ -173,14 +173,13 @@ const AboutScreen: React.FC = () => {
       <TouchableOpacity
         onPress={handleVersionTap}
         activeOpacity={1}
-        accessibilityLabel="App version — triple-tap to toggle developer mode"
+        accessibilityLabel={`App version ${appVersion}`}
       >
         <Text style={styles.versionText} testID="version-text">
           v{appVersion}
           {devMode ? ' (dev)' : ''}
         </Text>
       </TouchableOpacity>
-      <Text style={styles.versionHint}>Triple-tap the version to toggle Developer Mode.</Text>
 
       {teamProfile?.lud16 && (
         <SendSheet
@@ -308,12 +307,6 @@ const createStyles = (colors: Palette) =>
       fontWeight: '600',
       textAlign: 'center',
       paddingTop: 32,
-    },
-    versionHint: {
-      color: 'rgba(255,255,255,0.6)',
-      fontSize: 12,
-      textAlign: 'center',
-      paddingTop: 4,
     },
   });
 


### PR DESCRIPTION
Closes #217.

Removes the visible hint advertising the secret triple-tap-the-version → Developer Mode gesture. Two leaks plugged:

1. Visible `<Text style={styles.versionHint}>Triple-tap the version to toggle Developer Mode.</Text>` line — deleted.
2. `accessibilityLabel="App version — triple-tap to toggle developer mode"` on the wrapping TouchableOpacity — replaced with plain `\`App version \${appVersion}\`` so screen readers announce just the version.

Also dropped the now-unused `styles.versionHint` block.

The `handleVersionTap` behaviour and the `testID="version-text"` are unchanged — Maestro tests can still drive the toggle if needed; users discover it the way Easter eggs are meant to be discovered.

## Test plan

- Open About screen → version line visible, no hint text underneath.
- Triple-tap the version → `(dev)` suffix appears, dev mode toggles. (manual)
- Screen reader (TalkBack) on the version → reads "App version 1.0.0". (manual)