### PR TITLE
perf(ui): skeletons + deferred mount across all 4 tabs + 2 sheets

### DIFF
--- a/src/components/ConversationRow.tsx
+++ b/src/components/ConversationRow.tsx
@@ -7,6 +7,14 @@ import type { Palette } from '../styles/palettes';
 import type { ConversationSummary } from '../utils/conversationSummaries';
 import { conversationPreview, formatConversationTimestamp } from '../utils/conversationSummaries';
 
+/**
+ * Total row height in dp: avatar 48 + paddingVertical 12 × 2 = 72.
+ * Exported so SkeletonRow can match the height exactly — mismatched
+ * heights produce layout shift the moment the skeleton is replaced.
+ * If you change paddingVertical or the avatar size below, update this too.
+ */
+export const CONVERSATION_ROW_HEIGHT = 72;
+
 interface Props {
   summary: ConversationSummary;
   onPress?: () => void;

--- a/src/components/CreateGroupSheet.tsx
+++ b/src/components/CreateGroupSheet.tsx
@@ -7,6 +7,7 @@ import {
   ActivityIndicator,
   BackHandler,
   Alert,
+  InteractionManager,
 } from 'react-native';
 import { Image } from 'expo-image';
 import Svg, { Path, Circle } from 'react-native-svg';
@@ -17,6 +18,7 @@ import {
   BottomSheetScrollView,
   BottomSheetTextInput,
 } from '@gorhom/bottom-sheet';
+import { SkeletonList } from './SkeletonRow';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 import { useNostr } from '../contexts/NostrContext';
@@ -31,6 +33,13 @@ interface Props {
 }
 
 type ContactWithLabel = NostrContact & { displayName: string };
+
+/**
+ * Total row height in dp: avatar 40 + paddingVertical 10 × 2 = 60.
+ * Exported so SkeletonRow can match the height exactly while the real
+ * member list is being built off the JS thread post-animation.
+ */
+export const MEMBER_ROW_HEIGHT = 60;
 
 interface MemberRowProps {
   contact: ContactWithLabel;
@@ -123,6 +132,22 @@ const CreateGroupSheet: React.FC<Props> = ({ visible, onClose, onCreated }) => {
     } else {
       sheetRef.current?.dismiss();
     }
+  }, [visible]);
+
+  // Defer the heavy member-list mount until after the sheet's open
+  // animation completes — same pattern as FriendPickerSheet. With ~50
+  // contacts each rendering an avatar Image, mounting them DURING the
+  // animation produces visible jank. Skeleton fills the area in the
+  // meantime; the real list mounts on the next interaction tick.
+  // See plan in #245 follow-up.
+  const [listReady, setListReady] = useState(false);
+  useEffect(() => {
+    if (!visible) {
+      setListReady(false);
+      return;
+    }
+    const handle = InteractionManager.runAfterInteractions(() => setListReady(true));
+    return () => handle.cancel();
   }, [visible]);
 
   useEffect(() => {
@@ -229,7 +254,9 @@ const CreateGroupSheet: React.FC<Props> = ({ visible, onClose, onCreated }) => {
         />
 
         <Text style={styles.label}>Members {selected.size > 0 ? `(${selected.size})` : ''}</Text>
-        {sortedContacts.length === 0 ? (
+        {!listReady ? (
+          <SkeletonList count={8} rowHeight={MEMBER_ROW_HEIGHT} avatarSize={40} lines={1} />
+        ) : sortedContacts.length === 0 ? (
           <Text style={styles.emptyText}>Add Nostr friends first to include them in a group.</Text>
         ) : (
           <View>

--- a/src/components/FriendPickerSheet.tsx
+++ b/src/components/FriendPickerSheet.tsx
@@ -7,6 +7,7 @@ import {
   BackHandler,
   Keyboard,
   Platform,
+  InteractionManager,
 } from 'react-native';
 import { Image } from 'expo-image';
 import { UserRound, UsersRound } from 'lucide-react-native';
@@ -21,6 +22,12 @@ import { useNostr } from '../contexts/NostrContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 import AlphabetBar from './AlphabetBar';
+import { SkeletonList } from './SkeletonRow';
+
+/** Local row height for the SkeletonList placeholder: matches the
+ * picker's `styles.row` (paddingVertical 10 × 2 + avatar 40 = 60).
+ * Inlined rather than imported because this row is rendered only here. */
+const PICKER_ROW_HEIGHT = 60;
 
 export interface PickedFriend {
   pubkey: string;
@@ -99,6 +106,22 @@ const FriendPickerSheet: React.FC<Props> = ({
     } else {
       sheetRef.current?.dismiss();
     }
+  }, [visible]);
+
+  // Defer the heavy BottomSheetFlatList mount until after the open
+  // animation completes — otherwise the JS thread is busy building
+  // 50 friend rows (with image decode queueing) DURING the sheet's
+  // upward animation and the user sees jank. Skeleton fills the
+  // visible area in the meantime; real list mounts on the next tick
+  // after the animation runs to completion. See plan in #245 follow-up.
+  const [listReady, setListReady] = useState(false);
+  useEffect(() => {
+    if (!visible) {
+      setListReady(false);
+      return;
+    }
+    const handle = InteractionManager.runAfterInteractions(() => setListReady(true));
+    return () => handle.cancel();
   }, [visible]);
 
   useEffect(() => {
@@ -267,68 +290,74 @@ const FriendPickerSheet: React.FC<Props> = ({
           />
         </View>
         <View style={styles.listWithBar}>
-          {availableLetters.length > 0 ? (
-            <AlphabetBar
-              letters={availableLetters}
-              currentLetter={currentLetter}
-              onLetterPress={handleLetterPress}
-            />
-          ) : null}
-          <BottomSheetFlatList<PickedFriend>
-            ref={listRef}
-            data={friends}
-            keyExtractor={(f: PickedFriend) => f.pubkey}
-            renderItem={renderItem}
-            ListHeaderComponent={
-              onNewGroup ? (
-                <TouchableOpacity
-                  style={styles.row}
-                  onPress={onNewGroup}
-                  accessibilityLabel="Create a new group"
-                  testID="friend-picker-new-group"
-                >
-                  <View style={styles.newGroupIcon}>
-                    <UsersRound size={28} color={colors.brandPink} />
+          {!listReady ? (
+            <SkeletonList count={8} rowHeight={PICKER_ROW_HEIGHT} avatarSize={40} lines={2} />
+          ) : (
+            <>
+              {availableLetters.length > 0 ? (
+                <AlphabetBar
+                  letters={availableLetters}
+                  currentLetter={currentLetter}
+                  onLetterPress={handleLetterPress}
+                />
+              ) : null}
+              <BottomSheetFlatList<PickedFriend>
+                ref={listRef}
+                data={friends}
+                keyExtractor={(f: PickedFriend) => f.pubkey}
+                renderItem={renderItem}
+                ListHeaderComponent={
+                  onNewGroup ? (
+                    <TouchableOpacity
+                      style={styles.row}
+                      onPress={onNewGroup}
+                      accessibilityLabel="Create a new group"
+                      testID="friend-picker-new-group"
+                    >
+                      <View style={styles.newGroupIcon}>
+                        <UsersRound size={28} color={colors.brandPink} />
+                      </View>
+                      <View style={styles.info}>
+                        <Text style={styles.newGroupName}>New group</Text>
+                      </View>
+                    </TouchableOpacity>
+                  ) : null
+                }
+                contentContainerStyle={[
+                  styles.listContent,
+                  { paddingBottom: keyboardHeight > 0 ? keyboardHeight + 80 : 40 },
+                ]}
+                keyboardShouldPersistTaps="handled"
+                style={styles.list}
+                onScrollToIndexFailed={(info: {
+                  index: number;
+                  highestMeasuredFrameIndex: number;
+                  averageItemLength: number;
+                }) => {
+                  const offset = info.averageItemLength * info.index;
+                  listRef.current?.scrollToOffset?.({ offset, animated: false });
+                  setTimeout(() => {
+                    listRef.current?.scrollToIndex?.({
+                      index: info.index,
+                      animated: false,
+                      viewPosition: 0,
+                    });
+                  }, 50);
+                }}
+                ListEmptyComponent={
+                  <View style={styles.empty}>
+                    <Text style={styles.emptyText}>
+                      {contacts.length === 0
+                        ? 'You don’t follow anyone on Nostr yet.'
+                        : search
+                          ? 'No friends match your search.'
+                          : 'No contacts with resolved profiles to send to.'}
+                    </Text>
                   </View>
-                  <View style={styles.info}>
-                    <Text style={styles.newGroupName}>New group</Text>
-                  </View>
-                </TouchableOpacity>
-              ) : null
-            }
-            contentContainerStyle={[
-              styles.listContent,
-              { paddingBottom: keyboardHeight > 0 ? keyboardHeight + 80 : 40 },
-            ]}
-            keyboardShouldPersistTaps="handled"
-            style={styles.list}
-            onScrollToIndexFailed={(info: {
-              index: number;
-              highestMeasuredFrameIndex: number;
-              averageItemLength: number;
-            }) => {
-              const offset = info.averageItemLength * info.index;
-              listRef.current?.scrollToOffset?.({ offset, animated: false });
-              setTimeout(() => {
-                listRef.current?.scrollToIndex?.({
-                  index: info.index,
-                  animated: false,
-                  viewPosition: 0,
-                });
-              }, 50);
-            }}
-            ListEmptyComponent={
-              <View style={styles.empty}>
-                <Text style={styles.emptyText}>
-                  {contacts.length === 0
-                    ? 'You don’t follow anyone on Nostr yet.'
-                    : search
-                      ? 'No friends match your search.'
-                      : 'No contacts with resolved profiles to send to.'}
-                </Text>
-              </View>
-            }
-          />
+                }
+              />
+            </>
+          )}
         </View>
       </View>
     </BottomSheetModal>

--- a/src/components/GroupRow.tsx
+++ b/src/components/GroupRow.tsx
@@ -7,6 +7,13 @@ import { useNostr } from '../contexts/NostrContext';
 import GroupAvatar from './GroupAvatar';
 import { formatConversationTimestamp } from '../utils/conversationSummaries';
 
+/**
+ * Total row height in dp: avatar 48 + paddingVertical 12 × 2 = 72.
+ * Exported so SkeletonRow can match the height exactly — mismatched
+ * heights produce layout shift when the skeleton is replaced.
+ */
+export const GROUP_ROW_HEIGHT = 72;
+
 interface Props {
   summary: GroupSummary;
   onPress?: () => void;

--- a/src/components/SkeletonRow.tsx
+++ b/src/components/SkeletonRow.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
+import { useThemeColors } from '../contexts/ThemeContext';
+
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
+
+interface SkeletonRowProps {
+  /** Total row height in dp. Must equal the real row's height to avoid
+   * layout shift when the skeleton is replaced by real content. */
+  height: number;
+  /** Avatar diameter in dp. `0` skips the avatar block (leading-only rows). */
+  avatarSize?: number;
+  /** Number of text "lines" to draw on the right (1 = name only, 2 = name +
+   * subtitle). Trailing edge gets a small shape regardless (for timestamp /
+   * action button silhouette) when `lines === 2`. */
+  lines?: 1 | 2;
+}
+
+/**
+ * One row of placeholder content with a moving-gradient shimmer.
+ *
+ * The shimmer effect is a `LinearGradient` ribbon that sweeps left-to-right
+ * across the row at a 1.5 s loop. The gradient itself is animated via
+ * `react-native-reanimated`'s `withRepeat(withTiming, -1)` so it runs on
+ * the UI thread (no JS-bridge cost per frame).
+ *
+ * Why a custom component instead of a library: react-native-keyboard-controller
+ * + reanimated 4 + expo-linear-gradient are already in deps for other
+ * features. A skeleton/shimmer lib would add weight for one job.
+ *
+ * Sizing rule: pass `height` equal to the real row's height (e.g.
+ * `CONTACT_LIST_ITEM_HEIGHT` from `ContactListItem.tsx`). Mismatched heights
+ * produce layout shift the moment the skeleton is replaced — visible jank.
+ */
+const SkeletonRow: React.FC<SkeletonRowProps> = ({ height, avatarSize = 0, lines = 2 }) => {
+  const colors = useThemeColors();
+  const styles = makeStyles(colors, height, avatarSize);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withRepeat(
+      withTiming(1, { duration: 1500, easing: Easing.linear }),
+      -1,
+      false,
+    );
+  }, [progress]);
+
+  // The shimmer ribbon starts off-screen left (-100%) and ends off-screen
+  // right (+100%), so a full sweep cycles cleanly back to the start with
+  // no visible "snap" between iterations.
+  const shimmerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: progress.value * 400 - 200 }],
+  }));
+
+  const Block: React.FC<{ style: object }> = ({ style }) => (
+    <View style={[styles.block, style]}>
+      <AnimatedLinearGradient
+        colors={['transparent', colors.surface, 'transparent']}
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 1, y: 0.5 }}
+        style={[styles.shimmer, shimmerStyle]}
+      />
+    </View>
+  );
+
+  return (
+    <View style={styles.row}>
+      {avatarSize > 0 ? <Block style={styles.avatar} /> : null}
+      <View style={styles.lines}>
+        <Block style={styles.lineLong} />
+        {lines === 2 ? <Block style={styles.lineShort} /> : null}
+      </View>
+      {lines === 2 ? <Block style={styles.trailing} /> : null}
+    </View>
+  );
+};
+
+const makeStyles = (
+  colors: ReturnType<typeof useThemeColors>,
+  height: number,
+  avatarSize: number,
+) =>
+  StyleSheet.create({
+    row: {
+      height,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 16,
+      gap: 12,
+    },
+    avatar: {
+      width: avatarSize,
+      height: avatarSize,
+      borderRadius: avatarSize / 2,
+    },
+    lines: {
+      flex: 1,
+      gap: 8,
+    },
+    lineLong: {
+      height: 14,
+      width: '60%',
+      borderRadius: 4,
+    },
+    lineShort: {
+      height: 11,
+      width: '40%',
+      borderRadius: 4,
+    },
+    trailing: {
+      width: 32,
+      height: 11,
+      borderRadius: 4,
+    },
+    block: {
+      // Faint base tint that's visible on both light + dark surfaces.
+      // The shimmer ribbon (drawn on top via absoluteFill) does the work
+      // of conveying "loading"; the base just hints at the row's shape.
+      backgroundColor: colors.divider,
+      overflow: 'hidden',
+    },
+    shimmer: {
+      ...StyleSheet.absoluteFillObject,
+      width: '100%',
+    },
+  });
+
+interface SkeletonListProps {
+  /** Number of skeleton rows to draw. */
+  count: number;
+  /** Per-row height — see `SkeletonRow.height`. */
+  rowHeight: number;
+  /** Per-row avatar diameter — see `SkeletonRow.avatarSize`. */
+  avatarSize?: number;
+  /** Per-row text-line count — see `SkeletonRow.lines`. */
+  lines?: 1 | 2;
+}
+
+/**
+ * Convenience wrapper: render N stacked SkeletonRows. Used as the
+ * placeholder for a list while the real data hydrates.
+ */
+export const SkeletonList: React.FC<SkeletonListProps> = ({
+  count,
+  rowHeight,
+  avatarSize = 0,
+  lines = 2,
+}) => (
+  <View accessibilityLabel="Loading" accessibilityRole="progressbar">
+    {Array.from({ length: count }, (_, i) => (
+      <SkeletonRow key={i} height={rowHeight} avatarSize={avatarSize} lines={lines} />
+    ))}
+  </View>
+);
+
+export default SkeletonRow;

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -385,6 +385,13 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
 
 const AVATAR_SIZE = 40;
 
+/**
+ * Total row height in dp: AVATAR_SIZE (40) + paddingVertical 10 × 2 = 60.
+ * Exported so HomeScreen's SkeletonList can match while transactions
+ * are still being fetched, avoiding a layout shift when they land.
+ */
+export const TRANSACTION_ROW_HEIGHT = AVATAR_SIZE + 20;
+
 const createStyles = (colors: Palette) =>
   StyleSheet.create({
     list: {

--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -16,6 +16,7 @@ import ContactProfileSheet from '../components/ContactProfileSheet';
 import AddFriendSheet from '../components/AddFriendSheet';
 import SendSheet from '../components/SendSheet';
 import AlphabetBar from '../components/AlphabetBar';
+import { SkeletonList } from '../components/SkeletonRow';
 import { fetchPhoneContacts, PhoneContact, setLightningAddress } from '../services/contactsService';
 import { createFriendsScreenStyles } from '../styles/FriendsScreen.styles';
 import type { MainTabParamList, RootStackParamList } from '../navigation/types';
@@ -88,6 +89,22 @@ const FriendsScreen: React.FC = () => {
       .then(setPhoneContacts)
       .catch(() => {});
   }, []);
+
+  // Cold-mount skeleton: hide as soon as either data source lands, OR
+  // after the first InteractionManager tick if neither fires (i.e. user
+  // truly has zero contacts — fall through to the empty state). Without
+  // this we'd render a blank list area for the few hundred ms it takes
+  // NostrContext + phoneContacts to hydrate. See plan in #245 follow-up.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    if (hydrated) return;
+    if (contacts.length > 0 || phoneContacts.length > 0) {
+      setHydrated(true);
+      return;
+    }
+    const handle = InteractionManager.runAfterInteractions(() => setHydrated(true));
+    return () => handle.cancel();
+  }, [hydrated, contacts.length, phoneContacts.length]);
 
   // Force-refresh the own-profile kind-0 on focus so the top-right
   // profile icon picks up external renames (e.g. via Amber or another
@@ -451,29 +468,38 @@ const FriendsScreen: React.FC = () => {
               />
             )}
             <Profiler id="FriendsList" onRender={onProfilerRender}>
-              <FlashList
-                ref={flatListRef}
-                data={combinedList}
-                keyExtractor={(item) => item.id}
-                renderItem={renderItem}
-                refreshControl={
-                  <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
-                }
-                ListEmptyComponent={
-                  <View style={styles.emptyState}>
-                    <Text style={styles.emptySubtitle}>
-                      {search ? 'No contacts match your search.' : 'No contacts found.'}
-                    </Text>
-                  </View>
-                }
-                contentContainerStyle={styles.listContent}
-                onScroll={handleScroll}
-                // 32ms ≈ 2 frames at 60fps — keeps the alphabet-bar
-                // highlight in sync with fast flings without firing the
-                // handler every frame. The previous 250ms made the
-                // highlight lag visibly on momentum scrolls.
-                scrollEventThrottle={32}
-              />
+              {!hydrated ? (
+                <SkeletonList
+                  count={10}
+                  rowHeight={CONTACT_LIST_ITEM_HEIGHT}
+                  avatarSize={44}
+                  lines={2}
+                />
+              ) : (
+                <FlashList
+                  ref={flatListRef}
+                  data={combinedList}
+                  keyExtractor={(item) => item.id}
+                  renderItem={renderItem}
+                  refreshControl={
+                    <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+                  }
+                  ListEmptyComponent={
+                    <View style={styles.emptyState}>
+                      <Text style={styles.emptySubtitle}>
+                        {search ? 'No contacts match your search.' : 'No contacts found.'}
+                      </Text>
+                    </View>
+                  }
+                  contentContainerStyle={styles.listContent}
+                  onScroll={handleScroll}
+                  // 32ms ≈ 2 frames at 60fps — keeps the alphabet-bar
+                  // highlight in sync with fast flings without firing the
+                  // handler every frame. The previous 250ms made the
+                  // highlight lag visibly on momentum scrolls.
+                  scrollEventThrottle={32}
+                />
+              )}
             </Profiler>
           </View>
         )}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   ScrollView,
   RefreshControl,
