### PR TITLE
test(e2e): restrict group-membership flows to Piggy fixtures only

### DIFF
--- a/tests/e2e/README.adoc
+++ b/tests/e2e/README.adoc
@@ -1,0 +1,87 @@
+= Maestro E2E test suite
+
+Maestro flows in this directory run on the developer's AVD (and
+sometimes their physical Pixel) against *real* Nostr relays under the
+developer's *real* signed-in identity. There is no test relay or test
+sandbox — anything a flow does will publish real events that real
+contacts may see.
+
+That makes selector hygiene a safety issue, not just a code-quality
+issue. The rules below are enforced by hand on every PR that touches
+this directory.
+
+== Piggy-only fixtures (group membership)
+
+Any flow that *creates*, *adds members to*, *removes members from*, or
+otherwise mutates a Nostr group MUST scope its member-targeting
+selectors to the three Piggy test accounts and no others. A wildcard
+like `text: 'Remove .*'` or `id: 'member-row-.*'` could happily remove
+the developer's real friend from a real group, send a DM to a stranger,
+or otherwise leak test activity outside the controlled fixture set.
+
+The three Piggy accounts and their `member-row` / `group-member-remove`
+testID suffixes (first 12 hex chars of the pubkey, matching the
+`pubkey.slice(0, 12)` slicing in `CreateGroupSheet.tsx` and
+`GroupMembersSheet.tsx`):
+
+|===
+| Account      | testID suffix    | Notes
+
+| Big Piggy    | `ccedbff9a6f2`   | Default `MAESTRO_NSEC`. Usually the
+                                    logged-in user, so doesn't appear
+                                    in the *other* members list — appears
+                                    in `group-member-row-*` (with a
+                                    "· you" tag) but NOT in
+                                    `group-member-remove-*`.
+| Middle Piggy | `4b2fcb4e3c30`   | `MAESTRO_NSEC3`.
+| Little Piggy | `d9b33280ba73`   | `MAESTRO_NSEC2`. The default
+                                    `MEMBER_PUBKEY_PREFIX` for the
+                                    `test-create-leave-group.yaml` flow.
+|===
+
+The "Triad" fixture group (created by
+`test-3way-group-create-as-big.yaml`) has all three Piggies as members
+and is the canonical group to drive any member-mutation flow against.
+
+=== Selector rules
+
+Do:
+
+* `id: 'member-row-d9b33280ba73'` — full Piggy testID
+* `id: 'group-member-remove-d9b33280ba73'` — full Piggy testID
+* `id: 'member-row-${MEMBER_PUBKEY_PREFIX}'` — env var, with the
+  comment in the flow stating that the default + accepted values are
+  Piggy prefixes only
+* `text: 'Triad'` — exact, known fixture group name
+* `text: 'Open group Triad'` — accessibility-label exact match
+
+Don't:
+
+* `text: 'Remove .*'` — matches any member's X button, including real
+  friends
+* `id: 'member-row-.*'` — matches any contact in the picker
+* `text: 'Open group .*'` — opens whichever group happens to be at the
+  top, which on a real signed-in device is whatever the user's most
+  recent group activity is
+* `text: '.* members'` — same problem
+* Any other regex / substring that could resolve to a non-Piggy member
+  or non-fixture group
+
+=== When a flow can't use a Piggy prefix
+
+If a flow needs to exercise a code path the Piggies can't cover (e.g.
+something specific to a profile-card layout that only renders for a
+non-Piggy contact), the flow MUST be gated behind a `runFlow when:`
+clause that asserts a Piggy fixture is present, OR explicitly documented
+at the top of the file as "manual run only — do NOT add to run-all.sh".
+Don't ship an unguarded flow that taps a non-Piggy member.
+
+== Other safety conventions
+
+* Never use coordinate taps (`point:`, `tapOn: { point: }`,
+  `adb shell input tap`). See `CLAUDE.md` § Testing.
+* Never send a real Lightning payment from a flow. Use lightning
+  addresses that don't resolve (`test@example.com`) or invoices the
+  flow generates and then cancels.
+* Never tap "Confirm" / "Send" on a payment, contact-share, or DM
+  unless the recipient is another Piggy.

--- a/tests/e2e/test-group-manage-members.yaml
+++ b/tests/e2e/test-group-manage-members.yaml
@@ -6,11 +6,20 @@ name: Group manage-members sheet — open + add picker + remove flow
 # affordance that opens a manage-members bottom sheet, and that the
 # Remove path actually fires the confirmation alert.
 #
+# SAFETY (Piggy-only fixtures): this flow MUST target the "Triad" group
+# created by the 3-way group-chat fixture (test-3way-group-create-as-big.yaml)
+# and ONLY the Little Piggy member's Remove button (full testID
+# `group-member-remove-d9b33280ba73`). Earlier revisions used
+# `text: 'Open group .*'` and `text: 'Remove .*'`, which would happily
+# remove a real (non-Piggy) friend from a real group on Ben's signed-in
+# device. See tests/e2e/README.adoc § Piggy-only fixtures for the
+# member-prefix table.
+#
 # Preconditions:
-#   - User is logged in (nsec or Amber).
-#   - At least one group exists with at least 2 members.
-#   - At least one Nostr contact is NOT yet in that group (so "Add" has
-#     a valid candidate).
+#   - User is logged in as Big Piggy (MAESTRO_NSEC).
+#   - The "Triad" fixture group exists with Big + Middle + Little Piggy
+#     as members. Run `scripts/test-3way-group-chat.sh` first if it
+#     doesn't.
 #
 # Run: maestro test tests/e2e/test-group-manage-members.yaml
 
@@ -19,13 +28,21 @@ name: Group manage-members sheet — open + add picker + remove flow
 - waitForAnimationToEnd:
     timeout: 30000
 
