### PR TITLE
chore(release): sync EAS build numbers into GH Release title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,81 @@ jobs:
             dist/lightning-piggy-${{ github.event.release.tag_name }}.apk \
             --repo "$GITHUB_REPOSITORY" --clobber
 
+  sync-release-identifiers:
+    name: Sync EAS build numbers into Release title
+    # A TestFlight tester sees `1.0.1 (42)` (X.Y.Z + EAS build number); the
+    # GH Release shows `v1.0.1-rc1`. Without correlation it's hard to tell
+    # which release a given TestFlight build came from. This step rewrites
+    # the Release title to embed the iOS + Android build numbers, so a
+    # tester can match `(42)` in TestFlight against the title here.
+    if: github.event_name == 'release'
+    needs: [build-and-submit, attach-android-apk]
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+      NODE_NO_WARNINGS: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+
+      - name: Resolve build numbers + edit Release title
+        run: |
+          # Pull the build number for this commit on each platform. Filter
+          # by gitCommitHash so we don't accidentally pick up an unrelated
+          # in-flight build from a parallel branch.
+          ios_build=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
+            --platform ios --status finished --limit 5 --json --non-interactive \
+            | jq -r --arg sha "${{ github.sha }}" \
+                '[.[] | select(.gitCommitHash == $sha)][0].buildVersion // empty')
+          android_build=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
+            --platform android --status finished --limit 5 --json --non-interactive \
+            | jq -r --arg sha "${{ github.sha }}" \
+                '[.[] | select(.gitCommitHash == $sha)][0].buildVersion // empty')
+
+          # Derive the original title from the release event payload.
+          # Fall back to the tag name if no title was set.
+          base_title=$(gh release view "${{ github.event.release.tag_name }}" \
+            --repo "$GITHUB_REPOSITORY" --json name --jq .name)
+          if [ -z "$base_title" ] || [ "$base_title" = "${{ github.event.release.tag_name }}" ]; then
+            base_title="${{ github.event.release.tag_name }}"
+          fi
+
+          # Compose the suffix from whichever build numbers we resolved.
+          # Both should be present on a normal "all platforms" release;
+          # platform-specific re-runs may legitimately have only one.
+          suffix=""
+          if [ -n "$ios_build" ] && [ -n "$android_build" ]; then
+            suffix=" (iOS build $ios_build / Android build $android_build)"
+          elif [ -n "$ios_build" ]; then
+            suffix=" (iOS build $ios_build)"
+          elif [ -n "$android_build" ]; then
+            suffix=" (Android build $android_build)"
+          fi
+
+          if [ -z "$suffix" ]; then
+            echo "::warning title=No build numbers resolved::Could not find a finished EAS build for commit ${{ github.sha }} on either platform; leaving Release title unchanged."
+            exit 0
+          fi
+
+          # Idempotency: if the title already contains the build-number
+          # suffix (e.g. workflow re-run), don't double-append.
+          if echo "$base_title" | grep -qE '\(iOS build [0-9]+|Android build [0-9]+)'; then
+            echo "Release title already has a build-number suffix; skipping rewrite."
+            exit 0
+          fi
+
+          new_title="${base_title}${suffix}"
+          echo "Old title: $base_title"
+          echo "New title: $new_title"
+          gh release edit "${{ github.event.release.tag_name }}" \
+            --repo "$GITHUB_REPOSITORY" --title "$new_title"
+
   attach-technical-pdf:
     name: Generate & attach Technical Solution PDF
     if: github.event_name == 'release'

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -51,6 +51,25 @@ TMPDIR="$HOME/eas-tmp" EXPO_NO_DOCTOR=1 \
 ----
 *Cleanup:* `rm -rf "$HOME/eas-tmp"` between builds when you want to reclaim disk; the next run's `mkdir -p` and Gradle will re-create everything, including hidden entries such as `.gradle` or `.expo`. The EAS-CLI checkout under `$TMPDIR/eas-build-local-nodejs/` is also safe to delete between runs. Full recipe + rationale in `docs/DEPLOYMENT.adoc` → "Local production builds".
 