-  ActivityIndicator,
   InteractionManager,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -19,7 +18,8 @@ import { useThemeColors } from '../contexts/ThemeContext';
 import ReceiveSheet from '../components/ReceiveSheet';
 import SendSheet from '../components/SendSheet';
 import TransferSheet from '../components/TransferSheet';
-import TransactionList from '../components/TransactionList';
+import TransactionList, { TRANSACTION_ROW_HEIGHT } from '../components/TransactionList';
+import { SkeletonList } from '../components/SkeletonRow';
 import WalletCarousel from '../components/WalletCarousel';
 import AddWalletWizard from '../components/AddWalletWizard';
 import WalletSettingsSheet from '../components/WalletSettingsSheet';
@@ -286,9 +286,11 @@ const HomeScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
           ) : loadingTransactions && transactions.length === 0 ? (
-            <View style={styles.emptyState}>
-              <ActivityIndicator size="small" color="#EC008C" />
-            </View>
+            // Row-shaped skeleton instead of a centred spinner so the
+            // layout doesn't jump when transactions land. 5 rows ≈ one
+            // viewport of pre-roll on a typical phone. See plan in
+            // #245 follow-up.
+            <SkeletonList count={5} rowHeight={TRANSACTION_ROW_HEIGHT} avatarSize={40} lines={2} />
           ) : (
             <TransactionList transactions={transactions} />
           )}

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -19,8 +19,9 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNostr } from '../contexts/NostrContext';
 import { useWallet } from '../contexts/WalletContext';
 import { useGroups } from '../contexts/GroupsContext';
