### PR TITLE
chore(repo): add pr-lint workflow + PR/issue templates + copilot-instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Tap on '...'
+3. Observe '...'
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Screenshots / Recording
+
+If applicable, attach screenshots or a screen recording. Capture on Android via:
+
+```sh
+adb exec-out screencap -p > /tmp/screen.png
+convert /tmp/screen.png -resize 1200x1200\> /tmp/screen_small.png
+```
+
+## Environment
+
+- Device: [e.g. Pixel 8 / AVD `Medium_Phone_API_36.1`]
+- Android version: [e.g. 16]
+- App version: [e.g. v1.0.0 versionCode 28 — see Settings → About]
+- Build flavor: [release / dev / preview]
+- Signer: [nsec / Amber / N/A]
+
+## Logs
+
+If the bug shows up in `adb logcat`, attach the relevant slice:
+
+```sh
+adb logcat -d -t 300 | grep -E "ReactNativeJS|FATAL|AndroidRuntime"
+```
+
+## Additional Context
+
+Anything else worth knowing — frequency, recent app updates, related Nostr / NWC state.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,23 @@
+---
+name: Enhancement
+about: Suggest an improvement to an existing feature
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## Current Behavior
+
+Describe the current behavior or feature you want to improve.
+
+## Proposed Enhancement
+
+A clear and concise description of what you want to change or improve.
+
+## Benefits
+
+Explain the benefits of this enhancement (UX, perf, clarity, etc.).
+
+## Additional Context
+
+Mockups, screenshots, links to related issues or PRs.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: 'feat: '
+labels: feature
+assignees: ''
+---
+
+## Problem Statement
+
+Describe the problem or need this feature would address. Who is the user, and what are they trying to accomplish?
+
+## Proposed Solution
+
+A clear and concise description of the feature you'd like.
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Mockups, screenshots, related Nostr NIPs, related Lightning specs, or any other context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+Title format: Conventional Commits + optional scope, optional trailing issue suffix.
+  feat(scope): subject (#nnn)        feat: subject
+  fix(scope): subject (#nnn)         fix: subject
+  perf(scope): subject (#nnn)        refactor(scope): subject
+  chore: subject     ci: subject     docs: subject     deps: subject
+  test: subject      build: subject  style: subject
+
+Body sections below are required.
+- feat / fix / perf / refactor PRs MUST include a `Closes #nnn` line (one per resolved issue).
+- All PRs MUST include a `## Test plan` section with steps or `N/A — <reason>`.
+-->
+
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+
+## Closes
+
+Closes #
+
+<!-- One `Closes #nnn` per resolved issue. Delete this section for chore / ci / docs / deps PRs not tied to an issue. -->
+
+## Test plan
+
+<!--
+Step-by-step actions a reviewer or tester can follow, with expected results.
+Example:
+  1. Open the Messages tab.
+  2. **Expected:** conversations appear immediately on cold start (no blank flash).
+  3. Tap the (+) FAB.
+  4. **Expected:** sheet animates up smoothly, friend list appears within ~250 ms.
+
+For pure-refactor / docs / CI / deps PRs with no user-visible change, replace with:
+
+  N/A — <one-line reason, e.g. "internal refactor, covered by existing perf-suite">
+-->
+
+## Screenshots (if applicable)
+
+<!--
+For UI changes, attach before/after screenshots. Use ADB to capture on Android:
+  adb exec-out screencap -p > /tmp/screen.png
+  convert /tmp/screen.png -resize 1200x1200\> /tmp/screen_small.png
+-->
+
+## Perf impact (if applicable)
+
+<!--
+For PRs touching list-rendering / sheet / animation surfaces, run:
+  scripts/perf-suite.sh
+on this branch and on `main`, then paste the median table delta. Otherwise N/A.
+-->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,14 +16,14 @@ When reviewing pull requests in this repository, format your output to support *
 
 4. **Each comment should be self-contained.** Include enough context that the author can act on it without scrolling back to the summary or other comments.
 
-5. **Suggest concrete fixes** when possible. A 3-line code suggestion is more useful than a paragraph of prose. Use GitHub's suggestion blocks (` ```suggestion `) when the fix is mechanical.
+5. **Suggest concrete fixes** when possible. A 3-line code suggestion is more useful than a paragraph of prose. Use GitHub's `suggestion` code blocks when the fix is mechanical.
 
 ## Repository conventions to enforce
 
-- **Conventional Commits + scope** in PR titles: `<type>(<scope>): <subject> (#issue)`
+- **Conventional Commits + optional scope** in PR titles: `<type>: <subject>` or `<type>(<scope>): <subject>`
   - Types: `feat`, `fix`, `perf`, `refactor`, `chore`, `ci`, `docs`, `deps`, `test`, `build`, `style`
-  - Scope is optional, lower-case alphanumeric (e.g. `ui`, `nostr`, `dm`, `onboarding`)
-  - `feat`/`fix`/`perf`/`refactor` PRs must reference an issue with `Closes #N` in the body
+  - Scope is optional, lower-case alphanumeric when present (e.g. `ui`, `nostr`, `dm`, `onboarding`)
+  - A trailing `(#nnn)` issue suffix is allowed but optional; what's required (for `feat`/`fix`/`perf`/`refactor`) is at least one `Closes #nnn` line in the PR body — see `pr-lint.yml`
 - **All PRs include `## Test plan`** section with concrete steps or `N/A — <reason>`
 - **Mobile-specific:** all interactive elements need `accessibilityLabel` and/or `testID`. Maestro tests must use `id:` or `text:` selectors, never coordinates (see `CLAUDE.md`)
 - **Avatar caching:** every `expo-image` `<Image>` for an avatar must use `cachePolicy="memory-disk"` + `recyclingKey={picture}` + `autoplay={false}` (see PR #245 follow-ups)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# Copilot review instructions
+
+When reviewing pull requests in this repository, format your output to support **per-finding resolution** instead of a single bulk text response. Each distinct issue should be a separate inline comment so reviewers can address and resolve them one by one.
+
+## How to leave reviews
+
+1. **One inline comment per distinct finding.** Anchor each comment to the specific line(s) of code it concerns. Do NOT bundle multiple findings into a single inline comment, and do NOT put actionable findings in the top-level review summary — those can't be resolved individually.
+
+2. **Top-level review summary** should ONLY describe the PR overall (1-3 sentences on what the PR changes + a verdict). Do not put actionable items there.
+
+3. **Tag findings by severity** at the start of each comment so authors can prioritise:
+   - `[blocking]` — would cause a regression / bug / data loss / security issue if shipped
+   - `[suggestion]` — non-blocking improvement worth considering
+   - `[nit]` — small style / clarity / consistency note
+   - `[question]` — clarification request, not necessarily a fix
+
+4. **Each comment should be self-contained.** Include enough context that the author can act on it without scrolling back to the summary or other comments.
+
+5. **Suggest concrete fixes** when possible. A 3-line code suggestion is more useful than a paragraph of prose. Use GitHub's suggestion blocks (` ```suggestion `) when the fix is mechanical.
+
+## Repository conventions to enforce
+
+- **Conventional Commits + scope** in PR titles: `<type>(<scope>): <subject> (#issue)`
+  - Types: `feat`, `fix`, `perf`, `refactor`, `chore`, `ci`, `docs`, `deps`, `test`, `build`, `style`
+  - Scope is optional, lower-case alphanumeric (e.g. `ui`, `nostr`, `dm`, `onboarding`)
+  - `feat`/`fix`/`perf`/`refactor` PRs must reference an issue with `Closes #N` in the body
+- **All PRs include `## Test plan`** section with concrete steps or `N/A — <reason>`
+- **Mobile-specific:** all interactive elements need `accessibilityLabel` and/or `testID`. Maestro tests must use `id:` or `text:` selectors, never coordinates (see `CLAUDE.md`)
+- **Avatar caching:** every `expo-image` `<Image>` for an avatar must use `cachePolicy="memory-disk"` + `recyclingKey={picture}` + `autoplay={false}` (see PR #245 follow-ups)
+
+## What NOT to do
+
+- Don't repeat the same finding across multiple comments — pick the most specific anchor line
+- Don't comment on auto-formatted lines (Prettier already gates this)
+- Don't suggest naming changes for already-shipping symbols unless there's a real bug or ambiguity
+- Don't comment on commented-out code unless removing it would actually clean things up

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,93 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-lint:
+    name: Title, body and issue link
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title, body and issue reference
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -u
+
+          # Bots open PRs without ticket refs / test plans — skip with success
+          # (exit 0 inside the step, not a job-level `if:`, so the check still
+          # reports "success" rather than "skipped" and can be required).
+          if [ "$GITHUB_ACTOR" = 'dependabot[bot]' ] || [ "$GITHUB_ACTOR" = 'github-actions[bot]' ]; then
+            echo "Skipping PR lint for bot actor: $GITHUB_ACTOR"
+            exit 0
+          fi
+
+          fail=0
+
+          # 1. Title must use Conventional Commits + optional scope:
+          #      <type>(<scope>): <subject>           e.g. perf(ui): kill 5s GPU stall
+          #      <type>: <subject>                    e.g. docs: tidy README
+          #    Optional trailing "(#nnn)" or "(#nnn, #mmm)" issue suffix is allowed.
+          #    feat / fix / perf / refactor REQUIRE a "Closes #nnn" line in the body.
+          #    chore / ci / docs / deps / test / build / style do not.
+          title_regex='^(feat|fix|perf|refactor|chore|ci|docs|deps|test|build|style)(\([a-z0-9-]+\))?: .+'
+          if ! echo "$PR_TITLE" | grep -Eq "$title_regex"; then
+            echo "::error::PR title must follow: <type>(<scope>): <subject>"
+            echo "::error::types: feat, fix, perf, refactor, chore, ci, docs, deps, test, build, style"
+            echo "::error::scope is optional but lower-case alphanumeric (eg. ui, nostr, dm, onboarding)"
+            echo "::error::Got: '$PR_TITLE'"
+            fail=1
+          fi
+
+          # 2. Body must not be empty and must be a meaningful length
+          body_len=$(echo -n "${PR_BODY:-}" | wc -c)
+          if [ "$body_len" -lt 40 ]; then
+            echo "::error::PR body is missing or too short (<40 chars). Describe what changed and why."
+            fail=1
+          fi
+
+          # 3. feat / fix / perf / refactor PRs must contain at least one
+          #    'Closes #nnn' (or 'Fixes #nnn') line so GitHub auto-closes
+          #    the linked issue when the PR merges.
+          if echo "$PR_TITLE" | grep -Eq '^(feat|fix|perf|refactor)(\([a-z0-9-]+\))?: '; then
+            closes_regex='^(Closes|Fixes) #[0-9]+'
+            if ! echo "$PR_BODY" | grep -Eq "$closes_regex"; then
+              echo "::error::PR body must contain at least one 'Closes #nnn' line for"
+              echo "::error::feat/fix/perf/refactor PRs. Example:  Closes #123"
+              echo "::error::This auto-closes the linked issue when the PR merges."
+              fail=1
+            fi
+          else
+            echo "Non-issue PR prefix detected — skipping 'Closes #nnn' requirement."
+          fi
+
+          # 4. Body must include a Test plan section
+          if ! echo "$PR_BODY" | grep -Eq '^## Test plan'; then
+            echo "::error::PR body must include a '## Test plan' section."
+            echo "::error::Provide step-by-step tester actions, or 'N/A — <reason>'"
+            echo "::error::for pure refactor / docs / ci / deps with no user-visible change."
+            fail=1
+          else
+            tp_content=$(echo "$PR_BODY" | awk '
+              /^## Test plan/ {intp=1; next}
+              /^## / {intp=0}
+              intp {print}
+            ' | perl -0pe 's/<!--.*?-->//gs' | tr -d '[:space:]')
+            if [ -z "$tp_content" ]; then
+              echo "::error::'## Test plan' section is empty or only contains the template comment."
+              echo "::error::Add steps or 'N/A — <reason>'."
+              fail=1
+            fi
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "PR lint passed."


### PR DESCRIPTION
## Summary

Brings repo hygiene in line with sibling repos (\`../thyme\`, \`../zapdesk\`). Adds:

- **\`.github/workflows/pr-lint.yml\`** — Conventional Commits title check with scope support, required body length, required \`Closes #N\` for feat/fix/perf/refactor, required \`## Test plan\` section
- **\`.github/PULL_REQUEST_TEMPLATE.md\`** — scaffolds Summary / Closes / Test plan / Screenshots / Perf impact
- **\`.github/ISSUE_TEMPLATE/\`** — bug_report, feature_request, enhancement, config (4 files). Mobile-specific bug fields (device, signer, app versionCode)
- **\`.github/copilot-instructions.md\`** — tells Copilot to leave per-finding inline comments (resolvable independently) instead of bulk top-level summaries. Codifies severity tagging (\`[blocking]\`/\`[suggestion]\`/\`[nit]\`/\`[question]\`) and our repo conventions

## Why

Sibling repos already have most of these and our piggy-mobile repo is the outlier. The Copilot-instructions piece is new across the org and addresses Ben's observation that Copilot has been posting bulk top-level reviews instead of resolvable inline comments.

## Already done outside this PR

- Branch protection: \`required_conversation_resolution: true\` enabled on \`main\` via \`gh api\` so PRs can't merge while inline review threads remain open. Other settings preserved.

## Recommended follow-ups (not in this PR)

- Add \`Title, body and issue link\` (this workflow's job name) as a required status check on \`main\` once it has run on at least one PR. Configurable via Settings → Rules → Rulesets
- Consider \`required_linear_history\` on main (sibling repos enforce this; piggy currently allows merge commits)
- Adopt \`AGENTS.md\` style content (thyme has it; we have CLAUDE.md and could either point one at the other or merge)
- A separate PR will add CODEOWNERS

## Test plan

- [x] Workflow YAML parses (no \`on/permissions/jobs\` errors)
- [x] All template files render properly (frontmatter parses)
- [ ] Open one trivial PR after merge and verify the new \`pr-lint\` workflow runs (status: PR title gets the standard checks; PR body is required to include \`## Test plan\`)
- [ ] Confirm Copilot's next review uses inline comments per finding instead of bulk summary

## References

- \`../thyme/.github/workflows/pr-lint.yml\` — base for the workflow (adapted to allow our scope syntax)
- \`../thyme/.github/ISSUE_TEMPLATE/\` — templates adapted to mobile context
- Existing CLAUDE.md PR-title convention: \`<type>(<scope>): <subject> (#issue)\`