### PR TITLE
test: raise unit-test coverage across services + utils

### DIFF
--- a/src/services/fiatService.test.ts
+++ b/src/services/fiatService.test.ts
@@ -32,15 +32,28 @@ describe('satsToFiat', () => {
 describe('formatFiat', () => {
   it('renders an amount with 2 decimal places + currency symbol', () => {
     const out = formatFiat(12.34, 'USD');
-    expect(out).toContain('12.34');
-    // Don't lock the symbol position (locale-specific) — just check
-    // both the number and currency identifier are present.
+    // formatFiat goes through `toLocaleString(undefined, ...)`, so the
+    // decimal separator (.,) and grouping/spacing are locale-driven.
+    // Compute the locale-correct fraction substring at runtime so the
+    // assertion is valid on `de-DE` ("12,34 $") just as much as on
+    // `en-US` ("$12.34").
+    const expectedNumber = (12.34).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    expect(out).toContain(expectedNumber);
   });
 
   it('renders sub-cent amounts as "< <symbol>0.01"', () => {
     const out = formatFiat(0.0001, 'USD');
     expect(out.startsWith('< ')).toBe(true);
-    expect(out).toContain('0.01');
+    // Compute the locale-correct "0.01" substring (`0,01` on `de-DE`
+    // etc.) so the assertion is locale-agnostic.
+    const expectedFloor = (0.01).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    expect(out).toContain(expectedFloor);
   });
 
   it('does not collapse 0 to "< 0.01"', () => {
@@ -56,6 +69,14 @@ describe('satsToFiatString', () => {
 
   it('formats sats into the localised currency string when a price is given', () => {
     const out = satsToFiatString(100_000, 50_000, 'USD');
-    expect(out).toContain('50.00');
+    // Like formatFiat above, the result goes through
+    // toLocaleString(undefined, ...) — compute the expected `50.00`
+    // substring in the host locale so this passes on `de-DE` /
+    // `fr-FR` / etc., where the decimal separator differs.
+    const expected = (50).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    expect(out).toContain(expected);
   });
 });

--- a/src/services/fiatService.test.ts
+++ b/src/services/fiatService.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Coverage for the pure formatting / arithmetic helpers in fiatService.
+ * The cached `getBtcPrice` network path is out of scope here — the cache
+ * is module-level which would cross-pollinate between cases, and the
+ * fetch wrapper is best validated end-to-end from a flow test rather
+ * than a Jest fixture.
+ */
+
+import { formatFiat, satsToFiat, satsToFiatString, CURRENCIES } from './fiatService';
+
+describe('CURRENCIES', () => {
+  it('exports the expected ISO-4217 codes', () => {
+    expect(CURRENCIES).toEqual(['USD', 'EUR', 'GBP', 'AUD', 'CAD', 'CHF', 'JPY', 'ZAR']);
+  });
+});
+
+describe('satsToFiat', () => {
+  it('converts sats to fiat using the provided BTC price', () => {
+    // 1 BTC = 100M sats. At $50,000/BTC, 100,000 sats = $50.
+    expect(satsToFiat(100_000, 50_000)).toBeCloseTo(50, 5);
+  });
+
+  it('returns 0 when sats is 0', () => {
+    expect(satsToFiat(0, 50_000)).toBe(0);
+  });
+
+  it('returns 0 when btcPrice is 0', () => {
+    expect(satsToFiat(100_000, 0)).toBe(0);
+  });
+});
+
+describe('formatFiat', () => {
+  it('renders an amount with 2 decimal places + currency symbol', () => {
+    const out = formatFiat(12.34, 'USD');
+    expect(out).toContain('12.34');
+    // Don't lock the symbol position (locale-specific) — just check
+    // both the number and currency identifier are present.
+  });
+
+  it('renders sub-cent amounts as "< <symbol>0.01"', () => {
+    const out = formatFiat(0.0001, 'USD');
+    expect(out.startsWith('< ')).toBe(true);
+    expect(out).toContain('0.01');
+  });
+
+  it('does not collapse 0 to "< 0.01"', () => {
+    const out = formatFiat(0, 'USD');
+    expect(out.startsWith('< ')).toBe(false);
+  });
+});
+
+describe('satsToFiatString', () => {
+  it('returns an empty string when btcPrice is null', () => {
+    expect(satsToFiatString(100_000, null, 'USD')).toBe('');
+  });
+
+  it('formats sats into the localised currency string when a price is given', () => {
+    const out = satsToFiatString(100_000, 50_000, 'USD');
+    expect(out).toContain('50.00');
+  });
+});

--- a/src/services/giphyService.test.ts
+++ b/src/services/giphyService.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Coverage for the pure helpers in giphyService: API-key gate
+ * (`isConfigured`) and the message-body GIF detector (`extractGifUrl`).
+ * The network paths (`searchGifs`, `getTrending`) are out of scope here
+ * — they hit GIPHY over `fetch`, not what we want from a unit test.
+ */
+
+import { extractGifUrl, isConfigured } from './giphyService';
+
+describe('isConfigured', () => {
+  const ORIGINAL = process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+    else process.env.EXPO_PUBLIC_GIPHY_API_KEY = ORIGINAL;
+  });
+
+  it('returns true when EXPO_PUBLIC_GIPHY_API_KEY is set', () => {
+    process.env.EXPO_PUBLIC_GIPHY_API_KEY = 'k123';
+    expect(isConfigured()).toBe(true);
+  });
+
+  it('returns false when the env var is empty / unset', () => {
+    process.env.EXPO_PUBLIC_GIPHY_API_KEY = '';
+    expect(isConfigured()).toBe(false);
+  });
+});
+
+describe('extractGifUrl', () => {
+  it('returns null for empty input', () => {
+    expect(extractGifUrl('')).toBeNull();
+  });
+
+  it('matches a bare i.giphy.com URL', () => {
+    const url = 'https://i.giphy.com/media/abc123/giphy.gif';
+    expect(extractGifUrl(url)).toBe(url);
+  });
+
+  it('matches numbered media subdomains', () => {
+    const url = 'https://media2.giphy.com/media/abc/giphy.gif';
+    expect(extractGifUrl(url)).toBe(url);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    const url = 'https://i.giphy.com/media/x/giphy.gif';
+    expect(extractGifUrl(`  ${url}  `)).toBe(url);
+  });
+
+  it('rejects when the URL is mid-sentence (not the entire body)', () => {
+    // Per the source comment: a URL in the middle of a user-typed
+    // message is still a text message, not a GIF card.
+    expect(extractGifUrl('check this https://i.giphy.com/media/abc/giphy.gif please')).toBeNull();
+  });
+
+  it('rejects non-giphy hosts even with a .gif extension', () => {
+    expect(extractGifUrl('https://example.com/foo.gif')).toBeNull();
+  });
+
+  it('rejects unsupported extensions on a giphy host', () => {
+    // The send path emits .gif specifically; any other extension means
+    // the picker / sender isn't the source — don't auto-inline.
+    expect(extractGifUrl('https://media.giphy.com/media/abc/giphy.webp')).toBeNull();
+  });
+});

--- a/src/services/groupRoutingRegistry.test.ts
+++ b/src/services/groupRoutingRegistry.test.ts
@@ -61,14 +61,17 @@ describe('findGroupForParticipants', () => {
     expect(hit).toBe(g);
   });
 
-  it('treats lookups case-insensitively', () => {
-    const g = makeGroup('g1', [PK_A, PK_B]);
+  it('normalises stored member pubkeys to lowercase before comparing', () => {
+    // findGroupForParticipants compares `pk.toLowerCase()` (stored
+    // member) against the participant set as-is, so the case-folding
+    // it actually performs is on the stored side. Register the group
+    // with uppercase members and look up with lowercase to exercise
+    // that branch — using `.toUpperCase().toLowerCase()` on both
+    // sides (as the test used to) just folds back to lowercase before
+    // the call and never reaches the normalisation code path.
+    const g = makeGroup('g1', [PK_A.toUpperCase(), PK_B.toUpperCase()]);
     setKnownGroups([g]);
-    // Lookup uses lowercase comparison against the stored member list,
-    // so an upper-case participant set still matches.
-    const hit = findGroupForParticipants(
-      new Set([PK_A.toUpperCase().toLowerCase(), PK_B.toLowerCase()]),
-    );
+    const hit = findGroupForParticipants(new Set([PK_A, PK_B]));
     expect(hit).toBe(g);
   });
 

--- a/src/services/groupRoutingRegistry.test.ts
+++ b/src/services/groupRoutingRegistry.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Coverage for the in-memory group registry that NostrContext consults
+ * during NIP-17 decrypt to route inbound kind-14 rumors to the right
+ * local thread. Resets module state between tests so registrations
+ * from one case can't leak into another.
+ */
+
+import {
+  findGroupForParticipants,
+  getKnownGroups,
+  reconcileSyntheticGroup,
+  setKnownGroups,
+  setSyntheticGroupReconciler,
+  type SyntheticRoomInput,
+} from './groupRoutingRegistry';
+import type { Group } from '../types/groups';
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+const PK_C = 'c'.repeat(64);
+
+function makeGroup(id: string, members: string[]): Group {
+  return {
+    id,
+    name: `Group ${id}`,
+    memberPubkeys: members,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+beforeEach(() => {
+  // Reset shared module state so each test starts from a clean slate.
+  setKnownGroups([]);
+  setSyntheticGroupReconciler(null);
+});
+
+describe('setKnownGroups / getKnownGroups', () => {
+  it('starts empty', () => {
+    expect(getKnownGroups()).toEqual([]);
+  });
+
+  it('replaces the registered list on each set', () => {
+    setKnownGroups([makeGroup('g1', [PK_A])]);
+    setKnownGroups([makeGroup('g2', [PK_B])]);
+    const known = getKnownGroups();
+    expect(known).toHaveLength(1);
+    expect(known[0].id).toBe('g2');
+  });
+});
+
+describe('findGroupForParticipants', () => {
+  it('returns null when nothing is registered', () => {
+    expect(findGroupForParticipants(new Set([PK_A, PK_B]))).toBeNull();
+  });
+
+  it('matches a group whose member set equals the participant set', () => {
+    const g = makeGroup('g1', [PK_A, PK_B]);
+    setKnownGroups([g]);
+    const hit = findGroupForParticipants(new Set([PK_A, PK_B]));
+    expect(hit).toBe(g);
+  });
+
+  it('treats lookups case-insensitively', () => {
+    const g = makeGroup('g1', [PK_A, PK_B]);
+    setKnownGroups([g]);
+    // Lookup uses lowercase comparison against the stored member list,
+    // so an upper-case participant set still matches.
+    const hit = findGroupForParticipants(
+      new Set([PK_A.toUpperCase().toLowerCase(), PK_B.toLowerCase()]),
+    );
+    expect(hit).toBe(g);
+  });
+
+  it('rejects partial overlaps (different size)', () => {
+    setKnownGroups([makeGroup('g1', [PK_A, PK_B])]);
+    expect(findGroupForParticipants(new Set([PK_A]))).toBeNull();
+    expect(findGroupForParticipants(new Set([PK_A, PK_B, PK_C]))).toBeNull();
+  });
+
+  it('rejects same-size sets that disagree on at least one member', () => {
+    setKnownGroups([makeGroup('g1', [PK_A, PK_B])]);
+    expect(findGroupForParticipants(new Set([PK_A, PK_C]))).toBeNull();
+  });
+});
+
+describe('reconcileSyntheticGroup', () => {
+  it('returns null when no reconciler is registered', async () => {
+    const out = await reconcileSyntheticGroup({
+      groupId: 's_test',
+      name: 'x',
+      memberPubkeys: [PK_A],
+      createdAtSec: 0,
+    });
+    expect(out).toBeNull();
+  });
+
+  it('forwards the input to the registered reconciler and returns its result', async () => {
+    const expected = makeGroup('s_test', [PK_A]);
+    const calls: SyntheticRoomInput[] = [];
+    setSyntheticGroupReconciler(async (input) => {
+      calls.push(input);
+      return expected;
+    });
+    const input: SyntheticRoomInput = {
+      groupId: 's_test',
+      name: 'Cross-client room',
+      memberPubkeys: [PK_A],
+      createdAtSec: 1234,
+    };
+    const out = await reconcileSyntheticGroup(input);
+    expect(out).toBe(expected);
+    expect(calls).toEqual([input]);
+  });
+
+  it('clears the reconciler when set back to null', async () => {
+    setSyntheticGroupReconciler(async () => makeGroup('s_test', [PK_A]));
+    setSyntheticGroupReconciler(null);
+    const out = await reconcileSyntheticGroup({
+      groupId: 's_test',
+      name: 'x',
+      memberPubkeys: [PK_A],
+      createdAtSec: 0,
+    });
+    expect(out).toBeNull();
+  });
+});

--- a/src/services/groupsStorageService.test.ts
+++ b/src/services/groupsStorageService.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Coverage for the AsyncStorage-backed groups + group-activity store.
+ * The schema-validation path on `loadGroupActivity` is the load-bearing
+ * one — `formatConversationTimestamp` throws RangeError on a non-finite
+ * lastActivityAt, so the cache MUST drop entries that fail the shape
+ * check rather than passing them through.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  createGroupId,
+  loadGroupActivity,
+  loadGroups,
+  saveGroupActivity,
+  saveGroups,
+} from './groupsStorageService';
+import type { Group, GroupActivity } from '../types/groups';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run before ESM imports are hoisted; require is the canonical form.
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+const PUBKEY = 'a'.repeat(64);
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('createGroupId', () => {
+  it('returns a string with the g_ prefix', () => {
+    expect(createGroupId().startsWith('g_')).toBe(true);
+  });
+
+  it('returns distinct ids on successive calls', () => {
+    const a = createGroupId();
+    const b = createGroupId();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('loadGroups / saveGroups', () => {
+  it('returns an empty array when nothing is stored', async () => {
+    expect(await loadGroups()).toEqual([]);
+  });
+
+  it('round-trips a list of groups', async () => {
+    const groups: Group[] = [
+      {
+        id: 'g_1',
+        name: 'Test',
+        memberPubkeys: ['x'],
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ];
+    await saveGroups(groups);
+    expect(await loadGroups()).toEqual(groups);
+  });
+
+  it('returns an empty array when the persisted JSON is not an array', async () => {
+    await AsyncStorage.setItem('nostr_groups', JSON.stringify({ wrong: 'shape' }));
+    expect(await loadGroups()).toEqual([]);
+  });
+
+  it('returns an empty array when the persisted blob is invalid JSON', async () => {
+    await AsyncStorage.setItem('nostr_groups', '{{{not json');
+    expect(await loadGroups()).toEqual([]);
+  });
+});
+
+describe('loadGroupActivity / saveGroupActivity', () => {
+  function validActivity(): GroupActivity {
+    return {
+      lastActivityAt: 1234,
+      lastText: 'hi',
+      lastSenderPubkey: 'b'.repeat(64),
+      recentSenderPubkeys: ['b'.repeat(64)],
+    };
+  }
+
+  it('returns {} when nothing is stored for the pubkey', async () => {
+    expect(await loadGroupActivity(PUBKEY)).toEqual({});
+  });
+
+  it('round-trips a valid activity map', async () => {
+    const map: Record<string, GroupActivity> = { g1: validActivity() };
+    await saveGroupActivity(PUBKEY, map);
+    expect(await loadGroupActivity(PUBKEY)).toEqual(map);
+  });
+
+  it('drops entries whose lastActivityAt is not a finite number', async () => {
+    // The shape guard exists specifically because
+    // formatConversationTimestamp throws on a non-finite ts. A malformed
+    // entry must be silently dropped rather than crashing the inbox on
+    // mount.
+    const stored = {
+      g_good: validActivity(),
+      g_nan: { ...validActivity(), lastActivityAt: NaN },
+      g_str: { ...validActivity(), lastActivityAt: '123' },
+      g_inf: { ...validActivity(), lastActivityAt: Infinity },
+    };
+    await AsyncStorage.setItem(`nostr_group_activity_${PUBKEY}`, JSON.stringify(stored));
+    const loaded = await loadGroupActivity(PUBKEY);
+    expect(Object.keys(loaded)).toEqual(['g_good']);
+  });
+
+  it('drops entries missing required fields', async () => {
+    const stored = {
+      // valid → keep
+      g_good: validActivity(),
+      // missing lastText
+      g_no_text: {
+        lastActivityAt: 1,
+        lastSenderPubkey: null,
+        recentSenderPubkeys: [],
+      },
+      // recentSenderPubkeys not an array
+      g_no_arr: {
+        lastActivityAt: 1,
+        lastText: 'x',
+        lastSenderPubkey: null,
+        recentSenderPubkeys: 'nope',
+      },
+    };
+    await AsyncStorage.setItem(`nostr_group_activity_${PUBKEY}`, JSON.stringify(stored));
+    const loaded = await loadGroupActivity(PUBKEY);
+    expect(Object.keys(loaded).sort()).toEqual(['g_good']);
+  });
+
+  it('returns {} when the persisted JSON is an array (wrong shape)', async () => {
+    await AsyncStorage.setItem(`nostr_group_activity_${PUBKEY}`, JSON.stringify([1, 2, 3]));
+    expect(await loadGroupActivity(PUBKEY)).toEqual({});
+  });
+
+  it('returns {} on invalid JSON', async () => {
+    await AsyncStorage.setItem(`nostr_group_activity_${PUBKEY}`, '!!!');
+    expect(await loadGroupActivity(PUBKEY)).toEqual({});
+  });
+});

--- a/src/services/groupsStorageService.test.ts
+++ b/src/services/groupsStorageService.test.ts
@@ -91,18 +91,43 @@ describe('loadGroupActivity / saveGroupActivity', () => {
 
   it('drops entries whose lastActivityAt is not a finite number', async () => {
     // The shape guard exists specifically because
-    // formatConversationTimestamp throws on a non-finite ts. A malformed
-    // entry must be silently dropped rather than crashing the inbox on
-    // mount.
+    // formatConversationTimestamp throws on a non-finite ts. A
+    // malformed entry must be silently dropped rather than crashing
+    // the inbox on mount.
+    //
+    // We can't round-trip NaN / Infinity through AsyncStorage via
+    // JSON.stringify — both get coerced to `null`, which would
+    // degenerate this case into the "non-number" branch and let a
+    // regression that removes the `Number.isFinite(...)` guard slip
+    // through. Spy on JSON.parse for exactly one call so the parsed
+    // object actually contains NaN / Infinity, exercising the finite-
+    // number branch the production guard cares about.
     const stored = {
       g_good: validActivity(),
-      g_nan: { ...validActivity(), lastActivityAt: NaN },
+      g_nan: { ...validActivity(), lastActivityAt: '__NaN' },
       g_str: { ...validActivity(), lastActivityAt: '123' },
-      g_inf: { ...validActivity(), lastActivityAt: Infinity },
+      g_inf: { ...validActivity(), lastActivityAt: '__Infinity' },
     };
-    await AsyncStorage.setItem(`nostr_group_activity_${PUBKEY}`, JSON.stringify(stored));
-    const loaded = await loadGroupActivity(PUBKEY);
-    expect(Object.keys(loaded)).toEqual(['g_good']);
+    const raw = JSON.stringify(stored);
+    const realParse = JSON.parse;
+    const spy = jest.spyOn(JSON, 'parse').mockImplementationOnce(((text: string) => {
+      const parsed = realParse(text);
+      if (parsed && typeof parsed === 'object') {
+        for (const key of Object.keys(parsed)) {
+          const entry = (parsed as Record<string, { lastActivityAt: unknown }>)[key];
+          if (entry && entry.lastActivityAt === '__NaN') entry.lastActivityAt = NaN;
+          if (entry && entry.lastActivityAt === '__Infinity') entry.lastActivityAt = Infinity;
+        }
+      }
+      return parsed;
+    }) as typeof JSON.parse);
+    try {
+      await AsyncStorage.setItem(`nostr_group_activity_${PUBKEY}`, raw);
+      const loaded = await loadGroupActivity(PUBKEY);
+      expect(Object.keys(loaded)).toEqual(['g_good']);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('drops entries missing required fields', async () => {

--- a/src/services/learnProgressService.test.ts
+++ b/src/services/learnProgressService.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Coverage for the AsyncStorage-backed Learn-progress store. The pure
+ * helpers (isMissionComplete / getCourseCompletedCount / isCourseComplete)
+ * don't touch storage at all so they're tested directly; the async
+ * read/write helpers get the official AsyncStorage jest mock.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getCourseCompletedCount,
+  getProgress,
+  isCourseComplete,
+  isMissionComplete,
+  markMissionComplete,
+  markMissionIncomplete,
+} from './learnProgressService';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run before ESM imports are hoisted; require is the canonical form.
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('getProgress', () => {
+  it('returns an empty progress object on first run', async () => {
+    expect(await getProgress()).toEqual({ completedMissions: [] });
+  });
+
+  it('returns the parsed payload when present', async () => {
+    await AsyncStorage.setItem(
+      'learn_progress',
+      JSON.stringify({ completedMissions: ['m1', 'm2'] }),
+    );
+    expect(await getProgress()).toEqual({ completedMissions: ['m1', 'm2'] });
+  });
+
+  it('rejects malformed payloads and returns the empty default', async () => {
+    // Schema-shape guard: anything missing `completedMissions` array
+    // is treated as no-progress so the UI doesn't blow up.
+    await AsyncStorage.setItem('learn_progress', JSON.stringify({ junk: true }));
+    expect(await getProgress()).toEqual({ completedMissions: [] });
+  });
+
+  it('returns the empty default on JSON parse failure', async () => {
+    // Silence the expected console.warn so the test output stays clean —
+    // the warn is a deliberate part of the function under test, but
+    // surfacing it on a passing case clutters CI logs.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await AsyncStorage.setItem('learn_progress', 'not json{{{');
+      expect(await getProgress()).toEqual({ completedMissions: [] });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe('markMissionComplete', () => {
+  it('adds a new mission id to the persisted list', async () => {
+    const out = await markMissionComplete('m1');
+    expect(out.completedMissions).toEqual(['m1']);
+    const round = await getProgress();
+    expect(round.completedMissions).toEqual(['m1']);
+  });
+
+  it('is idempotent — re-marking the same mission does not duplicate it', async () => {
+    await markMissionComplete('m1');
+    const out = await markMissionComplete('m1');
+    expect(out.completedMissions).toEqual(['m1']);
+  });
+});
+
+describe('markMissionIncomplete', () => {
+  it('removes an existing mission id from the persisted list', async () => {
+    await markMissionComplete('m1');
+    await markMissionComplete('m2');
+    const out = await markMissionIncomplete('m1');
+    expect(out.completedMissions).toEqual(['m2']);
+  });
+
+  it('is a no-op when the mission was never completed', async () => {
+    const out = await markMissionIncomplete('never');
+    expect(out.completedMissions).toEqual([]);
+  });
+});
+
+describe('pure helpers', () => {
+  it('isMissionComplete checks list membership', () => {
+    const p = { completedMissions: ['m1', 'm2'] };
+    expect(isMissionComplete(p, 'm1')).toBe(true);
+    expect(isMissionComplete(p, 'm9')).toBe(false);
+  });
+
+  it('getCourseCompletedCount counts intersected missions', () => {
+    const p = { completedMissions: ['m1', 'm3'] };
+    expect(getCourseCompletedCount(p, ['m1', 'm2', 'm3', 'm4'])).toBe(2);
+    expect(getCourseCompletedCount(p, [])).toBe(0);
+  });
+
+  it('isCourseComplete is true only when every mission is completed', () => {
+    const p = { completedMissions: ['m1', 'm2'] };
+    expect(isCourseComplete(p, ['m1', 'm2'])).toBe(true);
+    expect(isCourseComplete(p, ['m1', 'm2', 'm3'])).toBe(false);
+    // Empty course is vacuously complete.
+    expect(isCourseComplete(p, [])).toBe(true);
+  });
+});

--- a/src/services/locationService.test.ts
+++ b/src/services/locationService.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Coverage for the pure (non-permission) helpers in locationService:
+ * geo: URI formatter + parser, OSM URL builder, slippy-map URL builder,
+ * coords formatter. The permission-gated `getCurrentLocation` flow is
+ * out of scope here — it depends on Expo's Location runtime and would
+ * require mocking expo-location wholesale.
+ */
+
+import {
+  buildOsmViewUrl,
+  buildStaticMapUrl,
+  formatCoordsForDisplay,
+  formatGeoMessage,
+  parseGeoMessage,
+  USER_AGENT,
+} from './locationService';
+
+describe('formatGeoMessage', () => {
+  it('emits the geo: URI + OSM link with 5 decimal places', () => {
+    const out = formatGeoMessage({ lat: 51.50735, lon: -0.12776, accuracyMeters: 12 });
+    expect(out).toContain('geo:51.50735,-0.12776;u=12');
+    expect(out).toContain('https://www.openstreetmap.org/?mlat=51.50735&mlon=-0.12776');
+    // The leading 📍 emoji is part of the contract — clients without a
+    // geo-URI parser still see something meaningful.
+    expect(out).toContain('📍');
+  });
+
+  it('omits the ;u= suffix when no accuracy is known', () => {
+    const out = formatGeoMessage({ lat: 0, lon: 0, accuracyMeters: null });
+    expect(out).toContain('geo:0.00000,0.00000\n');
+    expect(out).not.toContain(';u=');
+  });
+});
+
+describe('parseGeoMessage', () => {
+  it('returns null for empty / non-matching input', () => {
+    expect(parseGeoMessage('')).toBeNull();
+    expect(parseGeoMessage('hello')).toBeNull();
+  });
+
+  it('round-trips a formatted message', () => {
+    const original = { lat: 12.34567, lon: -76.54321, accuracyMeters: 9 };
+    const out = parseGeoMessage(formatGeoMessage(original));
+    expect(out).toEqual(original);
+  });
+
+  it('parses a bare geo: URI without any surrounding text', () => {
+    expect(parseGeoMessage('geo:1.0,2.0')).toEqual({
+      lat: 1.0,
+      lon: 2.0,
+      accuracyMeters: null,
+    });
+  });
+
+  it('rejects out-of-range coordinates', () => {
+    expect(parseGeoMessage('geo:91,0')).toBeNull();
+    expect(parseGeoMessage('geo:0,181')).toBeNull();
+    expect(parseGeoMessage('geo:-91,0')).toBeNull();
+  });
+
+  it('rejects nonsense accuracy values but still returns the coordinates', () => {
+    // Accuracy past the 40_000_000 m ceiling is dropped to null,
+    // not allowed to bubble up as an absurd radius.
+    expect(parseGeoMessage('geo:0,0;u=99999999999')).toEqual({
+      lat: 0,
+      lon: 0,
+      accuracyMeters: null,
+    });
+  });
+});
+
+describe('buildOsmViewUrl', () => {
+  it('includes mlat/mlon and the configured zoom', () => {
+    const out = buildOsmViewUrl({ lat: 1.234567, lon: 2.345678, accuracyMeters: null });
+    expect(out).toContain('mlat=1.23457');
+    expect(out).toContain('mlon=2.34568');
+    expect(out).toContain('#map=16/');
+  });
+
+  it('respects a custom zoom', () => {
+    const out = buildOsmViewUrl({ lat: 0, lon: 0, accuracyMeters: null }, 11);
+    expect(out).toContain('#map=11/');
+  });
+});
+
+describe('buildStaticMapUrl', () => {
+  it('returns a tile.openstreetmap.org URL with z/x/y in path', () => {
+    const out = buildStaticMapUrl({ lat: 0, lon: 0, accuracyMeters: null });
+    expect(out).toMatch(/^https:\/\/tile\.openstreetmap\.org\/15\/\d+\/\d+\.png$/);
+  });
+
+  it('respects a custom zoom level', () => {
+    const out = buildStaticMapUrl({ lat: 0, lon: 0, accuracyMeters: null }, { zoom: 4 });
+    expect(out).toMatch(/^https:\/\/tile\.openstreetmap\.org\/4\/\d+\/\d+\.png$/);
+  });
+});
+
+describe('formatCoordsForDisplay', () => {
+  it('renders a positive lat/lon with N/E', () => {
+    expect(formatCoordsForDisplay({ lat: 1.23456, lon: 2.34567, accuracyMeters: null })).toBe(
+      '1.2346° N, 2.3457° E',
+    );
+  });
+
+  it('renders a negative lat/lon with S/W', () => {
+    expect(formatCoordsForDisplay({ lat: -1.23456, lon: -2.34567, accuracyMeters: null })).toBe(
+      '1.2346° S, 2.3457° W',
+    );
+  });
+});
+
+describe('USER_AGENT', () => {
+  it('includes the LightningPiggyMobile app identifier', () => {
+    expect(USER_AGENT).toContain('LightningPiggyMobile/');
+    expect(USER_AGENT).toContain('lightningpiggy.com');
+  });
+});

--- a/src/services/nostrService.test.ts
+++ b/src/services/nostrService.test.ts
@@ -4,9 +4,27 @@
  * Quartz, 0xchat) read to display the group name — Lightning
  * Piggy's outgoing messages MUST include it for cross-client
  * interop. Issue #271.
+ *
+ * Plus coverage for the pure helpers in nostrService that don't need
+ * a SimplePool / relay round-trip (NIP-19 round-trips, profile
+ * reference decoding, kind-0 tolerance, nprofile relay hint
+ * dedup + cap). Per the project convention these are co-located in
+ * the single `<file>.test.ts` next to the subject.
  */
 
-import { createGroupChatRumor } from './nostrService';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { nsecEncode } from 'nostr-tools/nip19';
+
+import {
+  buildProfileRelayHints,
+  createGroupChatRumor,
+  decodeNsec,
+  decodeProfileReference,
+  DEFAULT_RELAYS,
+  nprofileEncode,
+  npubEncode,
+  parseProfileContent,
+} from './nostrService';
 
 const PK_A = 'a'.repeat(64);
 const PK_B = 'b'.repeat(64);
@@ -45,5 +63,165 @@ describe('createGroupChatRumor (outgoing kind-14)', () => {
     expect(rumor.kind).toBe(14);
     expect(rumor.pubkey).toBe(PK_A);
     expect(rumor.content).toBe('hi');
+  });
+});
+
+// Reference participant for the PK_C-touched rumor expectation kept in
+// the original interop block; not removing as it's still used implicitly
+// by createGroupChatRumor recipient asserts above.
+void PK_C;
+
+describe('decodeNsec / npubEncode round-trip', () => {
+  it('recovers (pubkey, secretKey) from a generated nsec', () => {
+    const sk = generateSecretKey();
+    const expectedPk = getPublicKey(sk);
+    const nsec = nsecEncode(sk);
+    const out = decodeNsec(nsec);
+    expect(out.pubkey).toBe(expectedPk);
+    expect(out.secretKey).toEqual(sk);
+  });
+
+  it('throws on a malformed nsec', () => {
+    expect(() => decodeNsec('nsec1notreal')).toThrow();
+  });
+
+  it('throws when given a non-nsec NIP-19 string (e.g. an npub)', () => {
+    const sk = generateSecretKey();
+    const npub = npubEncode(getPublicKey(sk));
+    expect(() => decodeNsec(npub)).toThrow(/invalid nsec/i);
+  });
+});
+
+describe('npubEncode + nprofileEncode', () => {
+  it('npubEncode produces an npub1 prefixed bech32 string', () => {
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+    const npub = npubEncode(pk);
+    expect(npub.startsWith('npub1')).toBe(true);
+  });
+
+  it('nprofileEncode produces an nprofile1 prefixed string', () => {
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+    const np = nprofileEncode(pk, ['wss://relay.example.com']);
+    expect(np.startsWith('nprofile1')).toBe(true);
+  });
+});
+
+describe('decodeProfileReference', () => {
+  const sk = generateSecretKey();
+  const pk = getPublicKey(sk);
+
+  it('decodes a bare npub', () => {
+    const out = decodeProfileReference(npubEncode(pk));
+    expect(out).toEqual({ pubkey: pk, relays: [] });
+  });
+
+  it('decodes a bare nprofile (preserves relay hints)', () => {
+    const np = nprofileEncode(pk, ['wss://r.example.com']);
+    const out = decodeProfileReference(np);
+    expect(out).toEqual({ pubkey: pk, relays: ['wss://r.example.com'] });
+  });
+
+  it('strips a case-insensitive nostr: URI prefix', () => {
+    const npub = npubEncode(pk);
+    expect(decodeProfileReference(`nostr:${npub}`)?.pubkey).toBe(pk);
+    expect(decodeProfileReference(`NOSTR:${npub}`)?.pubkey).toBe(pk);
+    expect(decodeProfileReference(`Nostr:${npub}`)?.pubkey).toBe(pk);
+  });
+
+  it('returns null for non-profile references (note, nevent, naddr, garbage)', () => {
+    expect(decodeProfileReference('nostr:garbage')).toBeNull();
+    expect(decodeProfileReference('hello world')).toBeNull();
+    expect(decodeProfileReference('')).toBeNull();
+  });
+});
+
+describe('parseProfileContent', () => {
+  it('extracts every documented field from a kind-0 JSON blob', () => {
+    const out = parseProfileContent(
+      JSON.stringify({
+        name: 'alice',
+        display_name: 'Alice',
+        picture: 'https://x.test/a.jpg',
+        banner: 'https://x.test/b.jpg',
+        about: 'hi',
+        lud16: 'alice@walletofsatoshi.com',
+        nip05: 'alice@example.com',
+      }),
+    );
+    expect(out).toEqual({
+      name: 'alice',
+      displayName: 'Alice',
+      picture: 'https://x.test/a.jpg',
+      banner: 'https://x.test/b.jpg',
+      about: 'hi',
+      lud16: 'alice@walletofsatoshi.com',
+      nip05: 'alice@example.com',
+    });
+  });
+
+  it('returns nulls when the field is absent', () => {
+    const out = parseProfileContent(JSON.stringify({ name: 'alice' }));
+    expect(out.name).toBe('alice');
+    expect(out.displayName).toBeNull();
+    expect(out.picture).toBeNull();
+    expect(out.lud16).toBeNull();
+  });
+
+  it('returns an all-nulls object on invalid JSON', () => {
+    const out = parseProfileContent('{not json');
+    expect(out).toEqual({
+      name: null,
+      displayName: null,
+      picture: null,
+      banner: null,
+      about: null,
+      lud16: null,
+      nip05: null,
+    });
+  });
+});
+
+describe('buildProfileRelayHints', () => {
+  const TARGET = 'd'.repeat(64);
+
+  it('prepends the contact relay when one is registered for the target', () => {
+    const out = buildProfileRelayHints(
+      TARGET,
+      [{ pubkey: TARGET, relay: 'wss://contact.example.com' }],
+      [],
+    );
+    expect(out[0]).toBe('wss://contact.example.com');
+  });
+
+  it('falls back to viewer read relays when the contact has no recorded relay', () => {
+    const out = buildProfileRelayHints(TARGET, [], ['wss://viewer.example.com']);
+    expect(out[0]).toBe('wss://viewer.example.com');
+  });
+
+  it('falls back to DEFAULT_RELAYS when nothing else is provided', () => {
+    const out = buildProfileRelayHints(TARGET, [], []);
+    expect(out.length).toBeGreaterThan(0);
+    expect(DEFAULT_RELAYS).toContain(out[0]);
+  });
+
+  it('caps the resulting list at 3 hints', () => {
+    const out = buildProfileRelayHints(
+      TARGET,
+      [{ pubkey: TARGET, relay: 'wss://a.example.com' }],
+      ['wss://b.example.com', 'wss://c.example.com', 'wss://d.example.com'],
+    );
+    expect(out).toHaveLength(3);
+  });
+
+  it('deduplicates a relay that appears in multiple sources', () => {
+    const dup = 'wss://shared.example.com';
+    const out = buildProfileRelayHints(
+      TARGET,
+      [{ pubkey: TARGET, relay: dup }],
+      [dup, 'wss://other.example.com'],
+    );
+    expect(out.filter((r) => r === dup)).toHaveLength(1);
   });
 });

--- a/src/services/zapCounterpartyStorage.test.ts
+++ b/src/services/zapCounterpartyStorage.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Coverage for the AsyncStorage-backed cache of resolved Nostr
+ * counterparties for outgoing zaps. The store is a key/value JSON blob
+ * — we mock AsyncStorage with the package's official jest mock so the
+ * tests exercise the real serialise/deserialise + LRU eviction code
+ * paths, just against an in-memory map.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  __resetForTests,
+  getByPaymentHash,
+  getMany,
+  getWriteVersion,
+  recordOutgoing,
+} from './zapCounterpartyStorage';
+import type { ZapCounterpartyInfo } from '../types/wallet';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run before ESM imports are hoisted; require is the canonical form.
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+function info(pubkey: string, comment = ''): ZapCounterpartyInfo {
+  return {
+    pubkey,
+    profile: null,
+    comment,
+    anonymous: false,
+  };
+}
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  __resetForTests();
+});
+
+describe('recordOutgoing + getByPaymentHash', () => {
+  it('round-trips a record through storage', async () => {
+    await recordOutgoing('hash1', info('pkA'));
+    expect(await getByPaymentHash('hash1')).toEqual(info('pkA'));
+  });
+
+  it('overwrites an existing entry on re-record (last write wins)', async () => {
+    await recordOutgoing('hash1', info('pkA', 'first'));
+    await recordOutgoing('hash1', info('pkA', 'second'));
+    const got = await getByPaymentHash('hash1');
+    expect(got?.comment).toBe('second');
+  });
+
+  it('no-ops on an empty paymentHash', async () => {
+    const before = getWriteVersion();
+    await recordOutgoing('', info('pkA'));
+    expect(getWriteVersion()).toBe(before);
+    expect(await getByPaymentHash('')).toBeNull();
+  });
+
+  it('returns null on a miss', async () => {
+    expect(await getByPaymentHash('never-recorded')).toBeNull();
+  });
+
+  it('bumps the write version on every successful record', async () => {
+    const start = getWriteVersion();
+    await recordOutgoing('h1', info('a'));
+    const afterFirst = getWriteVersion();
+    expect(afterFirst).toBe(start + 1);
+    await recordOutgoing('h2', info('b'));
+    expect(getWriteVersion()).toBe(afterFirst + 1);
+  });
+});
+
+describe('getMany', () => {
+  it('returns an empty map when given no hashes', async () => {
+    const out = await getMany([]);
+    expect(out.size).toBe(0);
+  });
+
+  it('returns only hits, omitting unknown hashes', async () => {
+    await recordOutgoing('h1', info('a'));
+    await recordOutgoing('h2', info('b'));
+    const out = await getMany(['h1', 'h2', 'missing']);
+    expect(out.size).toBe(2);
+    expect(out.get('h1')).toEqual(info('a'));
+    expect(out.get('h2')).toEqual(info('b'));
+    expect(out.has('missing')).toBe(false);
+  });
+});
+
+describe('LRU eviction', () => {
+  // The cap is 500 entries internally — exercise the eviction path with
+  // a smaller-but-still-meaningful number to avoid a 500-await loop in
+  // the test body. The eviction check fires whenever Object.keys.length
+  // exceeds MAX_ENTRIES (500), so we manually pre-seed storage with the
+  // 500 cap pre-loaded then push one more.
+  it('drops the oldest entries when the cap is exceeded', async () => {
+    // Pre-seed 500 entries via direct AsyncStorage write to skip 500
+    // sequential awaits. Each entry's savedAt counts upward so the
+    // sort-by-savedAt eviction picks the lowest savedAt as oldest.
+    const seeded: Record<string, { info: ZapCounterpartyInfo; savedAt: number }> = {};
+    for (let i = 0; i < 500; i++) {
+      seeded[`old${i}`] = { info: info(`old${i}`), savedAt: 1000 + i };
+    }
+    await AsyncStorage.setItem('zap_counterparties_v1', JSON.stringify(seeded));
+    // Force the in-memory cache to repopulate from the seeded blob.
+    __resetForTests();
+
+    // Now write one more — total 501 → triggers the >MAX_ENTRIES branch
+    // and the oldest (savedAt = 1000, "old0") should be evicted.
+    await recordOutgoing('newest', info('new-pk'));
+
+    expect(await getByPaymentHash('old0')).toBeNull();
+    expect(await getByPaymentHash('old499')).not.toBeNull();
+    expect(await getByPaymentHash('newest')).not.toBeNull();
+  });
+});

--- a/src/utils/conversationSummaries.test.ts
+++ b/src/utils/conversationSummaries.test.ts
@@ -214,7 +214,17 @@ describe('buildDmSummaries', () => {
 // ---------- mergeSummaries ----------
 
 describe('mergeSummaries', () => {
-  function summary(pubkey: string | null, ts: number, comment = ''): ConversationSummary {
+  // `kind` distinguishes a zap-shaped row (carries an amount) from a
+  // DM-shaped row (always 0 sats — buildDmSummaries hard-codes 0).
+  // Defaulting to the realistic shape per kind keeps the merge tests
+  // honest: passing 21 to every DM row would mask amount-handling
+  // regressions inside mergeSummaries.
+  function summary(
+    pubkey: string | null,
+    ts: number,
+    comment = '',
+    kind: 'zap' | 'dm' = 'zap',
+  ): ConversationSummary {
     return {
       id: pubkey ?? `anon:${ts}`,
       pubkey,
@@ -223,7 +233,7 @@ describe('mergeSummaries', () => {
       nip05: null,
       lightningAddress: null,
       lastActivityAt: ts,
-      lastAmountSats: pubkey ? 21 : 9,
+      lastAmountSats: kind === 'dm' ? 0 : pubkey ? 21 : 9,
       lastDirection: 'incoming',
       lastComment: comment,
       anonymous: pubkey === null,
@@ -238,7 +248,7 @@ describe('mergeSummaries', () => {
 
   it('uses the DM preview when zap + DM are within the preference window', () => {
     const z = summary(PK_A, 1000, '');
-    const d = summary(PK_A, 1000 + 60, 'hi from DM');
+    const d = summary(PK_A, 1000 + 60, 'hi from DM', 'dm');
     const merged = mergeSummaries([z], [d]);
     expect(merged).toHaveLength(1);
     expect(merged[0].lastComment).toBe('hi from DM');
@@ -247,17 +257,18 @@ describe('mergeSummaries', () => {
 
   it('uses the newer raw row outside the preference window', () => {
     const z = summary(PK_A, 1000, '');
-    const d = summary(PK_A, 1000 + 10 * 60, 'much later');
+    const d = summary(PK_A, 1000 + 10 * 60, 'much later', 'dm');
     const merged = mergeSummaries([z], [d]);
     expect(merged).toHaveLength(1);
     expect(merged[0].lastComment).toBe('much later');
-    // outside the window → the DM is the newest, but lastAmountSats
-    // takes the newest's value (which the DM shape provides as 21).
-    expect(merged[0].lastAmountSats).toBe(21);
+    // Outside the window → the DM is the newest, and DM rows from
+    // buildDmSummaries always carry lastAmountSats = 0. Asserting 0
+    // here keeps the test in step with what production really emits.
+    expect(merged[0].lastAmountSats).toBe(0);
   });
 
   it('passes through a zap-only or DM-only partner unchanged', () => {
-    const merged = mergeSummaries([summary(PK_A, 1000, '')], [summary(PK_B, 2000, 'hi')]);
+    const merged = mergeSummaries([summary(PK_A, 1000, '')], [summary(PK_B, 2000, 'hi', 'dm')]);
     // Sorted newest-first.
     expect(merged.map((m) => m.pubkey)).toEqual([PK_B, PK_A]);
   });
@@ -266,33 +277,60 @@ describe('mergeSummaries', () => {
 // ---------- formatConversationTimestamp ----------
 
 describe('formatConversationTimestamp', () => {
-  const NOW = new Date('2026-05-03T12:00:00.000Z');
-  const sec = (d: string) => Math.floor(new Date(d).getTime() / 1000);
+  // Build NOW + every fixture in *local* time so the calendar-day
+  // comparisons inside formatConversationTimestamp (which use
+  // `getFullYear/getMonth/getDate`) stay stable across host TZs.
+  // A pinned UTC string would shift to a different local day on
+  // hosts like UTC-10 / UTC+14, breaking the same-day / Yesterday
+  // assertions.
+  const NOW = new Date();
+  NOW.setFullYear(2026, 4 /* May */, 3);
+  NOW.setHours(12, 0, 0, 0);
+  const localSec = (
+    year: number,
+    month0: number,
+    day: number,
+    hour = 0,
+    minute = 0,
+    second = 0,
+  ): number => {
+    const d = new Date();
+    d.setFullYear(year, month0, day);
+    d.setHours(hour, minute, second, 0);
+    return Math.floor(d.getTime() / 1000);
+  };
 
   it('renders "now" inside the same minute', () => {
-    expect(formatConversationTimestamp(sec('2026-05-03T11:59:30.000Z'), NOW)).toBe('now');
+    expect(formatConversationTimestamp(localSec(2026, 4, 3, 11, 59, 30), NOW)).toBe('now');
   });
 
   it('renders minute granularity within the hour', () => {
-    expect(formatConversationTimestamp(sec('2026-05-03T11:30:00.000Z'), NOW)).toBe('30m');
+    expect(formatConversationTimestamp(localSec(2026, 4, 3, 11, 30), NOW)).toBe('30m');
   });
 
   it('renders hour granularity within the same calendar day', () => {
-    expect(formatConversationTimestamp(sec('2026-05-03T08:00:00.000Z'), NOW)).toBe('4h');
+    expect(formatConversationTimestamp(localSec(2026, 4, 3, 8, 0), NOW)).toBe('4h');
   });
 
   it('renders "Yesterday" for the previous calendar day', () => {
-    expect(formatConversationTimestamp(sec('2026-05-02T20:00:00.000Z'), NOW)).toBe('Yesterday');
+    expect(formatConversationTimestamp(localSec(2026, 4, 2, 20, 0), NOW)).toBe('Yesterday');
   });
 
   it('renders an explicit short date for older entries', () => {
-    const out = formatConversationTimestamp(sec('2026-04-10T12:00:00.000Z'), NOW);
-    expect(out).toMatch(/Apr/i);
-    expect(out).not.toMatch(/Yesterday/);
+    const ts = localSec(2026, 3 /* April */, 10, 12, 0);
+    const out = formatConversationTimestamp(ts, NOW);
+    // Compute the expected localised date substring at runtime so the
+    // assertion is locale-agnostic — `Apr` only appears for English
+    // locales; `de-DE` produces "10. Apr.", `ar-EG` Arabic digits, etc.
+    const expectedDateStr = new Date(ts * 1000).toLocaleDateString(undefined, {
+      day: 'numeric',
+      month: 'short',
+    });
+    expect(out).toBe(expectedDateStr);
   });
 
   it('includes the year for older years', () => {
-    const out = formatConversationTimestamp(sec('2024-12-31T12:00:00.000Z'), NOW);
+    const out = formatConversationTimestamp(localSec(2024, 11 /* December */, 31, 12, 0), NOW);
     expect(out).toContain('2024');
   });
 });
@@ -340,6 +378,12 @@ describe('conversationPreview', () => {
       lastDirection: 'incoming',
       lastComment: '',
     });
-    expect(out).toBe('⚡ 12,345 sats');
+    // conversationPreview uses `(12345).toLocaleString()` so the
+    // grouping separator depends on the host locale (`12,345` /
+    // `12.345` / `12 345` / Arabic digits, etc.). Compute the
+    // expected number locally so the assertion stays valid in any
+    // locale.
+    const expectedAmount = (12345).toLocaleString();
+    expect(out).toBe(`⚡ ${expectedAmount} sats`);
   });
 });

--- a/src/utils/conversationSummaries.test.ts
+++ b/src/utils/conversationSummaries.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Coverage for the conversation-list builders. The tests pin each
+ * documented merge rule:
+ *
+ *  - one zap row per identified pubkey (newest wins),
+ *  - anonymous zaps each get their own row,
+ *  - DM rule 1 (NIP-17 beats NIP-04 inside the dual-publish window),
+ *  - DM rule 2 (newer wins outside the window),
+ *  - merge: DM preview text wins when zap + DM are within
+ *    DM_PREVIEW_PREFERENCE_WINDOW_SEC, sort key is the newer of the
+ *    two timestamps, anonymous zaps pass through.
+ */
+
+import {
+  buildConversationSummaries,
+  buildDmSummaries,
+  conversationPreview,
+  formatConversationTimestamp,
+  mergeSummaries,
+  type ConversationSummary,
+  type DmInboxEntry,
+} from './conversationSummaries';
+import type { WalletState, WalletTransaction, ZapCounterpartyInfo } from '../types/wallet';
+import type { NostrContact } from '../types/nostr';
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+
+function makeWallet(transactions: WalletTransaction[]): WalletState {
+  return {
+    id: 'w1',
+    alias: 'Test',
+    theme: 'lightning-piggy',
+    order: 0,
+    walletType: 'nwc',
+    lightningAddress: null,
+    isConnected: true,
+    balance: 0,
+    walletAlias: null,
+    transactions,
+    // Cast to absorb fields not relevant to these tests.
+  } as unknown as WalletState;
+}
+
+function zapTx(opts: {
+  type: 'incoming' | 'outgoing';
+  amount: number;
+  ts: number;
+  counterparty: ZapCounterpartyInfo | undefined;
+  paymentHash?: string;
+}): WalletTransaction {
+  return {
+    type: opts.type,
+    amount: opts.amount,
+    settled_at: opts.ts,
+    paymentHash: opts.paymentHash,
+    zapCounterparty: opts.counterparty,
+  } as WalletTransaction;
+}
+
+function counterparty(
+  pubkey: string | null,
+  overrides: Partial<ZapCounterpartyInfo> = {},
+): ZapCounterpartyInfo {
+  return {
+    pubkey,
+    profile: null,
+    comment: '',
+    anonymous: pubkey === null,
+    ...overrides,
+  };
+}
+
+// ---------- buildConversationSummaries ----------
+
+describe('buildConversationSummaries', () => {
+  it('returns an empty list when no wallets / no zap-tagged txs are present', () => {
+    expect(buildConversationSummaries([], [])).toEqual([]);
+    expect(buildConversationSummaries([makeWallet([])], [])).toEqual([]);
+  });
+
+  it('skips transactions without a zapCounterparty info object', () => {
+    const w = makeWallet([
+      // type-cast: this tx has no counterparty info, must be ignored.
+      { type: 'incoming', amount: 100, settled_at: 10 } as WalletTransaction,
+    ]);
+    expect(buildConversationSummaries([w], [])).toEqual([]);
+  });
+
+  it('merges multiple zaps for one pubkey into a single row, keeping the newest', () => {
+    const w = makeWallet([
+      zapTx({ type: 'incoming', amount: 21, ts: 1000, counterparty: counterparty(PK_A) }),
+      zapTx({
+        type: 'outgoing',
+        amount: 100,
+        ts: 2000,
+        counterparty: counterparty(PK_A, { comment: 'thanks' }),
+      }),
+    ]);
+    const out = buildConversationSummaries([w], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].pubkey).toBe(PK_A);
+    expect(out[0].lastActivityAt).toBe(2000);
+    expect(out[0].lastDirection).toBe('outgoing');
+    expect(out[0].lastComment).toBe('thanks');
+    expect(out[0].lastAmountSats).toBe(100);
+  });
+
+  it('keeps anonymous zaps as their own rows, ordered newest-first', () => {
+    const w = makeWallet([
+      zapTx({
+        type: 'incoming',
+        amount: 50,
+        ts: 1000,
+        paymentHash: 'h1',
+        counterparty: counterparty(null),
+      }),
+      zapTx({
+        type: 'incoming',
+        amount: 75,
+        ts: 2000,
+        paymentHash: 'h2',
+        counterparty: counterparty(null),
+      }),
+    ]);
+    const out = buildConversationSummaries([w], []);
+    expect(out).toHaveLength(2);
+    expect(out[0].lastActivityAt).toBe(2000);
+    expect(out[0].id).toContain('anon:');
+    expect(out[0].anonymous).toBe(true);
+  });
+
+  it("uses the contact's profile name when the counterparty profile is missing", () => {
+    const contact: NostrContact = {
+      pubkey: PK_A,
+      relay: null,
+      petname: undefined,
+      profile: {
+        pubkey: PK_A,
+        npub: 'npub1ignored',
+        name: null,
+        displayName: 'Alice',
+        picture: null,
+        banner: null,
+        about: null,
+        lud16: null,
+        nip05: null,
+      },
+    } as unknown as NostrContact;
+    const w = makeWallet([
+      zapTx({ type: 'incoming', amount: 21, ts: 100, counterparty: counterparty(PK_A) }),
+    ]);
+    const out = buildConversationSummaries([w], [contact]);
+    expect(out[0].name).toBe('Alice');
+  });
+});
+
+// ---------- buildDmSummaries ----------
+
+describe('buildDmSummaries', () => {
+  function dm(partner: string, createdAt: number, wireKind: number, text = 'hi'): DmInboxEntry {
+    return {
+      id: `${partner}-${createdAt}-${wireKind}`,
+      partnerPubkey: partner,
+      fromMe: false,
+      createdAt,
+      text,
+      wireKind,
+    };
+  }
+
+  it('keeps one summary per partner, newest-first', () => {
+    const out = buildDmSummaries([dm(PK_A, 100, 4), dm(PK_B, 200, 4)], []);
+    expect(out.map((s) => s.pubkey)).toEqual([PK_B, PK_A]);
+  });
+
+  it('respects an explicit follow filter', () => {
+    const out = buildDmSummaries(
+      [dm(PK_A, 100, 4), dm(PK_B, 200, 4)],
+      [],
+      new Set([PK_A.toLowerCase()]),
+    );
+    expect(out.map((s) => s.pubkey)).toEqual([PK_A]);
+  });
+
+  it('prefers a NIP-17 message over a NIP-04 twin within the dual-publish window', () => {
+    // diff = 60 s — well inside the 5-min window. NIP-17 (kind-14) must
+    // win even though it arrived first / is older.
+    const out = buildDmSummaries([dm(PK_A, 1000, 14, 'wrap'), dm(PK_A, 1060, 4, 'legacy')], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].lastComment).toBe('wrap');
+  });
+
+  it('prefers the newer message when both are the same wire kind', () => {
+    const out = buildDmSummaries([dm(PK_A, 1000, 14, 'older'), dm(PK_A, 1100, 14, 'newer')], []);
+    expect(out[0].lastComment).toBe('newer');
+  });
+
+  it('outside the dual-publish window: newer wins regardless of wire kind', () => {
+    // diff = 6 minutes > 5-min window → rule 2 applies.
+    const out = buildDmSummaries(
+      [dm(PK_A, 1000, 14, 'old wrap'), dm(PK_A, 1000 + 6 * 60, 4, 'much newer kind4')],
+      [],
+    );
+    expect(out[0].lastComment).toBe('much newer kind4');
+  });
+
+  it('marks fromMe outgoing direction', () => {
+    const out = buildDmSummaries([{ ...dm(PK_A, 100, 14, 'sent'), fromMe: true }], []);
+    expect(out[0].lastDirection).toBe('outgoing');
+  });
+});
+
+// ---------- mergeSummaries ----------
+
+describe('mergeSummaries', () => {
+  function summary(pubkey: string | null, ts: number, comment = ''): ConversationSummary {
+    return {
+      id: pubkey ?? `anon:${ts}`,
+      pubkey,
+      name: pubkey ?? 'anon',
+      picture: null,
+      nip05: null,
+      lightningAddress: null,
+      lastActivityAt: ts,
+      lastAmountSats: pubkey ? 21 : 9,
+      lastDirection: 'incoming',
+      lastComment: comment,
+      anonymous: pubkey === null,
+    };
+  }
+
+  it('passes anonymous zap rows through untouched', () => {
+    const out = mergeSummaries([summary(null, 1000)], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].anonymous).toBe(true);
+  });
+
+  it('uses the DM preview when zap + DM are within the preference window', () => {
+    const z = summary(PK_A, 1000, '');
+    const d = summary(PK_A, 1000 + 60, 'hi from DM');
+    const merged = mergeSummaries([z], [d]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].lastComment).toBe('hi from DM');
+    expect(merged[0].lastAmountSats).toBe(0);
+  });
+
+  it('uses the newer raw row outside the preference window', () => {
+    const z = summary(PK_A, 1000, '');
+    const d = summary(PK_A, 1000 + 10 * 60, 'much later');
+    const merged = mergeSummaries([z], [d]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].lastComment).toBe('much later');
+    // outside the window → the DM is the newest, but lastAmountSats
+    // takes the newest's value (which the DM shape provides as 21).
+    expect(merged[0].lastAmountSats).toBe(21);
+  });
+
+  it('passes through a zap-only or DM-only partner unchanged', () => {
+    const merged = mergeSummaries([summary(PK_A, 1000, '')], [summary(PK_B, 2000, 'hi')]);
+    // Sorted newest-first.
+    expect(merged.map((m) => m.pubkey)).toEqual([PK_B, PK_A]);
+  });
+});
+
+// ---------- formatConversationTimestamp ----------
+
+describe('formatConversationTimestamp', () => {
+  const NOW = new Date('2026-05-03T12:00:00.000Z');
+  const sec = (d: string) => Math.floor(new Date(d).getTime() / 1000);
+
+  it('renders "now" inside the same minute', () => {
+    expect(formatConversationTimestamp(sec('2026-05-03T11:59:30.000Z'), NOW)).toBe('now');
+  });
+
+  it('renders minute granularity within the hour', () => {
+    expect(formatConversationTimestamp(sec('2026-05-03T11:30:00.000Z'), NOW)).toBe('30m');
+  });
+
+  it('renders hour granularity within the same calendar day', () => {
+    expect(formatConversationTimestamp(sec('2026-05-03T08:00:00.000Z'), NOW)).toBe('4h');
+  });
+
+  it('renders "Yesterday" for the previous calendar day', () => {
+    expect(formatConversationTimestamp(sec('2026-05-02T20:00:00.000Z'), NOW)).toBe('Yesterday');
+  });
+
+  it('renders an explicit short date for older entries', () => {
+    const out = formatConversationTimestamp(sec('2026-04-10T12:00:00.000Z'), NOW);
+    expect(out).toMatch(/Apr/i);
+    expect(out).not.toMatch(/Yesterday/);
+  });
+
+  it('includes the year for older years', () => {
+    const out = formatConversationTimestamp(sec('2024-12-31T12:00:00.000Z'), NOW);
+    expect(out).toContain('2024');
+  });
+});
+
+// ---------- conversationPreview ----------
+
+describe('conversationPreview', () => {
+  const base = {
+    id: PK_A,
+    pubkey: PK_A,
+    name: 'Alice',
+    picture: null,
+    nip05: null,
+    lightningAddress: null,
+    lastActivityAt: 0,
+    anonymous: false,
+  };
+
+  it('uses the comment when one is present', () => {
+    expect(
+      conversationPreview({
+        ...base,
+        lastAmountSats: 100,
+        lastDirection: 'incoming',
+        lastComment: 'thanks!',
+      }),
+    ).toBe('thanks!');
+  });
+
+  it('prefixes outgoing with "You: "', () => {
+    expect(
+      conversationPreview({
+        ...base,
+        lastAmountSats: 21,
+        lastDirection: 'outgoing',
+        lastComment: 'hello',
+      }),
+    ).toBe('You: hello');
+  });
+
+  it('falls back to a sat amount when there is no comment', () => {
+    const out = conversationPreview({
+      ...base,
+      lastAmountSats: 12345,
+      lastDirection: 'incoming',
+      lastComment: '',
+    });
+    expect(out).toBe('⚡ 12,345 sats');
+  });
+});

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -32,36 +32,56 @@ describe('truncateMiddle', () => {
 });
 
 describe('formatFriendlyDateTime', () => {
-  // Pin a fixed "now" so the same input always produces the same Today/
-  // Yesterday/explicit-date branch regardless of when the test runs.
-  const NOW = new Date('2026-05-03T12:00:00.000Z');
+  // Build the "now" reference via local-time setters so the calendar
+  // day comparisons inside formatFriendlyDateTime (which use
+  // `getFullYear/getMonth/getDate` — i.e. *local* dates) are stable
+  // regardless of the host TZ. Using a fixed UTC string here would
+  // shift to a different local calendar day on hosts like UTC-10 /
+  // UTC+14, breaking the Today / Yesterday assertions.
+  const NOW = new Date();
+  NOW.setFullYear(2026, 4 /* May */, 3);
+  NOW.setHours(12, 0, 0, 0);
+
+  // Helper: create an epoch-second timestamp at a specific local
+  // calendar date + time, so the test doesn't depend on the host TZ.
+  const localTs = (year: number, month0: number, day: number, hour = 0, minute = 0): number => {
+    const d = new Date();
+    d.setFullYear(year, month0, day);
+    d.setHours(hour, minute, 0, 0);
+    return Math.floor(d.getTime() / 1000);
+  };
 
   it('renders "Today · <time>" for the same calendar day', () => {
-    const ts = Math.floor(new Date('2026-05-03T08:30:00.000Z').getTime() / 1000);
+    const ts = localTs(2026, 4 /* May */, 3, 8, 30);
     const out = formatFriendlyDateTime(ts, NOW);
     expect(out.startsWith('Today · ')).toBe(true);
   });
 
   it('renders "Yesterday · <time>" for the previous day', () => {
-    const ts = Math.floor(new Date('2026-05-02T22:15:00.000Z').getTime() / 1000);
+    const ts = localTs(2026, 4 /* May */, 2, 22, 15);
     const out = formatFriendlyDateTime(ts, NOW);
     expect(out.startsWith('Yesterday · ')).toBe(true);
   });
 
   it('renders an explicit short date for older entries', () => {
-    const ts = Math.floor(new Date('2026-04-10T09:00:00.000Z').getTime() / 1000);
+    const ts = localTs(2026, 3 /* April */, 10, 9, 0);
     const out = formatFriendlyDateTime(ts, NOW);
     expect(out.startsWith('Today · ')).toBe(false);
     expect(out.startsWith('Yesterday · ')).toBe(false);
-    // The date half should reference April; we don't lock the exact
-    // locale-driven shape ("10 Apr" vs "Apr 10") because Node's Intl
-    // formatting is locale-dependent.
-    expect(out).toMatch(/Apr/i);
+    // Compute the expected localised date substring at runtime so the
+    // assertion is locale-agnostic — on `de-DE` Intl renders "10. Apr."
+    // / "10 avr." / numeric forms in other locales, all of which are
+    // correct outputs of the implementation.
+    const expectedDateStr = new Date(ts * 1000).toLocaleDateString(undefined, {
+      day: 'numeric',
+      month: 'short',
+    });
+    expect(out).toContain(expectedDateStr);
     expect(out).toContain(' · ');
   });
 
   it('includes the year when older than the current year', () => {
-    const ts = Math.floor(new Date('2024-12-31T10:00:00.000Z').getTime() / 1000);
+    const ts = localTs(2024, 11 /* December */, 31, 10, 0);
     const out = formatFriendlyDateTime(ts, NOW);
     expect(out).toContain('2024');
   });

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit coverage for the small string / date formatters used by the
+ * Messages list and contact rows. Pure functions, deterministic — no
+ * timer / locale plumbing required beyond an injected `now` for the
+ * relative date helper.
+ */
+
+import { formatFriendlyDateTime, truncateMiddle } from './format';
+
+describe('truncateMiddle', () => {
+  it('returns empty string for falsy input', () => {
+    expect(truncateMiddle('')).toBe('');
+  });
+
+  it('returns the original string when shorter than head + tail + 1', () => {
+    // 'abcde' is 5 chars, defaults are head=6 tail=6 so head+tail+1 = 13.
+    expect(truncateMiddle('abcde')).toBe('abcde');
+  });
+
+  it('elides the middle with the unicode ellipsis', () => {
+    const long = 'npub1' + 'x'.repeat(60) + 'tail99';
+    const out = truncateMiddle(long);
+    expect(out.startsWith('npub1x')).toBe(true);
+    expect(out.endsWith('tail99')).toBe(true);
+    expect(out).toContain('…');
+  });
+
+  it('respects a custom head/tail length', () => {
+    const out = truncateMiddle('abcdefghijklmnopqrstuvwxyz', 3, 4);
+    expect(out).toBe('abc…wxyz');
+  });
+});
+
+describe('formatFriendlyDateTime', () => {
+  // Pin a fixed "now" so the same input always produces the same Today/
+  // Yesterday/explicit-date branch regardless of when the test runs.
+  const NOW = new Date('2026-05-03T12:00:00.000Z');
+
+  it('renders "Today · <time>" for the same calendar day', () => {
+    const ts = Math.floor(new Date('2026-05-03T08:30:00.000Z').getTime() / 1000);
+    const out = formatFriendlyDateTime(ts, NOW);
+    expect(out.startsWith('Today · ')).toBe(true);
+  });
+
+  it('renders "Yesterday · <time>" for the previous day', () => {
+    const ts = Math.floor(new Date('2026-05-02T22:15:00.000Z').getTime() / 1000);
+    const out = formatFriendlyDateTime(ts, NOW);
+    expect(out.startsWith('Yesterday · ')).toBe(true);
+  });
+
+  it('renders an explicit short date for older entries', () => {
+    const ts = Math.floor(new Date('2026-04-10T09:00:00.000Z').getTime() / 1000);
+    const out = formatFriendlyDateTime(ts, NOW);
+    expect(out.startsWith('Today · ')).toBe(false);
+    expect(out.startsWith('Yesterday · ')).toBe(false);
+    // The date half should reference April; we don't lock the exact
+    // locale-driven shape ("10 Apr" vs "Apr 10") because Node's Intl
+    // formatting is locale-dependent.
+    expect(out).toMatch(/Apr/i);
+    expect(out).toContain(' · ');
+  });
+
+  it('includes the year when older than the current year', () => {
+    const ts = Math.floor(new Date('2024-12-31T10:00:00.000Z').getTime() / 1000);
+    const out = formatFriendlyDateTime(ts, NOW);
+    expect(out).toContain('2024');
+  });
+});

--- a/src/utils/lru.test.ts
+++ b/src/utils/lru.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Coverage for the tiny Map-backed LRU. Touches every public method
+ * (get/set/has/delete/clear/size) plus the eviction order contract
+ * documented in the source: oldest key is dropped when `max` is hit,
+ * and `get` re-inserts to mark most-recently-used.
+ */
+
+import { LRUCache } from './lru';
+
+describe('LRUCache', () => {
+  it('throws when max is not a positive integer', () => {
+    expect(() => new LRUCache<string, number>({ max: 0 })).toThrow(/positive integer/i);
+    expect(() => new LRUCache<string, number>({ max: -1 })).toThrow(/positive integer/i);
+    // 1.5 isn't an integer either.
+    expect(() => new LRUCache<string, number>({ max: 1.5 })).toThrow(/positive integer/i);
+  });
+
+  it('stores and retrieves values via set/get/has/size', () => {
+    const cache = new LRUCache<string, number>({ max: 3 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.size).toBe(2);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('evicts the oldest entry when max is exceeded', () => {
+    const cache = new LRUCache<string, number>({ max: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('b')).toBe(true);
+    expect(cache.has('c')).toBe(true);
+    expect(cache.size).toBe(2);
+  });
+
+  it('promotes the touched key on get, deferring its eviction', () => {
+    const cache = new LRUCache<string, number>({ max: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    // Touch 'a' so it becomes most-recently-used.
+    expect(cache.get('a')).toBe(1);
+    // Now 'b' is the least-recently-used and gets evicted by 'c'.
+    cache.set('c', 3);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.has('c')).toBe(true);
+  });
+
+  it('does not promote on get when touchOnGet is false', () => {
+    const cache = new LRUCache<string, number>({ max: 2, touchOnGet: false });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a');
+    cache.set('c', 3);
+    // Without the touch-on-get re-insert, 'a' is still the oldest.
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('b')).toBe(true);
+    expect(cache.has('c')).toBe(true);
+  });
+
+  it('overwrites an existing key without growing the size', () => {
+    const cache = new LRUCache<string, number>({ max: 2 });
+    cache.set('a', 1);
+    cache.set('a', 99);
+    expect(cache.size).toBe(1);
+    expect(cache.get('a')).toBe(99);
+  });
+
+  it('delete returns true on a hit and false on a miss', () => {
+    const cache = new LRUCache<string, number>({ max: 2 });
+    cache.set('a', 1);
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.delete('a')).toBe(false);
+    expect(cache.has('a')).toBe(false);
+  });
+
+  it('clear empties the cache', () => {
+    const cache = new LRUCache<string, number>({ max: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.has('a')).toBe(false);
+  });
+});

--- a/src/utils/messageContent.test.ts
+++ b/src/utils/messageContent.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Coverage for the message-content classifiers (image / invoice / LN
+ * address / shared contact / time / relative-future). The bolt11
+ * decoder is real (light-bolt11-decoder is pure JS); we only fixture
+ * a known-valid testnet invoice so the assertion is deterministic.
+ */
+
+import * as nip19 from 'nostr-tools/nip19';
+
+import {
+  extractImageUrl,
+  extractInvoice,
+  extractLightningAddress,
+  extractSharedContact,
+  formatRelativeFuture,
+  formatTime,
+} from './messageContent';
+
+// ---------- extractImageUrl ----------
+
+describe('extractImageUrl', () => {
+  it('returns null for empty input', () => {
+    expect(extractImageUrl('')).toBeNull();
+  });
+
+  it('matches a bare image URL with a trusted extension', () => {
+    expect(extractImageUrl('https://example.com/cat.jpg')).toBe('https://example.com/cat.jpg');
+    expect(extractImageUrl('http://x.test/y.png')).toBe('http://x.test/y.png');
+  });
+
+  it('tolerates surrounding whitespace and case-insensitive extensions', () => {
+    expect(extractImageUrl('  https://example.com/IMG.JPEG  ')).toBe(
+      'https://example.com/IMG.JPEG',
+    );
+  });
+
+  it('matches when a query string follows the extension', () => {
+    expect(extractImageUrl('https://example.com/cat.png?v=2')).toBe(
+      'https://example.com/cat.png?v=2',
+    );
+  });
+
+  it('rejects URLs the regex does not whitelist as images', () => {
+    expect(extractImageUrl('https://example.com/page.html')).toBeNull();
+    // Trailing text means the URL isn't the entire body — must not match.
+    expect(extractImageUrl('check this https://example.com/cat.jpg please')).toBeNull();
+  });
+});
+
+// ---------- extractInvoice ----------
+
+describe('extractInvoice', () => {
+  // A historical mainnet invoice from BOLT-11's own test vectors:
+  // 2500µBTC = 0.0025 BTC = 250_000 sats. Stable, decodable, no live network.
+  const TEST_INVOICE =
+    'lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp';
+
+  it('returns null when no invoice is present', () => {
+    expect(extractInvoice('hello there')).toBeNull();
+    expect(extractInvoice('')).toBeNull();
+  });
+
+  it('decodes amount, description and payment hash from a valid invoice', () => {
+    const dec = extractInvoice(TEST_INVOICE);
+    expect(dec).not.toBeNull();
+    expect(dec!.raw).toBe(TEST_INVOICE);
+    expect(dec!.amountSats).toBe(250_000);
+    // description / paymentHash come from the invoice itself — just
+    // assert their *presence* and shape (paymentHash = 64 hex).
+    expect(typeof dec!.description === 'string' || dec!.description === null).toBe(true);
+    if (dec!.paymentHash !== null) {
+      expect(dec!.paymentHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('strips a leading lightning: URI scheme', () => {
+    const dec = extractInvoice(`lightning:${TEST_INVOICE}`);
+    expect(dec).not.toBeNull();
+    expect(dec!.raw).toBe(TEST_INVOICE);
+  });
+
+  it('returns a partial result for an undecodable invoice-shaped string', () => {
+    // Looks like an invoice (lnbc + many chars) but won't decode → the
+    // catch path returns the raw with all numeric fields set to null.
+    const garbage = 'lnbc' + 'z'.repeat(60);
+    const dec = extractInvoice(`pay this ${garbage} please`);
+    expect(dec).not.toBeNull();
+    expect(dec!.amountSats).toBeNull();
+    expect(dec!.paymentHash).toBeNull();
+  });
+});
+
+// ---------- extractLightningAddress ----------
+
+describe('extractLightningAddress', () => {
+  it('returns null for empty input', () => {
+    expect(extractLightningAddress('')).toBeNull();
+  });
+
+  it('extracts a lightning: prefixed LN address', () => {
+    expect(extractLightningAddress('Pay me at lightning:alice@example.com please')).toBe(
+      'alice@example.com',
+    );
+  });
+
+  it('does NOT match a plain unprefixed email-shaped string', () => {
+    // The whole point of the prefix gate: avoid turning every shared
+    // email into a Pay button.
+    expect(extractLightningAddress('Email me at alice@example.com')).toBeNull();
+  });
+});
+
+// ---------- extractSharedContact ----------
+
+describe('extractSharedContact', () => {
+  it('returns null for empty input', () => {
+    expect(extractSharedContact('')).toBeNull();
+  });
+
+  it('returns null when no nostr: URI is present', () => {
+    expect(extractSharedContact('hello world')).toBeNull();
+  });
+
+  it('decodes a nostr:npub… profile URI', () => {
+    // BIP-340 generator pubkey, valid 32-byte x-only key — chosen
+    // because nip19 will accept it as an npub payload deterministically.
+    // npub is recomputed from a known hex via nip19 to avoid hand-encoding.
+    const hex = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+    const npub = nip19.npubEncode(hex);
+    const out = extractSharedContact(`Add me on nostr:${npub} thanks`);
+    expect(out).not.toBeNull();
+    expect(out!.pubkey).toBe(hex);
+  });
+});
+
+// ---------- formatTime ----------
+
+describe('formatTime', () => {
+  it('formats seconds-since-epoch as zero-padded HH:MM in local time', () => {
+    // Build a Date for 13:05 local time, then convert to epoch seconds —
+    // formatTime then re-renders it from local-time getHours/getMinutes,
+    // so the round-trip gives back 13:05 regardless of the test's TZ.
+    const d = new Date();
+    d.setHours(13, 5, 0, 0);
+    const epoch = Math.floor(d.getTime() / 1000);
+    expect(formatTime(epoch)).toBe('13:05');
+  });
+
+  it('zero-pads single-digit hours and minutes', () => {
+    const d = new Date();
+    d.setHours(3, 7, 0, 0);
+    const epoch = Math.floor(d.getTime() / 1000);
+    expect(formatTime(epoch)).toBe('03:07');
+  });
+});
+
+// ---------- formatRelativeFuture ----------
+
+describe('formatRelativeFuture', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Fix wall-clock time so the relative deltas are deterministic.
+    jest.setSystemTime(new Date('2026-05-03T12:00:00.000Z'));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns "in <1 min" for sub-minute deltas', () => {
+    expect(formatRelativeFuture(Date.now() + 30_000)).toBe('in <1 min');
+  });
+
+  it('returns minute-granularity output for sub-hour deltas', () => {
+    expect(formatRelativeFuture(Date.now() + 5 * 60_000)).toBe('in 5 min');
+  });
+
+  it('returns hour-granularity output for sub-day deltas', () => {
+    expect(formatRelativeFuture(Date.now() + 3 * 60 * 60_000)).toBe('in 3h');
+  });
+
+  it('returns day-granularity output beyond one day', () => {
+    expect(formatRelativeFuture(Date.now() + 2 * 24 * 60 * 60_000)).toBe('in 2d');
+  });
+
+  it('clamps past timestamps to "in <1 min"', () => {
+    expect(formatRelativeFuture(Date.now() - 60_000)).toBe('in <1 min');
+  });
+});

--- a/src/utils/messageContent.test.ts
+++ b/src/utils/messageContent.test.ts
@@ -2,7 +2,8 @@
  * Coverage for the message-content classifiers (image / invoice / LN
  * address / shared contact / time / relative-future). The bolt11
  * decoder is real (light-bolt11-decoder is pure JS); we only fixture
- * a known-valid testnet invoice so the assertion is deterministic.
+ * a known-valid mainnet invoice (from the BOLT-11 spec's own test
+ * vectors) so the assertion is deterministic.
  */
 
 import * as nip19 from 'nostr-tools/nip19';

--- a/src/utils/paymentErrors.test.ts
+++ b/src/utils/paymentErrors.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Coverage for the payment-error humanizer. The mapping rules are
+ * order-sensitive — `Cancelled` is checked before `connectivity`, etc.
+ * — so each pattern bucket has its own happy-path assertion plus a
+ * couple of edge cases (empty / unknown / hex-stripped fallbacks).
+ */
+
+import { humanizePaymentError } from './paymentErrors';
+
+describe('humanizePaymentError', () => {
+  it('returns a generic message when given no input', () => {
+    expect(humanizePaymentError(undefined).message).toBe('Payment failed. Please try again.');
+    expect(humanizePaymentError(null).message).toBe('Payment failed. Please try again.');
+    expect(humanizePaymentError('').message).toBe('Payment failed. Please try again.');
+  });
+
+  it('maps cancellation patterns to "Cancelled."', () => {
+    for (const raw of ['Aborted', 'Cancelled', 'canceled by user']) {
+      const out = humanizePaymentError(raw);
+      expect(out.message).toBe('Cancelled.');
+      expect(out.detail).toBe(raw.trim());
+    }
+  });
+
+  it('maps connectivity patterns to the wallet-unreachable message', () => {
+    for (const raw of [
+      'reply timeout: event abc',
+      'publish timed out',
+      'failed to publish',
+      'All promises were rejected',
+      'wallet unreachable',
+      'Network request failed',
+      'websocket closed',
+    ]) {
+      const out = humanizePaymentError(raw);
+      expect(out.message).toBe("Couldn't reach your wallet. Check your connection and try again.");
+      expect(out.detail).toBe(raw.trim());
+    }
+  });
+
+  it('maps insufficient-funds patterns to "Insufficient balance."', () => {
+    expect(humanizePaymentError('Insufficient balance').message).toBe('Insufficient balance.');
+    expect(humanizePaymentError('insufficient_balance').message).toBe('Insufficient balance.');
+    expect(humanizePaymentError('insufficient').message).toBe('Insufficient balance.');
+  });
+
+  it('maps expired-invoice patterns to the expired message', () => {
+    expect(humanizePaymentError('invoice has expired').message).toBe('This invoice has expired.');
+    expect(humanizePaymentError('invoice expired').message).toBe('This invoice has expired.');
+    expect(humanizePaymentError('expired').message).toBe('This invoice has expired.');
+  });
+
+  it('maps already-paid patterns to the already-paid message', () => {
+    expect(humanizePaymentError('already paid').message).toBe(
+      'This invoice has already been paid.',
+    );
+    expect(humanizePaymentError('already settled').message).toBe(
+      'This invoice has already been paid.',
+    );
+    expect(humanizePaymentError('is_settled').message).toBe('This invoice has already been paid.');
+  });
+
+  it('strips 64-char hex event ids from fallback messages', () => {
+    const hex = 'a'.repeat(64);
+    const raw = `something failed for event ${hex} please retry`;
+    const out = humanizePaymentError(raw);
+    expect(out.message).not.toContain(hex);
+    // Detail keeps the raw text so support can still see the event id.
+    expect(out.detail).toBe(raw);
+  });
+
+  it('falls back to the generic message when stripping leaves only noise', () => {
+    // After stripping the 64-char hex this is short / non-alphabetic and
+    // looks "technical" — must collapse to the generic message.
+    const out = humanizePaymentError(`!!!! ${'b'.repeat(64)} !!!!`);
+    expect(out.message).toBe('Payment failed. Please try again.');
+  });
+
+  it('passes through clean error messages verbatim', () => {
+    const out = humanizePaymentError('Recipient rejected the payment');
+    expect(out.message).toBe('Recipient rejected the payment');
+    expect(out.detail).toBe('Recipient rejected the payment');
+  });
+});

--- a/src/utils/txCategory.test.ts
+++ b/src/utils/txCategory.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Coverage for the transaction-category classifier. The rules below
+ * mirror the precedence comments in `getTxCategory`: Boltz beats
+ * on-chain (a swap claim tx has a txid but should still render under
+ * the Boltz icon), and on-chain beats lightning when blockHeight or
+ * txid are present.
+ */
+
+import { getTxCategory } from './txCategory';
+
+describe('getTxCategory', () => {
+  it('classifies entries with a swapId as boltz', () => {
+    expect(
+      getTxCategory({
+        swapId: 'B0Lt2',
+        // even with an on-chain-looking txid present, swap wins
+        txid: 'deadbeef',
+        blockHeight: 800000,
+      }),
+    ).toBe('boltz');
+  });
+
+  it('matches "Boltz swap" in the description (case-insensitive)', () => {
+    expect(getTxCategory({ description: 'Boltz Swap claim' })).toBe('boltz');
+    expect(getTxCategory({ description: 'boltz swap' })).toBe('boltz');
+  });
+
+  it('matches "Send to BTC / Bitcoin" descriptions as boltz', () => {
+    expect(getTxCategory({ description: 'send to BTC' })).toBe('boltz');
+    expect(getTxCategory({ description: 'Send to bitcoin address' })).toBe('boltz');
+  });
+
+  it('matches "Receive from BTC / Bitcoin" descriptions as boltz', () => {
+    expect(getTxCategory({ description: 'receive from BTC' })).toBe('boltz');
+    expect(getTxCategory({ description: 'Receive from Bitcoin' })).toBe('boltz');
+  });
+
+  it('classifies as onchain when blockHeight is present', () => {
+    expect(getTxCategory({ blockHeight: 825000 })).toBe('onchain');
+  });
+
+  it('classifies as onchain when only a txid is present', () => {
+    expect(getTxCategory({ txid: 'abc123' })).toBe('onchain');
+  });
+
+  it('falls back to lightning for everything else', () => {
+    expect(getTxCategory({})).toBe('lightning');
+    expect(getTxCategory({ description: 'Pay invoice' })).toBe('lightning');
+    expect(getTxCategory({ description: null, blockHeight: null })).toBe('lightning');
+  });
+});

--- a/src/utils/youtube.test.ts
+++ b/src/utils/youtube.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Coverage for the YouTube ID + thumbnail helpers. The regex accepts
+ * the three standard URL shapes (long watch?v=, short youtu.be, embed)
+ * — these tests pin each, plus the null-handling on the public API.
+ */
+
+import { extractYouTubeId, getYouTubeThumbnail } from './youtube';
+
+describe('extractYouTubeId', () => {
+  it('extracts the id from a long watch URL', () => {
+    expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('extracts the id from a short youtu.be URL', () => {
+    expect(extractYouTubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('extracts the id from an embed URL', () => {
+    expect(extractYouTubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('returns null when the URL does not match', () => {
+    expect(extractYouTubeId('https://example.com/dQw4w9WgXcQ')).toBeNull();
+    expect(extractYouTubeId('https://www.youtube.com/')).toBeNull();
+  });
+});
+
+describe('getYouTubeThumbnail', () => {
+  it('returns the mqdefault thumbnail URL for a recognised video', () => {
+    expect(getYouTubeThumbnail('https://youtu.be/dQw4w9WgXcQ')).toBe(
+      'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+    );
+  });
+
+  it('returns null for unrecognised input', () => {
+    expect(getYouTubeThumbnail(null)).toBeNull();
+    expect(getYouTubeThumbnail('https://example.com/')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **174 new tests** across 14 co-located test files, plus 17 new pure-helper cases tacked onto the existing `nostrService.test.ts` (per the documented one-test-file-per-subject convention). All targets are pure utilities or pure services with no React tree / native dependency — components and React-context files are out of scope for this PR.

Bumps Jest coverage on the in-scope subjects from a baseline of **2 service files + 2 util files at 0%** to:

| File | Lines% (was → now) |
|---|---|
| `src/utils/format.ts` | 0 → 100 |
| `src/utils/txCategory.ts` | 0 → 100 |
| `src/utils/lru.ts` | 0 → 100 |
| `src/utils/youtube.ts` | 0 → 100 |
| `src/utils/paymentErrors.ts` | 0 → 100 |
| `src/utils/conversationSummaries.ts` | 0 → 96 |
| `src/utils/messageContent.ts` | 0 → 91 |
| `src/services/groupRoutingRegistry.ts` | 0 → 100 |
| `src/services/learnProgressService.ts` | 0 → 100 |
| `src/services/groupsStorageService.ts` | 0 → 100 |
| `src/services/zapCounterpartyStorage.ts` | 0 → 97 |
| `src/services/locationService.ts` | 0 → 54 (pure helpers; permission-gated `getCurrentLocation` skipped) |
| `src/services/giphyService.ts` | 0 → 38 (pure helpers; network paths skipped) |
| `src/services/fiatService.ts` | 0 → 45 (pure helpers; cached fetch path skipped) |
| `src/services/nostrService.ts` | 16 → 16* |

\* nostrService.ts is a 1041-line file — the new tests cover its pure-JS surface (NIP-19 round-trip, profile reference decoding, kind-0 tolerance, nprofile relay hint dedup) but the line count is dominated by relay / fetch / SimplePool paths that need a different (integration) approach. The line-coverage % moves only fractionally because the file is so large.

Picked from `bash scripts/coverage-priorities.sh 60` — biased toward the long tail of low-LOC, high-impact pure helpers where tests cost least and document behaviour most clearly.

## Files attempted but skipped

- `src/contexts/NostrContext.tsx`, `src/contexts/WalletContext.tsx`, `src/contexts/GroupsContext.tsx` — top-of-list by score but need React-renderer + provider-tree setup beyond this PR's scope. Worth a follow-up issue if we want to track them.
- `src/services/swapRecoveryService.ts` — depends on `bitcoinjs-lib` ECC init + `expo-secure-store` + a live BoltzService; recovery loop is a poor unit-test fit, better validated end-to-end.
- `src/services/nwcService.ts`, `src/services/onchainService.ts`, `src/services/boltzService.ts` — heavy native / network dependencies; would need fetch + websocket mocks well beyond this PR's surface.
- `src/services/amberService.ts`, `src/services/nfcService.ts`, `src/services/blossomService.ts`, `src/services/imageUploadService.ts`, `src/services/lnurlService.ts` — same reason; native-bridge or HTTP-heavy.
- `src/services/contactsService.ts`, `src/services/walletStorageService.ts`, `src/services/groupMessagesStorageService.ts` — viable next-pass targets (AsyncStorage-only) but kept out to keep this PR focused on the most clear-cut wins.

## Test plan

- [x] `npm test` — 187 passed, 0 failed (was 13)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/` — 0 errors (only pre-existing warnings in source files I didn't touch)
- [x] `npx prettier --check src/` — clean
- [ ] Coverage workflow on this PR shouldn't regress vs base (only adds tests; no source edits)

Based on `chore/coverage-scope-services-utils-contexts` (PR #285) since the new tests rely on the co-located convention + tightened `testMatch` introduced there. Rebase onto `main` once #285 lands.