-# Land on the Messages tab and pick the first visible group conversation.
+# Land on the Messages tab and open the Triad fixture group. We
+# scrollUntilVisible because Big follows ~50+ accounts and Triad may
+# be below the fold depending on recent activity.
 - tapOn:
     id: 'tab-messages'
 - waitForAnimationToEnd:
     timeout: 5000
+- scrollUntilVisible:
+    element:
+      text: 'Triad'
+    direction: DOWN
+    timeout: 8000
+    visibilityPercentage: 50
 - tapOn:
-    text: 'Open group .*'
+    text: 'Triad'
 - waitForAnimationToEnd:
     timeout: 5000
 
@@ -48,9 +65,9 @@ name: Group manage-members sheet — open + add picker + remove flow
 - waitForAnimationToEnd:
     timeout: 2000
 
-# Picker should be visible. We don't drive a selection here (the test
-# device's contacts vary); we just confirm the picker opened, then close
-# it via hardware back so the test cleans up.
+# Picker should be visible. We don't drive a selection here (any tap
+# would publish a real kind:30200 update) — just confirm the picker
+# opened, then close it via hardware back so the test cleans up.
 - assertVisible:
     id: 'friend-picker-search'
 - back
@@ -69,18 +86,19 @@ name: Group manage-members sheet — open + add picker + remove flow
 - assertVisible:
     id: 'group-member-count'
 
-# Re-open the sheet and exercise the Remove path. We can't predict
-# the testID suffix (`group-member-remove-${pubkey-prefix}`) without
-# a stable test fixture, so use the accessibilityLabel pattern
-# `Remove .*` to match any non-self member's X button. Self has no
-# Remove button (per the GroupMembersSheet self-guard) so this is
-# always a real other-member.
+# Re-open the sheet and exercise the Remove path on a SPECIFIC Piggy
+# fixture member (Little Piggy, pubkey prefix d9b33280ba73). DO NOT
+# replace this with a wildcard — this device runs Maestro against the
+# user's real Nostr identity and a wildcard could remove a real friend
+# from the Triad group, leaking test activity to non-test accounts.
 - tapOn:
     id: 'group-member-count'
 - waitForAnimationToEnd:
     timeout: 2000
+- assertVisible:
+    id: 'group-member-remove-d9b33280ba73'
 - tapOn:
-    text: 'Remove .*'
+    id: 'group-member-remove-d9b33280ba73'
 - waitForAnimationToEnd:
     timeout: 1500
 


### PR DESCRIPTION
## Summary

- Replace wildcard selectors in `tests/e2e/test-group-manage-members.yaml` (added in #260) with explicit Piggy fixtures so the flow can never remove a real (non-Piggy) friend from a real group on Ben's signed-in AVD / phone.
- Open the **Triad** fixture group by exact name (created by `test-3way-group-create-as-big.yaml`) instead of `text: 'Open group .*'`.
- Target Little Piggy's Remove button by full testID `group-member-remove-d9b33280ba73` instead of `text: 'Remove .*'`.
- Add `tests/e2e/README.adoc` documenting the Piggy-only fixture rule, the three Piggy testID suffixes, and the do/don't selector list so future flow authors can't recreate the wildcard problem.

### Audit results

Every flow under `tests/e2e/` (including `keyboard-audit/` and `_subflow-*.yaml`) was inspected. Only three flows touch group-membership mutation; two were already safe.

| Flow file | Before selector | After selector | Status |
| --- | --- | --- | --- |
| `tests/e2e/test-group-manage-members.yaml` | `text: 'Open group .*'` | `text: 'Triad'` (with `scrollUntilVisible`) | Fixed |
| `tests/e2e/test-group-manage-members.yaml` | `text: 'Remove .*'` | `id: 'group-member-remove-d9b33280ba73'` | Fixed |
| `tests/e2e/test-3way-group-create-as-big.yaml` | `id: 'member-row-d9b33280ba73'`, `id: 'member-row-4b2fcb4e3c30'` | (unchanged) | Already safe |
| `tests/e2e/test-create-leave-group.yaml` | `id: 'member-row-${MEMBER_PUBKEY_PREFIX}'` (default `d9b33280ba73`) | (unchanged) | Already safe |

All other flows that mention "group" (e.g. `test-3way-group-as-{little,middle}.yaml`, `test-3way-group-rename-as-big.yaml`, `test-3way-group-rename-confirm-as-middle.yaml`, `test-rename-group.yaml`, `test-group-conversation-keyboard.yaml`, `test-group-attach-tiles.yaml`, `test-group-rich-cards.yaml`, `keyboard-audit/04-create-group-name.yaml`, `keyboard-audit/11-rename-group.yaml`) only navigate to / send messages in / rename groups — they do not add or remove members and so don't need changes.

### Pubkey prefixes (derived via `node scripts/derive-pubkey-from-env.mjs`)

| Account | Env var | testID suffix |
| --- | --- | --- |
| Big Piggy | `MAESTRO_NSEC` | `ccedbff9a6f2` (logged-in user; `member-row-*` only, no Remove button) |
| Middle Piggy | `MAESTRO_NSEC3` | `4b2fcb4e3c30` |
| Little Piggy | `MAESTRO_NSEC2` | `d9b33280ba73` |

## Test plan

- [ ] `maestro test tests/e2e/test-group-manage-members.yaml` after the 3-way group fixture is in place — the flow should still pass with the tighter selectors.
- [ ] `scripts/test-3way-group-chat.sh` continues to pass (no selectors loosened, only tightened in the unrelated manage-members flow).
- [ ] `tests/e2e/README.adoc` renders correctly on GitHub.