### PR TITLE
test(nostr): migrate remaining BottomSheetTextInput sites to plain RN TextInput for Maestro reliability (#146)

### DIFF
--- a/src/components/AddFriendSheet.tsx
+++ b/src/components/AddFriendSheet.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   BackHandler,
@@ -15,7 +16,6 @@ import {
   BottomSheetBackdrop,
   BottomSheetBackdropProps,
   BottomSheetScrollView,
-  BottomSheetTextInput,
 } from '@gorhom/bottom-sheet';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import * as Clipboard from 'expo-clipboard';
@@ -163,7 +163,20 @@ const AddFriendSheet: React.FC<Props> = ({ visible, onClose, onAdd }) => {
         {mode === 'paste' ? (
           <View style={styles.pasteContent}>
             <View style={styles.inputRow}>
-              <BottomSheetTextInput
+              {/*
+                Plain RN TextInput rather than BottomSheetTextInput. Issue
+                #146: Maestro's `inputText` drops characters when typing
+                into @gorhom/bottom-sheet's BottomSheetTextInput under the
+                New Architecture (testID lands on the wrapper View, not
+                the native EditText, so the synthetic keystrokes never
+                advance the JS event path). The npub input is exercised
+                by `tests/e2e/test-follow-unfollow.yaml`, where a 63-char
+                bech32 string would otherwise arrive truncated and trip
+                "Invalid public key format". Keyboard tracking for the
+                sheet is preserved by its `keyboardBehavior="interactive"`
+                + `android_keyboardInputMode="adjustResize"` props above.
+              */}
+              <TextInput
                 style={styles.input}
                 placeholder="npub1..."
                 placeholderTextColor={colors.textSupplementary}

--- a/src/components/AddWalletWizard.tsx
+++ b/src/components/AddWalletWizard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
@@ -10,12 +11,7 @@ import {
 } from 'react-native';
 import { Alert } from './BrandedAlert';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import {
-  BottomSheetModal,
-  BottomSheetBackdrop,
-  BottomSheetScrollView,
-  BottomSheetTextInput,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetModal, BottomSheetBackdrop, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Clipboard from 'expo-clipboard';
 import { useWallet } from '../contexts/WalletContext';
@@ -362,7 +358,23 @@ const AddWalletWizard: React.FC<Props> = ({ visible, onClose }) => {
                 <Text style={styles.description}>
                   Paste or scan your Nostr Wallet Connect (NWC) connection string.
                 </Text>
-                <BottomSheetTextInput
+                {/*
+                  Plain RN TextInput rather than BottomSheetTextInput. Issue
+                  #146: Maestro's `inputText` drops characters when typing
+                  into @gorhom/bottom-sheet's BottomSheetTextInput under the
+                  New Architecture (testID lands on the wrapper View, not
+                  the native EditText). This wizard's four inputs
+                  (`nwc-url-input`, `xpub-input`, `mnemonic-input`,
+                  `wallet-alias-input`) are all exercised by Maestro
+                  `inputText` flows (`tests/e2e/test-add-nwc-wallet*.yaml`,
+                  `test-add-onchain-wallet.yaml`,
+                  `test-revolut-xapo-cards.yaml`,
+                  `test-add-hot-wallet.yaml`). Keyboard tracking is
+                  preserved by the wizard sheet's
+                  `keyboardBehavior="interactive"` +
+                  `android_keyboardInputMode="adjustResize"` props.
+                */}
+                <TextInput
                   style={styles.nwcInput}
                   placeholder="nostr+walletconnect://..."
                   placeholderTextColor={colors.textSupplementary}
@@ -449,7 +461,8 @@ const AddWalletWizard: React.FC<Props> = ({ visible, onClose }) => {
                   Paste or scan an extended public key (xpub, ypub, or zpub) to track a whole HD
                   wallet, or a single Bitcoin address (bc1…, 1…, 3…) to watch just that one.
                 </Text>
-                <BottomSheetTextInput
+                {/* Plain RN TextInput — see comment on nwc-url-input above (#146). */}
+                <TextInput
                   style={styles.nwcInput}
                   placeholder="xpub6… or bc1q…"
                   placeholderTextColor={colors.textSupplementary}
@@ -497,7 +510,8 @@ const AddWalletWizard: React.FC<Props> = ({ visible, onClose }) => {
               Enter your 12 or 24 word seed phrase. Numbers, colons, and extra whitespace will be
               stripped automatically.
             </Text>
-            <BottomSheetTextInput
+            {/* Plain RN TextInput — see comment on nwc-url-input above (#146). */}
+            <TextInput
               style={[styles.nwcInput, { minHeight: 100 }]}
               placeholder="word1 word2 word3 ..."
               placeholderTextColor={colors.textSupplementary}
@@ -538,7 +552,8 @@ const AddWalletWizard: React.FC<Props> = ({ visible, onClose }) => {
             <Text style={styles.description}>
               Give this wallet a name so you can easily identify it.
             </Text>
-            <BottomSheetTextInput
+            {/* Plain RN TextInput — see comment on nwc-url-input above (#146). */}
+            <TextInput
               style={styles.aliasInput}
               placeholder="e.g. My Savings, Spending Wallet"
               placeholderTextColor={colors.textSupplementary}

--- a/src/components/CreateGroupSheet.tsx
+++ b/src/components/CreateGroupSheet.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useSt
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
@@ -467,7 +468,20 @@ const CreateGroupSheet: React.FC<Props> = ({ visible, onClose, onCreated }) => {
         </View>
 
         <Text style={styles.label}>Group Name</Text>
-        <BottomSheetTextInput
+        {/*
+          Plain RN TextInput rather than BottomSheetTextInput. Issue #146:
+          Maestro's `inputText` drops characters when typing into
+          @gorhom/bottom-sheet's BottomSheetTextInput under the New
+          Architecture (testID lands on the wrapper View, not the native
+          EditText). Exercised by `tests/e2e/test-3way-group-create-as-big.yaml`
+          (taps by placeholder `text: 'e.g. Family'` then `inputText: 'Triad'`).
+          Keyboard tracking for the sheet is preserved by its
+          `keyboardBehavior="interactive"` +
+          `android_keyboardInputMode="adjustResize"` props. The
+          `create-group-search` input above stays as BottomSheetTextInput —
+          it is not driven by Maestro `inputText`.
+        */}
+        <TextInput
           style={styles.input}
           placeholder="e.g. Family"
           placeholderTextColor={colors.textSupplementary}

--- a/src/components/EditProfileSheet.tsx
+++ b/src/components/EditProfileSheet.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
@@ -233,7 +234,18 @@ const EditProfileSheet: React.FC<Props> = ({ visible, onClose }) => {
         </TouchableOpacity>
 
         <Text style={styles.label}>Display Name</Text>
-        <BottomSheetTextInput
+        {/*
+          Plain RN TextInput rather than BottomSheetTextInput. Issue #146:
+          Maestro's `inputText` drops characters when typing into
+          @gorhom/bottom-sheet's BottomSheetTextInput under the New
+          Architecture (testID lands on the wrapper View, not the native
+          EditText). Exercised by `tests/e2e/test-edit-profile.yaml`.
+          The `edit-about` field below stays as BottomSheetTextInput —
+          it is not driven by Maestro `inputText`. Keyboard tracking for
+          the sheet is preserved by its `keyboardBehavior="interactive"`
+          + `android_keyboardInputMode="adjustResize"` props.
+        */}
+        <TextInput
           style={styles.input}
           placeholder="Your name"
           placeholderTextColor={colors.textSupplementary}
@@ -246,7 +258,8 @@ const EditProfileSheet: React.FC<Props> = ({ visible, onClose }) => {
         />
 
         <Text style={styles.label}>Lightning Address</Text>
-        <BottomSheetTextInput
+        {/* Plain RN TextInput — see comment on edit-display-name above (#146). */}
+        <TextInput
           style={styles.input}
           placeholder="you@wallet.com"
           placeholderTextColor={colors.textSupplementary}

--- a/src/components/RenameGroupSheet.tsx
+++ b/src/components/RenameGroupSheet.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
@@ -14,7 +15,6 @@ import {
   BottomSheetBackdrop,
   BottomSheetBackdropProps,
   BottomSheetScrollView,
-  BottomSheetTextInput,
 } from '@gorhom/bottom-sheet';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
@@ -131,7 +131,19 @@ const RenameGroupSheet: React.FC<Props> = ({ visible, groupId, onClose }) => {
       >
         <Text style={styles.title}>Rename Group</Text>
         <Text style={styles.label}>Group Name</Text>
-        <BottomSheetTextInput
+        {/*
+          Plain RN TextInput rather than BottomSheetTextInput. Issue #146:
+          Maestro's `inputText` drops characters when typing into
+          @gorhom/bottom-sheet's BottomSheetTextInput under the New
+          Architecture (testID lands on the wrapper View, not the native
+          EditText). Exercised by `tests/e2e/test-rename-group.yaml` and
+          `tests/e2e/test-3way-group-rename-as-big.yaml`. Keyboard tracking
+          for the sheet is preserved by the manual `Keyboard.addListener`
+          + `keyboardHeight` padding above plus the sheet's own
+          `keyboardBehavior="interactive"` +
+          `android_keyboardInputMode="adjustResize"`.
+        */}
+        <TextInput
           style={styles.input}
           placeholder="Group name"
           placeholderTextColor={colors.textSupplementary}

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   ActivityIndicator,
   BackHandler,
@@ -14,7 +15,6 @@ import {
   BottomSheetModal,
   BottomSheetBackdrop,
   BottomSheetBackdropProps,
-  BottomSheetTextInput,
   BottomSheetScrollView,
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
@@ -774,7 +774,20 @@ const SendSheet: React.FC<Props> = ({
                   </View>
                 ) : (
                   <View style={styles.pasteSection}>
-                    <BottomSheetTextInput
+                    {/*
+                      Plain RN TextInput rather than BottomSheetTextInput.
+                      Issue #146: Maestro's `inputText` drops characters
+                      when typing into @gorhom/bottom-sheet's
+                      BottomSheetTextInput under the New Architecture
+                      (testID lands on the wrapper View, not the native
+                      EditText). Exercised by
+                      `tests/e2e/test-branded-alert.yaml` (paste a bad
+                      bolt11 to surface the validation Alert).
+                      Keyboard tracking for the sheet is preserved by its
+                      `keyboardBehavior="interactive"` +
+                      `android_keyboardInputMode="adjustResize"` props.
+                    */}
+                    <TextInput
                       style={styles.pasteInput}
                       placeholder="Paste invoice, lightning or bitcoin address..."
                       placeholderTextColor={colors.textSupplementary}
@@ -897,8 +910,18 @@ const SendSheet: React.FC<Props> = ({
                   )}
 
                   {/* Memo / comment field for Lightning address payments */}
+                  {/*
+                    Plain RN TextInput rather than BottomSheetTextInput.
+                    Issue #146: Maestro's `inputText` drops characters
+                    when typing into @gorhom/bottom-sheet's
+                    BottomSheetTextInput under the New Architecture.
+                    Exercised by `tests/e2e/test-sendsheet-typing.yaml`.
+                    Keyboard tracking is preserved by the sheet's
+                    `keyboardBehavior="interactive"` +
+                    `android_keyboardInputMode="adjustResize"` props.
+                  */}
                   {needsAmount && (
-                    <BottomSheetTextInput
+                    <TextInput
                       style={styles.memoInput}
                       placeholder={activePubkey ? 'Zap message (optional)' : 'Comment (optional)'}
                       placeholderTextColor={colors.textSupplementary}

--- a/src/components/WalletSettingsSheet.tsx
+++ b/src/components/WalletSettingsSheet.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform, Keyboard } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Platform,
+  Keyboard,
+} from 'react-native';
 import { Alert } from './BrandedAlert';
 import {
   BottomSheetModal,
@@ -185,7 +193,19 @@ const WalletSettingsSheet: React.FC<Props> = ({ walletId, onClose }) => {
         {wallet.walletType === 'nwc' && (
           <>
             <Text style={[styles.label, { marginTop: 20 }]}>Lightning Address</Text>
-            <BottomSheetTextInput
+            {/*
+              Plain RN TextInput rather than BottomSheetTextInput. Issue #146:
+              Maestro's `inputText` drops characters when typing into
+              @gorhom/bottom-sheet's BottomSheetTextInput under the New
+              Architecture (testID lands on the wrapper View, not the native
+              EditText). Exercised by `tests/e2e/test-set-lightning-address.yaml`.
+              The wallet `Alias` input above stays as BottomSheetTextInput —
+              it has no testID and is not driven by Maestro `inputText`.
+              Keyboard tracking for the sheet is preserved by its
+              `keyboardBehavior="interactive"` +
+              `android_keyboardInputMode="adjustResize"` props.
+            */}
+            <TextInput
               style={styles.input}
               value={lnAddress}
               onChangeText={setLnAddress}


### PR DESCRIPTION
## Summary

Maestro's `inputText` drops characters when typing into `@gorhom/bottom-sheet`'s `BottomSheetTextInput` under the New Architecture — the testID lands on the wrapper View rather than the native `EditText`, so the synthetic `adb shell input text` keystrokes never advance the JS event path. PR #321 fixed this for the NostrLoginSheet `nsec-input`. This PR extends the same migration to every other `BottomSheetTextInput` exercised by Maestro `inputText` flows, so the broader e2e suite stops losing characters mid-type.

Each migration is a `BottomSheetTextInput` -> RN `TextInput` swap. testIDs, accessibilityLabels, and props are preserved exactly. Keyboard handling is preserved by every affected sheet's existing `keyboardBehavior="interactive"` + `android_keyboardInputMode="adjustResize"` props (and, where applicable, the manual `Keyboard.addListener` + `keyboardHeight` padding pattern).

## Sites migrated (Maestro-tested)

| File | testID | Driving Maestro flow(s) |
| --- | --- | --- |
| `AddWalletWizard.tsx` | `nwc-url-input` | `test-add-nwc-wallet.yaml`, `test-add-nwc-wallet-dev.yaml` |
| `AddWalletWizard.tsx` | `xpub-input` | `test-add-onchain-wallet.yaml`, `test-revolut-xapo-cards.yaml` |
| `AddWalletWizard.tsx` | `mnemonic-input` | `test-add-hot-wallet.yaml` |
| `AddWalletWizard.tsx` | `wallet-alias-input` | `test-add-onchain-wallet.yaml`, `test-add-hot-wallet.yaml`, `test-revolut-xapo-cards.yaml` |
| `AddFriendSheet.tsx` | `npub-input` | `test-follow-unfollow.yaml` |
| `RenameGroupSheet.tsx` | `rename-group-input` | `test-rename-group.yaml`, `test-3way-group-rename-as-big.yaml` |
| `CreateGroupSheet.tsx` | `create-group-name` | `test-3way-group-create-as-big.yaml` |
| `EditProfileSheet.tsx` | `edit-display-name` | `test-edit-profile.yaml` |
| `EditProfileSheet.tsx` | `edit-lud16` | `test-edit-profile.yaml` |
| `SendSheet.tsx` | `send-paste-input` | `test-branded-alert.yaml` |
| `SendSheet.tsx` | `sendsheet-memo-input` | `test-sendsheet-typing.yaml` |
| `WalletSettingsSheet.tsx` | `wallet-lightning-address-input` | `test-set-lightning-address.yaml` |

## Sites left as `BottomSheetTextInput` (intentional)

- `NostrLoginSheet.tsx` (`nsec-input`, `create-name-input`) — left to PR #321 to avoid hunk conflicts; PR #321 already migrates `nsec-input` and a follow-up can migrate `create-name-input` after it lands.
- `GifPickerSheet.tsx` (`gif-search-input`) — `tests/e2e/test-attach-send-gif.yaml` deliberately skips typing into this input per a TROUBLESHOOTING-driven comment in the test.
- `FriendPickerSheet.tsx` (`friend-picker-search`), `FeedbackSheet.tsx` (`feedback-input`), `CreateGroupSheet.tsx` (`create-group-search`), `EditProfileSheet.tsx` (`edit-about`), `WalletSettingsSheet.tsx` Alias — only exercised by `tests/e2e/keyboard-audit/*.yaml` flows that tap to verify keyboard behavior; none of them call `inputText`. Skipped per the issue's "skip sites NOT exercised by Maestro if change adds risk" guidance — each can migrate independently if Maestro coverage expands to them.

## Why draft

Keyboard interaction inside a bottom sheet is fragile across devices and there are 7 affected sheets here. Local AVD is degraded so Maestro flows have not been re-run end-to-end against the migrations. The user should validate on the Pixel before merge that:

1. The keyboard still lifts each sheet so the focused input remains visible (no IME overlap).
2. The Maestro flows listed above complete green — each `inputText` lands intact and downstream validation succeeds.

Suggested smoke runs:

```bash
source .env
maestro test -e MAESTRO_NSEC="$MAESTRO_NSEC" tests/e2e/test-follow-unfollow.yaml
maestro test -e MAESTRO_NSEC="$MAESTRO_NSEC" tests/e2e/test-edit-profile.yaml
maestro test -e MAESTRO_NSEC="$MAESTRO_NSEC" tests/e2e/test-add-nwc-wallet-dev.yaml
maestro test -e MAESTRO_NSEC="$MAESTRO_NSEC" tests/e2e/test-sendsheet-typing.yaml
maestro test -e MAESTRO_NSEC="$MAESTRO_NSEC" tests/e2e/test-rename-group.yaml
```

Closes #146
References #321 (same root cause; this PR does not touch NostrLoginSheet to avoid conflicts).

## Test plan

- [x] `npx tsc --noEmit` — passed locally
- [x] `npx eslint src/ --quiet` — passed locally
- [x] `npx prettier --check src/` — passed locally
- [x] `npx jest` — 3 suites / 13 tests passed locally
- [ ] Manual on Pixel: open each migrated sheet, focus its input, confirm the sheet lifts above the soft keyboard and the input stays visible
- [ ] Maestro: each flow listed above runs green on a real device