### PR TITLE
fix(ui): lift npub share affordances to proper buttons + fix ContactProfileSheet overflow (#310)

### DIFF
--- a/src/components/ContactProfileSheet.tsx
+++ b/src/components/ContactProfileSheet.tsx
@@ -16,10 +16,11 @@ import {
   BottomSheetBackdropProps,
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
-import Svg, { Circle, Path } from 'react-native-svg';
+import Svg, { Circle, Path, Rect } from 'react-native-svg';
 import { Zap, Copy, Share2, UserRound } from 'lucide-react-native';
 import NfcIcon from './icons/NfcIcon';
 import NfcWriteSheet from './NfcWriteSheet';
+import QrSheet from './QrSheet';
 import { isNfcSupported } from '../services/nfcService';
 import * as Clipboard from 'expo-clipboard';
 import Toast from './BrandedToast';
@@ -28,6 +29,23 @@ import { useNostr } from '../contexts/NostrContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 import FriendPickerSheet, { PickedFriend } from './FriendPickerSheet';
+
+// Inline QR-grid icon — same look used by ProfileScreen so the share
+// row matches across own-profile and friend-profile surfaces.
+const QrIcon: React.FC<{ size?: number; color?: string }> = ({ size = 22, color }) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Rect x="3" y="3" width="7" height="7" rx="1" stroke={color} strokeWidth={2} />
+    <Rect x="14" y="3" width="7" height="7" rx="1" stroke={color} strokeWidth={2} />
+    <Rect x="3" y="14" width="7" height="7" rx="1" stroke={color} strokeWidth={2} />
+    <Path
+      d="M14 14h3v3h-3zM20 14v3h-3M14 20h3M20 20h0"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
 
 interface ContactData {
   pubkey: string | null;
@@ -71,6 +89,7 @@ const ContactProfileSheet: React.FC<Props> = ({
   const [sharing, setSharing] = useState(false);
   const [nfcWriteVisible, setNfcWriteVisible] = useState(false);
   const [nfcSupported, setNfcSupported] = useState(false);
+  const [qrSheetOpen, setQrSheetOpen] = useState(false);
   // Probe device NFC capability once when the sheet opens. Hide the
   // NFC tile entirely if the hardware isn't there (or expo-go's NFC
   // shim returns false in dev) — no point teasing a feature that
@@ -168,6 +187,12 @@ const ContactProfileSheet: React.FC<Props> = ({
   const handleCopyNpub = async () => {
     if (!contact?.pubkey) return;
     await Clipboard.setStringAsync(npubEncode(contact.pubkey));
+    Toast.show({
+      type: 'success',
+      text1: 'npub copied',
+      position: 'top',
+      visibilityTime: 1500,
+    });
   };
 
   const handleShare = useCallback(() => {
@@ -293,10 +318,49 @@ const ContactProfileSheet: React.FC<Props> = ({
 
         {/* npub */}
         {npubDisplay && (
-          <TouchableOpacity style={styles.npubRow} onPress={handleCopyNpub}>
+          <View style={styles.npubRow}>
             <Text style={styles.npubText}>{npubDisplay}</Text>
-            <Copy size={20} color={colors.brandPink} />
-          </TouchableOpacity>
+          </View>
+        )}
+
+        {/* npub share affordances: matches ProfileScreen (issue #310).
+            Friend's npub gets the same Copy / QR / NFC tile treatment
+            as the user's own npub — no more 18 px tap targets. */}
+        {contact.pubkey && (
+          <View style={styles.shareRow}>
+            <TouchableOpacity
+              style={styles.shareTile}
+              onPress={handleCopyNpub}
+              accessibilityLabel="Copy npub"
+              testID="contact-npub-copy"
+            >
+              <Copy size={22} color={colors.brandPink} />
+              <Text style={styles.shareTileText}>Copy</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.shareTile}
+              onPress={() => setQrSheetOpen(true)}
+              accessibilityLabel="Show npub QR"
+              testID="contact-npub-qr"
+            >
+              <QrIcon size={22} color={colors.brandPink} />
+              <Text style={styles.shareTileText}>QR</Text>
+            </TouchableOpacity>
+            {nfcSupported && (
+              <TouchableOpacity
+                style={styles.shareTile}
+                onPress={() => setNfcWriteVisible(true)}
+                accessibilityLabel="Write npub to NFC tag"
+                /* preserves the testID used by tests/e2e/test-nfc-write-sheet.yaml
+                   so the existing Maestro flow keeps passing — the action is
+                   the same, only the host moved from the bottom row to here. */
+                testID="contact-nfc-write-button"
+              >
+                <NfcIcon size={22} color={colors.brandPink} />
+                <Text style={styles.shareTileText}>NFC</Text>
+              </TouchableOpacity>
+            )}
+          </View>
         )}
 
         {/* Lightning Address */}
@@ -423,16 +487,6 @@ const ContactProfileSheet: React.FC<Props> = ({
               </Svg>
             </TouchableOpacity>
           )}
-          {contact.pubkey && nfcSupported && (
-            <TouchableOpacity
-              style={styles.iconButton}
-              onPress={() => setNfcWriteVisible(true)}
-              accessibilityLabel="Write to NFC tag"
-              testID="contact-nfc-write-button"
-            >
-              <NfcIcon size={18} color={colors.brandPink} />
-            </TouchableOpacity>
-          )}
         </View>
         {/* Write the friend's npub (nostr:-prefixed) to a physical NFC
             tag. The friend can then tap the tag against another device
@@ -444,6 +498,15 @@ const ContactProfileSheet: React.FC<Props> = ({
             onClose={() => setNfcWriteVisible(false)}
             npub={npubEncode(contact.pubkey)}
             displayName={contact.name}
+          />
+        )}
+        {contact.pubkey && (
+          <QrSheet
+            visible={qrSheetOpen}
+            onClose={() => setQrSheetOpen(false)}
+            npub={npubEncode(contact.pubkey)}
+            lightningAddress={contact.lightningAddress}
+            defaultMode="npub"
           />
         )}
       </BottomSheetView>
@@ -549,6 +612,30 @@ const createStyles = (colors: Palette) =>
       color: colors.textSupplementary,
       fontWeight: '500',
     },
+    shareRow: {
+      flexDirection: 'row',
+      gap: 8,
+      marginTop: 10,
+      paddingHorizontal: 24,
+      alignSelf: 'stretch',
+    },
+    shareTile: {
+      flex: 1,
+      minHeight: 56,
+      paddingVertical: 8,
+      paddingHorizontal: 8,
+      borderRadius: 10,
+      borderWidth: 1.5,
+      borderColor: colors.brandPink,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 4,
+    },
+    shareTileText: {
+      color: colors.brandPink,
+      fontSize: 12,
+      fontWeight: '600',
+    },
     lightningAddress: {
       fontSize: 13,
       color: colors.textSupplementary,
@@ -593,7 +680,13 @@ const createStyles = (colors: Palette) =>
     },
     actionRow: {
       flexDirection: 'row',
+      // Wrap so Follow / Message / Zap / Share / External never clip on
+      // narrow screens (issue #310 — bottom row was overflowing the
+      // right edge on Pixel-class widths).
+      flexWrap: 'wrap',
+      justifyContent: 'center',
       gap: 8,
+      rowGap: 8,
       marginTop: 20,
       paddingHorizontal: 16,
     },

--- a/src/screens/account/ProfileScreen.tsx
+++ b/src/screens/account/ProfileScreen.tsx
@@ -97,11 +97,28 @@ const ProfileScreen: React.FC = () => {
           </View>
 
           <View style={styles.npubRow}>
-            <TouchableOpacity style={styles.npubCopy} onPress={copyNpub}>
-              <Text style={styles.npubText}>{truncatedNpub}</Text>
-              <Copy size={20} color={colors.textSupplementary} />
+            <Text style={styles.npubText} numberOfLines={1}>
+              {truncatedNpub}
+            </Text>
+          </View>
+
+          {/* npub share affordances: lifted from tiny inline icons to
+              proper ≥44 dp tap targets with labels (issue #310). The
+              tiles share the same npub payload — Copy goes to clipboard,
+              QR displays a scannable npub, NFC writes nostr:npub to a
+              physical tag. */}
+          <View style={styles.shareRow}>
+            <TouchableOpacity
+              style={styles.shareTile}
+              onPress={copyNpub}
+              accessibilityLabel="Copy npub"
+              testID="profile-npub-copy"
+            >
+              <Copy size={22} color={colors.brandPink} />
+              <Text style={styles.shareTileText}>Copy</Text>
             </TouchableOpacity>
             <TouchableOpacity
+              style={styles.shareTile}
               onPress={() => {
                 setQrDefaultMode('npub');
                 setQrSheetOpen(true);
@@ -109,15 +126,18 @@ const ProfileScreen: React.FC = () => {
               accessibilityLabel="Show npub QR"
               testID="profile-npub-qr"
             >
-              <QrIcon size={22} color={colors.textSupplementary} />
+              <QrIcon size={22} color={colors.brandPink} />
+              <Text style={styles.shareTileText}>QR</Text>
             </TouchableOpacity>
             {nfcSupported && (
               <TouchableOpacity
+                style={styles.shareTile}
                 onPress={() => setNfcWriteVisible(true)}
                 accessibilityLabel="Write npub to NFC tag"
                 testID="profile-npub-nfc"
               >
-                <NfcIcon size={22} color={colors.textSupplementary} />
+                <NfcIcon size={22} color={colors.brandPink} />
+                <Text style={styles.shareTileText}>NFC</Text>
               </TouchableOpacity>
             )}
           </View>
@@ -225,20 +245,37 @@ const createStyles = (colors: Palette) =>
     npubRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 8,
       paddingHorizontal: 16,
       paddingBottom: 8,
-    },
-    npubCopy: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 6,
-      flex: 1,
     },
     npubText: {
       color: colors.textSupplementary,
       fontSize: 12,
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+      flex: 1,
+    },
+    shareRow: {
+      flexDirection: 'row',
+      gap: 8,
+      paddingHorizontal: 16,
+      paddingBottom: 12,
+    },
+    shareTile: {
+      flex: 1,
+      minHeight: 56,
+      paddingVertical: 8,
+      paddingHorizontal: 8,
+      borderRadius: 10,
+      borderWidth: 1.5,
+      borderColor: colors.brandPink,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 4,
+    },
+    shareTileText: {
+      color: colors.brandPink,
+      fontSize: 12,
+      fontWeight: '600',
     },
     profileLnRow: {
       flexDirection: 'row',


### PR DESCRIPTION
## Summary

Lifts the Copy / QR / NFC affordances out of the tiny inline-icon row and into proper-sized tiles on both the user's own profile (`ProfileScreen`) and a friend's profile (`ContactProfileSheet`), and fixes the bottom action-row overflow on the contact sheet.

- **ProfileScreen** — three pink-bordered tiles (icon + label, ≥56 dp tall, `flex: 1` so they share the row evenly) replace the 20-22 px icons that previously sat next to the npub.
- **ContactProfileSheet** — same Copy / QR / NFC tile row added below the npub. Previously only NFC was wired, and as an 18 px icon. Friend's npub is now as shareable as the user's own.
- **ContactProfileSheet bottom row** — `Follow / Message / Zap / Share / External` now wraps via `flexWrap: 'wrap'` + `rowGap`, so the row never clips on Pixel-class widths. NFC moved up into the new share tile row, which removes one button from this row too.

## Layout choice for the overflow fix

Took the smallest fix that compose-cleanly: kept all existing buttons, just added `flexWrap: 'wrap'` + `justifyContent: 'center'` + `rowGap: 8` to `actionRow`. No restructuring, no \"More\" menu — buttons reflow naturally on narrow widths and stay in one row on wider ones. The NFC tile moving up into the new npub-share row is what actually shrinks the row on common widths, so wrap is more of a safety net than a regular trigger.

## TestIDs

Preserved per `CLAUDE.md`:
- `profile-npub-qr`, `profile-npub-nfc` (own profile)
- `contact-nfc-write-button` — kept on the new NFC tile so `tests/e2e/test-nfc-write-sheet.yaml` keeps passing without edits

New (for future flows):
- `profile-npub-copy`, `contact-npub-copy`, `contact-npub-qr`

## Files changed

- `src/screens/account/ProfileScreen.tsx`
- `src/components/ContactProfileSheet.tsx`

## Why draft

Marked draft because the AVD ended up in a degraded state during this session (system_server kept restarting, ActivityManager couldn't resolve the dev MainActivity), so I couldn't grab live before/after screenshots from a build with these changes. Diff is small + gates are green; visuals are the missing piece. Will flip to ready once a screenshot pass lands.

## Test plan

- [ ] Visual: ProfileScreen shows three equal-width Copy/QR/NFC tiles below the npub
- [ ] Visual: ContactProfileSheet shows the same three tiles below the friend's npub
- [ ] Visual: ContactProfileSheet bottom row no longer clips on Pixel 8 / iPhone 13 widths
- [ ] Tap each tile → opens the same sheet/clipboard action as before
- [ ] `maestro test tests/e2e/test-nfc-write-sheet.yaml` — both the own-npub and friend-npub NFC entries still resolve

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)