+| "How long is the EAS iOS build queue right now?" — no public API
+| EAS doesn't expose live queue depth via API; status.expo.dev only reports operational/degraded. Best signals: +
+1. **Last completed-build duration** — proxy for current load: +
+[source,bash]
+----
+NODE_NO_WARNINGS=1 eas build:list --platform ios --status finished --limit 1 --non-interactive \
+  | grep -E "Started at|Finished at"
+----
+Subtract the two timestamps. Free-tier iOS production has historically been ~2-3 hours wall-time. +
+2. **Are any builds currently queued?** +
+[source,bash]
+----
+NODE_NO_WARNINGS=1 eas build:list --status in-queue --status in-progress --limit 10 --non-interactive
+----
+Empty output = nothing in flight; positive output shows projects ahead of you in the shared queue. +
+3. **EAS dashboard** — https://expo.dev/accounts/bengweeks/projects/lightning-piggy-app/builds renders queue position client-side once a build is in flight; the initial HTML doesn't include it. +
+*Why this matters:* GH-Release-driven iOS builds go to TestFlight after EAS finishes + Apple processes (~10 min). For a same-day TestFlight push, kick off in the morning. For a v1.X.Y-rc1 cycle, plan ~3-4 hours from tag-push to "installable in TestFlight". +
+*The only definitive number* is the queue position EAS prints once your build is submitted. Until then, all numbers are estimates from prior runs.
+
 | Maestro can't tap a third-party signer's FAB / button (Aegis, Clave, etc) — `Element not found` or silent no-op
 | Some signer apps (notably Aegis ≥0.5.0, possibly Clave) ship without accessibility labels on key UI elements like the "+" FAB to add a connection. Maestro's `tapOn: { id: ... }` and `tapOn: { text: ... }` both miss because there's nothing to match. The `index:` selector also ranks unpredictably for un-labelled `ImageView` clickables. +
 *Why coordinates aren't a workaround:* `point: '90%, 91%'` and `adb shell input tap` are forbidden by the project's CLAUDE.md (fragile across screen sizes / OS versions / device profiles). +


### PR DESCRIPTION
## Summary

Today a TestFlight tester sees \`1.0.1 (42)\` but the GitHub Release shows \`v1.0.1-rc1\` — no easy way to correlate. This PR adds a tiny workflow job that rewrites the Release title to include the resolved EAS build numbers for both platforms:

\`\`\`
Before: v1.0.1-rc1 — fix back-from-group lag
After:  v1.0.1-rc1 — fix back-from-group lag (iOS build 42 / Android build 38)
\`\`\`

Mechanism: new \`sync-release-identifiers\` job runs after \`build-and-submit\` + \`attach-android-apk\` finish, calls \`eas build:list --json\` for each platform with a commit-SHA filter, then \`gh release edit --title\`. Idempotent.

Also documents the "how long is the EAS iOS queue right now?" question in TROUBLESHOOTING.adoc since we don't expose live queue depth and the answer is non-obvious (no API; best signals are last-build duration + \`--status in-queue\` / \`--status in-progress\`).

## Test plan

Cannot fully test until the next release runs (the workflow only fires on a Release event). Manual review notes:

- [x] YAML validates (\`python -c "import yaml; yaml.safe_load(...)"\`)
- [x] \`eas build:list --status finished --limit 5 --json\` returns parseable JSON when piped through \`jq\` with \`NODE_NO_WARNINGS=1\` (verified locally)
- [ ] Verify on the next \`v*-rc*\` tag that the Release title gets rewritten correctly + the suffix shows up on the public Releases page
- [ ] Confirm idempotency by re-running the workflow on an already-edited Release (the \`grep -qE\` guard should short-circuit)