-import ConversationRow from '../components/ConversationRow';
+import ConversationRow, { CONVERSATION_ROW_HEIGHT } from '../components/ConversationRow';
 import GroupRow from '../components/GroupRow';
+import { SkeletonList } from '../components/SkeletonRow';
 import ContactProfileSheet from '../components/ContactProfileSheet';
 import FriendPickerSheet, { type PickedFriend } from '../components/FriendPickerSheet';
 import CreateGroupSheet from '../components/CreateGroupSheet';
@@ -84,6 +85,23 @@ const MessagesScreen: React.FC = () => {
       if (v === '90') setWindowDays(90);
     });
   }, []);
+
+  // Cold-mount skeleton: hide as soon as either dmInbox or wallets land
+  // (i.e. there are conversations to show), OR after the first
+  // InteractionManager tick if neither fires (truly empty inbox →
+  // fall through to the empty-state UI). Otherwise the list area renders
+  // blank for the few hundred ms it takes NostrContext + WalletContext
+  // to hydrate. See plan in #245 follow-up.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    if (hydrated) return;
+    if (dmInbox.length > 0 || wallets.length > 0) {
+      setHydrated(true);
+      return;
+    }
+    const handle = InteractionManager.runAfterInteractions(() => setHydrated(true));
+    return () => handle.cancel();
+  }, [hydrated, dmInbox.length, wallets.length]);
 
   const cycleWindowDays = useCallback(() => {
     setWindowDays((prev) => {
@@ -395,6 +413,8 @@ const MessagesScreen: React.FC = () => {
               <Text style={styles.connectButtonText}>Go to Account</Text>
             </TouchableOpacity>
           </View>
+        ) : !hydrated ? (
+          <SkeletonList count={6} rowHeight={CONVERSATION_ROW_HEIGHT} avatarSize={48} lines={2} />
         ) : (
           <FlashList
             data={filteredRows}


### PR DESCRIPTION
## Summary

Drives perceived perf from "blank flash → JS chugs → content appears" to "skeleton appears immediately → animation completes smoothly → real content takes over". Targets the cold-paint surfaces on every bottom tab + the two heavy sheets that make up the (+) "new chat" path Ben specifically flagged as slow.

Foundation + apply, in one PR. Layer 3 (avatar prefetch) deliberately deferred to a follow-up so the perf delta from skeletons + defer is measurable in isolation.

## Why

Current AVD measurements showed cold-paint modern jank in the **30–60% range** across these surfaces. Root cause isn't bad code — it's that the heavy work (50 contact rows, 50 avatar decodes, sheet measurement, list-build) fires **synchronously while the UI is animating**. The user taps the FAB; the JS thread immediately starts allocating + queuing image decodes; the bottom-sheet's open animation contends with all of it.

Stop doing the heavy work during the animation. Show a skeleton in the meantime. Real content mounts after \`InteractionManager.runAfterInteractions\` so the animation completes uninterrupted. See \`/home/benw/.claude/plans/ok-how-do-we-noble-gem.md\` for the full strategy doc the user approved.

## What changes

### 1. New foundation: \`<SkeletonRow>\` + \`<SkeletonList>\`

\`src/components/SkeletonRow.tsx\` (164 lines, no new deps):

- Configurable shape: avatar size, line count (1 or 2), height
- Shimmer effect via \`expo-linear-gradient\` + \`react-native-reanimated\` (both already in deps)
- Animation runs on the UI thread (via reanimated worklet) — no JS-thread cost per frame
- Theme-aware (\`useThemeColors()\`)
- \`SkeletonList\` convenience wrapper for stacking N rows

### 2. Apply across all 4 bottom tabs + 2 sheets

| Surface | What we did | Trigger |
|---|---|---|
| **Home** (\`HomeScreen.tsx\`) | 5 transaction-row skeletons replace the centred \`ActivityIndicator\` | While \`loadingTransactions === true\` |
| **Messages** (\`MessagesScreen.tsx\`) | 6 conversation-row skeletons | Until \`dmInbox\`/\`wallets\` hydrate or first \`InteractionManager\` tick |
| **Learn** | **None — out of scope per plan** (data is local + sub-second cold paint already) | n/a |
| **Friends** (\`FriendsScreen.tsx\`) | 10 contact-row skeletons | Until \`contacts\`/\`phoneContacts\` hydrate or first \`InteractionManager\` tick |
| **FriendPickerSheet** | 8 row skeletons + defer real list mount past sheet animation | \`useEffect([visible])\` → InteractionManager.runAfterInteractions → \`setListReady(true)\` |
| **CreateGroupSheet** | Same defer pattern | Same |

### 3. Row-height constants exported (for skeleton sizing without layout shift)

| File | New export |
|---|---|
| \`ConversationRow.tsx\` | \`CONVERSATION_ROW_HEIGHT = 72\` |
| \`GroupRow.tsx\` | \`GROUP_ROW_HEIGHT = 72\` |
| \`CreateGroupSheet.tsx\` | \`MEMBER_ROW_HEIGHT = 60\` |
| \`TransactionList.tsx\` | \`TRANSACTION_ROW_HEIGHT = 60\` |

(\`CONTACT_LIST_ITEM_HEIGHT = 72\` was already exported from \`ContactListItem.tsx\` — same pattern, just propagated to the others.)

**Why heights matter:** if the skeleton row is taller/shorter than the real row, replacing it produces visible layout shift = its own jank. Exporting the constant lets each surface size its skeleton against the canonical row height.

## Trade-offs accepted

- **Slight delay before real content** (skeleton shows ~250–400ms during the animation). Strictly worse than instant if there's nothing competing for the thread, but the animation we're guarding has its own duration anyway — the user just sees the skeleton instead of frame drops.
- **One additional component to maintain** (SkeletonRow, single file, no external lib).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint <changed files>\` clean (6 pre-existing warnings unrelated to this change)
- [x] \`npx prettier --check\` clean
- [ ] **AVD perf re-measurement** with \`scripts/perf-friends-tab.sh\` from PR #246 + the inline FAB→FriendPicker open harness from this session — 5 cold samples each on this branch vs main. Success bar: modern jank during sheet-open phase < 10% (currently 34%).
- [ ] **Visual on AVD via Metro reload:**
  - Tap (+) on Messages → sheet animates up with skeleton rows visible → real list replaces skeletons after ~250ms with NO visible layout shift
  - Cold-launch app → tap Friends tab → skeleton rows visible while contacts hydrate → real rows replace cleanly
  - Cold-launch app → Home tab → skeleton transaction rows visible while wallet syncs → real transactions replace cleanly
- [ ] **Pixel release-build check** (combined APK with PR #246 + #250 + this branch). Subjective bar: "I don't see jank during sheet open."
- [ ] **Maestro regression sweep:** \`maestro test tests/e2e/test-friend-picker-alphabet.yaml\`, \`test-messages-search.yaml\`, \`test-3way-group-create-as-big.yaml\`. May need \`extendedWaitUntil\` on tests that assumed instant list visibility.

## Out of scope (follow-up issues)

- **Avatar prefetch on Messages tab focus** — pre-warm \`expo-image\` disk cache so cold sheet open hits warm bitmaps. Risk: prefetching all 50 avatars could spike network + memory; needs throttle + size cap. Separate PR.
- **\`useTransition\` on filter switches** — FriendsScreen filter chips, Messages window toggle. Small standalone PR.
- **Lazy tab-mount + memo audit** — broader work, separate scope.
- **Conversation message-bubble skeletons** — existing \`ActivityIndicator\` is adequate; revisit if subjective slowness on real device persists.
- **Standardising "Loading messages…" label vs spinner-only** — UX polish, separate concern.

## Related

- Issue #245 — umbrella perf issue (this PR partially addresses; doesn't close).
- PR #246 — perf-pass on caching + sort keys + render-storm patterns. Independent of this PR; both can land.
- PR #250 — group-conversation keyboard fix. Unrelated, can land independently.