### PR TITLE
fix(ui): AlphabetBar uses flex:1 + space-around so # has top breathing and 27 letters distribute (#216)

### DIFF
--- a/src/components/AlphabetBar.tsx
+++ b/src/components/AlphabetBar.tsx
@@ -195,10 +195,12 @@ const createStyles = (colors: Palette) =>
       // the sidebar (the per-letter `flex: 1` below uses the
       // stretched height to distribute 27 letters proportionally).
       flexDirection: 'column',
-      // `space-around` (vs `space-between`) gives the first/last letters
-      // (`#` at top, `Z` at bottom) the same vertical breathing as the
-      // inter-letter gap. With `space-between` the bar packed letters
-      // tight against the top + bottom edges (#216).
+      // The visible top/bottom breathing comes from this container's
+      // padding, while the per-letter `flex: 1` buckets below consume
+      // the remaining height and centre each letter within its bucket.
+      // `space-around` is kept defensively in case a future change
+      // removes `flex: 1` from the touches; with `flex: 1` it has no
+      // material effect because the buckets fill all free space.
       justifyContent: 'space-around',
       alignItems: 'center',
       paddingTop: 8,
@@ -225,11 +227,10 @@ const createStyles = (colors: Palette) =>
       borderRadius: 8,
     },
     alphabetLetter: {
-      // Tight font size so 27 buckets fit into FriendPickerSheet's
-      // 75% bottom sheet on smaller AVDs without the trailing letters
-      // getting clipped. Each rendered letter ends up ~12-14 dp tall
-      // including its line-box, so 27 × ~13 = ~350 dp comfortably fits
-      // in any reasonable sidebar height.
+      // Keep the text compact so the full A-Z index is more likely to
+      // remain visible in constrained layouts such as
+      // FriendPickerSheet, reducing the chance that trailing letters
+      // get clipped on smaller screens.
       fontSize: 9,
       lineHeight: 11,
       fontWeight: '700',

--- a/src/components/AlphabetBar.tsx
+++ b/src/components/AlphabetBar.tsx
@@ -187,17 +187,34 @@ AlphabetBar.displayName = 'AlphabetBar';
 const createStyles = (colors: Palette) =>
   StyleSheet.create({
     alphabetBar: {
+      // The parent (`listWithBar` in both FriendsScreen and
+      // FriendPickerSheet) is `flexDirection: 'row'` so the default
+      // `alignItems: 'stretch'` already gives this bar the parent's
+      // full column height. We rely on that — do NOT set `flex: 1`
+      // here, which would claim row WIDTH instead and visibly bloat
+      // the sidebar (the per-letter `flex: 1` below uses the
+      // stretched height to distribute 27 letters proportionally).
       flexDirection: 'column',
-      justifyContent: 'space-between',
+      // `space-around` (vs `space-between`) gives the first/last letters
+      // (`#` at top, `Z` at bottom) the same vertical breathing as the
+      // inter-letter gap. With `space-between` the bar packed letters
+      // tight against the top + bottom edges (#216).
+      justifyContent: 'space-around',
       alignItems: 'center',
-      paddingTop: 12,
-      paddingBottom: 16,
+      paddingTop: 8,
+      paddingBottom: 8,
       width: 22,
       marginLeft: 2,
     },
     alphabetLetterTouch: {
+      // `flex: 1` distributes the 27 letter buckets proportionally
+      // across the bar's height, so they never overflow the container
+      // (which would clip the trailing letters — V-Z were getting
+      // hidden in FriendPickerSheet's bottom sheet on smaller AVDs
+      // when items kept their intrinsic heights via `space-between`/
+      // `space-around`). Each bucket gets ~containerHeight/27.
+      flex: 1,
       paddingHorizontal: 2,
-      paddingVertical: 1,
       borderRadius: 8,
       width: 18,
       justifyContent: 'center',
@@ -208,7 +225,13 @@ const createStyles = (colors: Palette) =>
       borderRadius: 8,
     },
     alphabetLetter: {
-      fontSize: 10,
+      // Tight font size so 27 buckets fit into FriendPickerSheet's
+      // 75% bottom sheet on smaller AVDs without the trailing letters
+      // getting clipped. Each rendered letter ends up ~12-14 dp tall
+      // including its line-box, so 27 × ~13 = ~350 dp comfortably fits
+      // in any reasonable sidebar height.
+      fontSize: 9,
+      lineHeight: 11,
       fontWeight: '700',
       color: colors.textSupplementary,
       textAlign: 'center',


### PR DESCRIPTION
Closes the AlphabetBar-side of #216.

## Problem

Two related layout issues with the AlphabetBar after PR #204 switched it from rendering only available letters to always rendering the full `FULL_ALPHABET` (27 buckets):

1. **#216** — On Pixel dark mode, the # bucket at the top hugged the sidebar's top edge with no breathing room.
2. **New, related** — In the FriendPickerSheet bottom sheet on smaller AVDs, the trailing V-Z were getting clipped off the bottom (caught by the new `test-friend-picker-alphabet.yaml`).

## Root cause

The per-letter `TouchableOpacity` had no flex distribution, so children laid out at intrinsic stack height. With 27 buckets that's ~378 dp, which exceeded the available height in tighter containers and overflowed.

## Fix

Changes in `src/components/AlphabetBar.tsx`:

- `flex: 1` on each `alphabetLetterTouch` — distributes the 27 buckets evenly across the bar's column height. The bar's outer View intentionally does NOT set `flex: 1` — the parent `listWithBar` is `flexDirection: 'row'`, so `alignItems: 'stretch'` (the default) already gives this bar the full column height. Setting `flex: 1` on the bar would claim row WIDTH and visibly bloat the sidebar.
- `paddingTop`/`paddingBottom`: 12/16 → 8/8 — # and Z get more reasonable top/bottom breathing (was the visible #216 symptom).
- `fontSize`: 10 → 9 (with explicit `lineHeight: 11`) — keeps the bar legible on tight containers.
- `justifyContent: 'space-around'` (was `'space-between'`) — kept defensively in case `flex: 1` is ever removed from the touches; with `flex: 1` it has no material effect because the buckets fill all free space.

## Test plan

`tests/e2e/test-friends-tab-alphabet.yaml` PASSES (A-Z all visible).

`tests/e2e/test-friend-picker-alphabet.yaml` still FAILS at V — the FriendPickerSheet's BottomSheetModal at '75%' snap further caps the available height, beyond what the bar's internal layout can compensate for. That's a sheet-side fix tracked as **#222**.

## Manual verification

- Friends tab → alphabet sidebar shows # at top with proper breathing room from the screen-top edge.
- All 27 buckets visible.
- Disabled letters still render at 0.3 opacity.
- Sidebar width unchanged (~22 dp); friend rows are NOT squished.

## Out of scope

- Bottom-sheet content area sizing in FriendPickerSheet — see #222.