### PR TITLE
ci(release): suppress Node DeprecationWarning to fix attach-android-apk jq parse (#207)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,12 @@ jobs:
 
       - name: Resolve latest finished Android APK URL
         id: find
+        env:
+          # Suppress Node `(node:NNN) [DEPxxxx] DeprecationWarning: ...`
+          # lines that eas-cli emits to stdout, which would otherwise
+          # poison the JSON pipe to jq with `Invalid numeric literal`.
+          # See #207 for the v1.0.0-rc2 release where this manifested.
+          NODE_NO_WARNINGS: '1'
         run: |
           # Pick the most recent FINISHED Android production build (the one we just submitted).
           # Filter by the git commit of the Release tag so we don't accidentally grab an


### PR DESCRIPTION
Closes #207.

## Symptom (recap)
The `attach-android-apk` job fails at the **Resolve latest finished Android APK URL** step:
```
jq: parse error: Invalid numeric literal at line 1, column 7
Error: build:list command failed.
##[error]Process completed with exit code 5.
```
EAS build itself succeeds, but the APK is never attached to the Release page. Manually verified on v1.0.0-rc2 → run https://github.com/BenGWeeks/lightning-piggy-mobile/actions/runs/24939276476.

## Root cause
eas-cli's npx wrapper emits a Node DeprecationWarning to stdout in some Node versions (`(node:NNNN) [DEP0040] DeprecationWarning: The 'punycode' module is deprecated.`) that gets prepended to the `--json` payload, breaking jq parsing.

## Fix
One env var on the step:
```yaml
env:
  NODE_NO_WARNINGS: '1'
```
Suppresses Node's deprecation noise at source. The eas-cli JSON pipes cleanly to jq.

## Test plan
- [ ] Tag a fresh release after merge → confirm `attach-android-apk` job goes green and the APK appears on the Release page within ~5 min of the EAS build completing.

## Out of scope
- Refactoring the build:list invocation to use a more robust JSON-only output mode (would be over-engineering for a one-line warning suppression).