### PR TITLE
chore(repo): add CODEOWNERS routing all paths to @BenGWeeks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners for lightning-piggy-mobile
+#
+# Order matters: the LAST matching pattern takes precedence.
+# Patterns mirror .gitignore syntax.
+#
+# When a PR is opened, GitHub auto-requests reviews from the matching
+# owner(s). With branch-protection's `require_code_owner_reviews`
+# enabled, those reviews are required before merge.
+#
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/customizing-your-repository/about-code-owners
+
+# Catch-all — any path not matched by a more specific rule below
+# routes to @BenGWeeks for review.
+* @BenGWeeks


### PR DESCRIPTION
## Summary

Adds a top-level \`CODEOWNERS\` file with a single catch-all entry routing every path to \`@BenGWeeks\`. Once merged, every PR auto-requests review from Ben.

## Why

Sibling repos (\`../thyme\`, \`../zapdesk\`) have \`require_code_owner_reviews: true\` in branch protection but our piggy-mobile repo has neither the file nor the setting. This PR adds the file. Flipping the branch-protection toggle is a separate one-click change in GitHub Settings (deferred so this PR can land cleanly first).

## Test plan

- [x] CODEOWNERS file syntax matches GitHub's spec (single-pattern catch-all per the docs)
- [ ] After merge: open any new PR → confirm \`@BenGWeeks\` is auto-requested as reviewer
- [ ] Optional next step: enable \`require_code_owner_reviews\` in branch protection

## Out of scope

- Per-area splits (e.g. \`/android/ @android-folks\`, \`/src/services/nostr* @nostr-folks\`). Not needed while the team is one maintainer; revisit when more contributors join.