### PR TITLE
perf(nostr): persistent relay subscription for DMs alongside refreshDmInbox (#188)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -2416,6 +2416,89 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (!isLoggedIn) setDmInbox([]);
   }, [isLoggedIn]);
 
+  /**
+   * Persistent relay subscription for inbound DM events (#188).
+   *
+   * Layered ALONGSIDE `refreshDmInbox` per the issue's option B: the
+   * one-shot `querySync` still drains historical state on cold start /
+   * pull-to-refresh; this subscription catches anything published
+   * after that, eliminating the focus-driven polling loop.
+   *
+   * Design notes:
+   *  - Lifecycle: starts when the user is hydrated (`pubkey` + `isLoggedIn`)
+   *    and read relays are known; tears down on logout / identity change /
+   *    unmount. The teardown closes every relay sub it opened so we don't
+   *    leak relay quota across logins.
+   *  - Reconnect: handled inside `nostr-tools/SimplePool` — the subs are
+   *    long-lived and the pool re-emits past events on socket reconnect.
+   *    A relay set change (read-relays toggle, NIP-65 update) re-fires
+   *    this effect, which closes the old sub before opening the new one.
+   *  - Dedupe: every incoming wrap fires a debounced
+   *    `refreshDmInbox({ force: true })`. The wrap-id NIP-17 cache (the
+   *    same one the cold-start path uses) makes re-processing cheap — a
+   *    cache hit per wrap, no double decrypt. `mergeInboxEntries` dedupes
+   *    on event id, so the same wrap landing through both the sub and a
+   *    concurrent `fetchInboxDmEvents` call collapses to one inbox row.
+   *  - Single-flight: `refreshDmInbox` already coalesces overlapping
+   *    refreshes via `dmInboxInFlight`; bursts of arrivals through the
+   *    sub piggy-back on the in-flight refresh instead of spawning
+   *    duplicate work.
+   *  - Debounce: 500 ms — a typical message burst (e.g. a friend
+   *    splitting a paragraph into 3 wraps) collapses into a single
+   *    refresh tick instead of 3 back-to-back ones.
+   */
+  const dmSubDebounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const PERSISTENT_DM_SUB_DEBOUNCE_MS = 500;
+  useEffect(() => {
+    if (!isLoggedIn || !pubkey) return;
+    const readRelays = getReadRelays();
+    if (readRelays.length === 0) return;
+
+    const scheduleRefresh = (): void => {
+      if (dmSubDebounceTimer.current) clearTimeout(dmSubDebounceTimer.current);
+      dmSubDebounceTimer.current = setTimeout(() => {
+        dmSubDebounceTimer.current = null;
+        // Force-refresh so the TTL gate doesn't swallow the streamed
+        // event. The single-flight guard means a refresh already in
+        // progress will absorb this trigger instead of racing.
+        refreshDmInbox({ force: true }).catch((err) => {
+          if (__DEV__) console.warn('[Nostr] persistent-sub refresh failed:', err);
+        });
+      }, PERSISTENT_DM_SUB_DEBOUNCE_MS);
+    };
+
+    if (__DEV__) {
+      console.log(
+        `[Nostr] starting persistent DM subscription on ${readRelays.length} relay(s) for ${pubkey.slice(0, 8)}…`,
+      );
+    }
+    const unsubscribe = nostrService.subscribeInboxDmEvents({
+      myPubkey: pubkey,
+      relays: readRelays,
+      onKind4: (_ev) => scheduleRefresh(),
+      onKind1059: (_ev) => scheduleRefresh(),
+    });
+
+    return () => {
+      if (dmSubDebounceTimer.current) {
+        clearTimeout(dmSubDebounceTimer.current);
+        dmSubDebounceTimer.current = null;
+      }
+      try {
+        unsubscribe();
+      } catch (err) {
+        if (__DEV__) console.warn('[Nostr] persistent-sub teardown failed:', err);
+      }
+      if (__DEV__) {
+        console.log(`[Nostr] stopped persistent DM subscription for ${pubkey.slice(0, 8)}…`);
+      }
+    };
+    // `relays` intentionally listed via getReadRelays — a relay-set
+    // change (NIP-65 update / user toggle) closes the old sub and opens
+    // a new one against the new set. `refreshDmInbox` is stable across
+    // these renders thanks to its useCallback deps.
+  }, [isLoggedIn, pubkey, getReadRelays, refreshDmInbox]);
+
   const signEvent = useCallback(
     async (event: {
       kind: number;

--- a/src/services/nostrService.test.ts
+++ b/src/services/nostrService.test.ts
@@ -4,9 +4,53 @@
  * Quartz, 0xchat) read to display the group name — Lightning
  * Piggy's outgoing messages MUST include it for cross-client
  * interop. Issue #271.
+ *
+ * Lifecycle guards for `subscribeInboxDmEvents` (issue #188): the
+ * persistent relay subscription must open the right filters, route
+ * events to the kind-specific callbacks, and close every underlying
+ * sub on teardown so we don't leak relay quota across logins.
  */
 
-import { createGroupChatRumor } from './nostrService';
+// jest.mock factory bodies must not reference outer-scope variables
+// (jest hoists the mock above any top-level `const`s). So the mock
+// state lives on a globalThis-namespaced bag the factory populates,
+// and the test reads it back from there. Each subscribeMany call
+// returns a fresh handle whose `close` we can assert was invoked.
+type MockSub = {
+  close: jest.Mock;
+  filter: unknown;
+  handlers: { onevent: Function; oneose?: Function };
+};
+type MockBag = { subs: MockSub[]; subscribeMany: jest.Mock };
+jest.mock('nostr-tools/pool', () => {
+  const subs: MockSub[] = [];
+  const subscribeMany = jest.fn(
+    (_relays: string[], filter: unknown, handlers: { onevent: Function; oneose?: Function }) => {
+      const sub: MockSub = { close: jest.fn(), filter, handlers };
+      subs.push(sub);
+      return sub;
+    },
+  );
+  // Stash on globalThis so the test body can read/clear it without
+  // tripping the "out-of-scope reference" check on the factory.
+  (globalThis as unknown as { __nostrPoolMock: MockBag }).__nostrPoolMock = {
+    subs,
+    subscribeMany,
+  };
+  return {
+    SimplePool: jest.fn().mockImplementation(() => ({
+      subscribeMany,
+      querySync: jest.fn().mockResolvedValue([]),
+      close: jest.fn(),
+      listConnectionStatus: jest.fn().mockReturnValue(new Map()),
+    })),
+  };
+});
+
+import { createGroupChatRumor, subscribeInboxDmEvents } from './nostrService';
+
+const poolMock = (): MockBag =>
+  (globalThis as unknown as { __nostrPoolMock: MockBag }).__nostrPoolMock;
 
 const PK_A = 'a'.repeat(64);
 const PK_B = 'b'.repeat(64);
@@ -45,5 +89,180 @@ describe('createGroupChatRumor (outgoing kind-14)', () => {
     expect(rumor.kind).toBe(14);
     expect(rumor.pubkey).toBe(PK_A);
     expect(rumor.content).toBe('hi');
+  });
+});
+
+describe('subscribeInboxDmEvents (persistent DM sub, #188)', () => {
+  beforeEach(() => {
+    poolMock().subs.length = 0;
+    poolMock().subscribeMany.mockClear();
+  });
+
+  it('opens three subs (sent kind-4, received kind-4, kind-1059 wraps) on the supplied relays', () => {
+    const unsubscribe = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay.example'],
+      onKind4: jest.fn(),
+      onKind1059: jest.fn(),
+    });
+
+    expect(poolMock().subscribeMany).toHaveBeenCalledTimes(3);
+    const filters = poolMock().subs.map((s) => s.filter as Record<string, unknown>);
+
+    // Sent kind-4: authors = me.
+    expect(filters[0]).toMatchObject({ kinds: [4], authors: [PK_A] });
+    // Received kind-4: #p tag = me.
+    expect(filters[1]).toMatchObject({ kinds: [4], '#p': [PK_A] });
+    // NIP-17 wraps: kind 1059, #p = me.
+    expect(filters[2]).toMatchObject({ kinds: [1059], '#p': [PK_A] });
+
+    unsubscribe();
+  });
+
+  it('routes incoming events to onKind4 vs onKind1059 by kind', () => {
+    const onKind4 = jest.fn();
+    const onKind1059 = jest.fn();
+    const unsubscribe = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay.example'],
+      onKind4,
+      onKind1059,
+    });
+
+    const k4Event = {
+      id: 'k4-1',
+      pubkey: PK_B,
+      kind: 4,
+      created_at: 1,
+      tags: [['p', PK_A]],
+      content: 'enc',
+      sig: 's',
+    };
+    const wrapEvent = {
+      id: 'wrap-1',
+      pubkey: PK_C,
+      kind: 1059,
+      created_at: 2,
+      tags: [['p', PK_A]],
+      content: 'enc',
+      sig: 's',
+    };
+
+    // Fire each handler — the receive-kind-4 sub (idx 1) gets the k4
+    // event; the wraps sub (idx 2) gets the wrap. Both should land in
+    // their respective callbacks.
+    poolMock().subs[1].handlers.onevent(k4Event);
+    poolMock().subs[2].handlers.onevent(wrapEvent);
+
+    expect(onKind4).toHaveBeenCalledWith(k4Event);
+    expect(onKind1059).toHaveBeenCalledWith(wrapEvent);
+
+    unsubscribe();
+  });
+
+  it('closes every underlying sub on unsubscribe (no relay-quota leak)', () => {
+    const unsubscribe = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay.example'],
+      onKind4: jest.fn(),
+      onKind1059: jest.fn(),
+    });
+    const subs = poolMock().subs;
+    expect(subs).toHaveLength(3);
+    expect(subs.every((s) => s.close.mock.calls.length === 0)).toBe(true);
+
+    unsubscribe();
+
+    expect(subs.every((s) => s.close.mock.calls.length === 1)).toBe(true);
+  });
+
+  it('survives an underlying sub.close throwing (other subs still close)', () => {
+    const unsubscribe = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay.example'],
+      onKind4: jest.fn(),
+      onKind1059: jest.fn(),
+    });
+    const subs = poolMock().subs;
+    subs[0].close.mockImplementationOnce(() => {
+      throw new Error('socket gone');
+    });
+
+    expect(() => unsubscribe()).not.toThrow();
+    // Subs 1 and 2 still get their close call despite sub 0 throwing.
+    expect(subs[1].close).toHaveBeenCalledTimes(1);
+    expect(subs[2].close).toHaveBeenCalledTimes(1);
+  });
+
+  it('a re-subscribe (e.g. relay-set change) opens a fresh set of subs', () => {
+    const off1 = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay-a.example'],
+      onKind4: jest.fn(),
+      onKind1059: jest.fn(),
+    });
+    expect(poolMock().subscribeMany).toHaveBeenCalledTimes(3);
+    off1();
+    expect(
+      poolMock()
+        .subs.slice(0, 3)
+        .every((s) => s.close.mock.calls.length === 1),
+    ).toBe(true);
+
+    const off2 = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay-b.example'],
+      onKind4: jest.fn(),
+      onKind1059: jest.fn(),
+    });
+    expect(poolMock().subscribeMany).toHaveBeenCalledTimes(6);
+    expect(poolMock().subs).toHaveLength(6);
+    off2();
+    expect(
+      poolMock()
+        .subs.slice(3, 6)
+        .every((s) => s.close.mock.calls.length === 1),
+    ).toBe(true);
+  });
+
+  it('a handler that throws does not break event delivery to sibling subs', () => {
+    const onKind1059 = jest.fn().mockImplementation(() => {
+      throw new Error('downstream blew up');
+    });
+    const onKind4 = jest.fn();
+    const unsubscribe = subscribeInboxDmEvents({
+      myPubkey: PK_A,
+      relays: ['wss://relay.example'],
+      onKind4,
+      onKind1059,
+    });
+    const subs = poolMock().subs;
+
+    const wrap = {
+      id: 'w',
+      pubkey: PK_C,
+      kind: 1059,
+      created_at: 1,
+      tags: [['p', PK_A]],
+      content: 'x',
+      sig: 's',
+    };
+    // Should not bubble — the SUT swallows handler errors so a buggy
+    // consumer can't tear down the WebSocket.
+    expect(() => subs[2].handlers.onevent(wrap)).not.toThrow();
+
+    const k4 = {
+      id: 'k',
+      pubkey: PK_B,
+      kind: 4,
+      created_at: 2,
+      tags: [['p', PK_A]],
+      content: 'y',
+      sig: 's',
+    };
+    subs[1].handlers.onevent(k4);
+    expect(onKind4).toHaveBeenCalledWith(k4);
+
+    unsubscribe();
   });
 });

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -986,6 +986,106 @@ function nip44EncryptForRecipient(
 }
 
 /**
+ * Open a persistent relay subscription that streams DM-relevant events
+ * (NIP-04 kind-4 in either direction + NIP-17 kind-1059 wraps p-tagged
+ * to the viewer) as they are published. Mirrors the filter shape of
+ * `fetchInboxDmEvents` so consumers can route incoming events through
+ * the same per-event processing path used by the cold-start
+ * `refreshDmInbox` cache-merge.
+ *
+ * This is layered ALONGSIDE `fetchInboxDmEvents` (issue #188): the
+ * one-shot `querySync` still drains historical state on cold start /
+ * pull-to-refresh; this subscription catches anything published after
+ * that, eliminating the polling loop while preserving the existing
+ * fetch path as a backstop.
+ *
+ * Subscription lifecycle:
+ *  - Caller starts on login / hydrate, stops on logout / unmount.
+ *  - `subscribeMany` keeps the WebSocket alive and re-emits past events
+ *    if a relay reconnects, so we don't manage reconnect ourselves —
+ *    the pool's relay layer handles it. The returned `onclose`-aware
+ *    unsubscribe just disposes the sub handle.
+ *  - `since` (optional) lets the caller pass a recent timestamp to
+ *    avoid re-streaming a full back-catalog on first connect; defaults
+ *    to "now − 60s" if undefined so we still catch events published in
+ *    the brief window between cold-start fetch and sub start.
+ *
+ * Dedup is the caller's responsibility — the same event MAY arrive via
+ * this sub AND a concurrent `fetchInboxDmEvents` call. The intended
+ * dedupe key is the wrap id (`ev.id`), which is what the existing
+ * NIP-17 wrap caches and `mergeInboxEntries` already use.
+ */
+export interface DmInboxSubscriptionInput {
+  myPubkey: string;
+  relays: string[];
+  /** Lower-bound timestamp (epoch seconds). Defaults to `now - 60`. */
+  since?: number;
+  onKind4: (ev: RawDmEvent) => void;
+  onKind1059: (ev: RawGiftWrapEvent) => void;
+  /** Best-effort EOSE callback (one per relay). Optional. */
+  onEose?: () => void;
+}
+
+export function subscribeInboxDmEvents(input: DmInboxSubscriptionInput): () => void {
+  const allRelays = [...new Set([...input.relays, ...DEFAULT_RELAYS])];
+  trackRelays(allRelays);
+  // Damus's clock-drift pad: shift `since` back 2 minutes (matches
+  // fetchInboxDmEvents) so a relay with a slow clock still streams the
+  // edge-case events whose stamp falls just behind our cursor.
+  const nowSec = Math.floor(Date.now() / 1000);
+  const since = Math.max(0, (input.since ?? nowSec - 60) - 120);
+  const sentK4Filter: Filter = { kinds: [4], authors: [input.myPubkey], since };
+  const recvK4Filter: Filter = { kinds: [4], '#p': [input.myPubkey], since };
+  const wrapsFilter: Filter = { kinds: [1059], '#p': [input.myPubkey], since };
+
+  const onevent = (ev: {
+    id: string;
+    pubkey: string;
+    kind: number;
+    created_at: number;
+    tags: string[][];
+    content: string;
+    sig: string;
+  }): void => {
+    try {
+      if (ev.kind === 1059) {
+        input.onKind1059(ev as RawGiftWrapEvent);
+      } else if (ev.kind === 4) {
+        input.onKind4(ev as RawDmEvent);
+      }
+    } catch (err) {
+      if (__DEV__) console.warn('[Nostr] subscribeInboxDmEvents handler threw:', err);
+    }
+  };
+
+  const oneose = (): void => {
+    try {
+      input.onEose?.();
+    } catch {
+      // best-effort
+    }
+  };
+
+  // Three separate subs because subscribeMany takes a single Filter and
+  // the relay-side semantics for `kinds + authors + #p` are an AND, not
+  // an OR — collapsing them would over-filter (only events that are
+  // BOTH authored by us AND p-tag us, which is roughly nothing).
+  const subSentK4 = pool.subscribeMany(allRelays, sentK4Filter, { onevent, oneose });
+  const subRecvK4 = pool.subscribeMany(allRelays, recvK4Filter, { onevent, oneose });
+  const subWraps = pool.subscribeMany(allRelays, wrapsFilter, { onevent, oneose });
+
+  return () => {
+    for (const s of [subSentK4, subRecvK4, subWraps]) {
+      try {
+        s.close();
+      } catch {
+        // best-effort — sub may already be torn down
+      }
+    }
+  };
+}
+
+/**
  * Subscribe to inbound kind-30200 group-state events relevant to the
  * viewer. Two filters are OR-ed together so the viewer sees:
  *


### PR DESCRIPTION
## Summary

- Adds `subscribeInboxDmEvents` (`nostrService`) — a long-lived `pool.subscribeMany` over kind-4 (sent + received) and kind-1059 (NIP-17 wraps p-tagged to the viewer). Mirrors the filter shape of `fetchInboxDmEvents` so it can be processed through the same path.
- `NostrContext` starts the sub on hydrate / login, tears it down on logout / identity change / unmount. On each incoming event it fires a debounced (500 ms) force-refresh through `refreshDmInbox` so streamed events get the same NIP-17 unwrap + cache-merge treatment the cold-start path uses.
- `querySync` cold-start path is **untouched** — this is option B (additive), per the issue body's risk note.

## Why option B?

A full migration (rip out `querySync`) would require duplicating the entire NIP-17 unwrap + group-routing + signer-specific decrypt + LRU cache pipeline inside the sub callback, and subscription bugs are notoriously hard to spot in code review. The additive path delivers the issue's UX win — real-time messages without waiting for tab focus / pull-to-refresh — at near-zero behavior-loss risk. A future PR can phase out `querySync` once the persistent sub has soaked.

## Lifecycle

- **Start**: `useEffect` keyed on `[isLoggedIn, pubkey, getReadRelays, refreshDmInbox]`. Fires once the user is hydrated and read relays are known.
- **Stop**: cleanup function closes every underlying sub (`subSentK4`, `subRecvK4`, `subWraps`) and clears the debounce timer. Triggered by logout, identity change, unmount, or relay-set change.
- **Reconnect**: delegated to `SimplePool` — its relay layer re-emits past events on socket reconnect, so we don't manage WS lifecycle ourselves. A relay-set change closes the old sub set before opening a new one against the new relays.
- **No quota leak**: every `subscribeMany` call is matched by an `s.close()` on teardown — covered by a unit test.

## Dedupe story

The persistent sub firing the same wrap that `refreshDmInbox` is also processing is handled by **two existing mechanisms**:

1. **Wrap-id NIP-17 cache** (`AMBER_NIP17_CACHE_KEY` / `NSEC_NIP17_CACHE_KEY`) — the second processing of a wrap hits the cache (no decrypt, no Amber IPC), making the cost negligible.
2. **`mergeInboxEntries` id-keyed merge** — collapses duplicate inbox entries on event id. The same wrap landing through both the sub trigger and a concurrent `fetchInboxDmEvents` collapses to one inbox row.

`dmInboxInFlight` (single-flight) further coalesces refresh triggers from event bursts so a 3-message burst becomes one refresh, not three.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/ --quiet` — clean
- [x] `npx prettier --check src/` — clean
- [x] `npx jest` — 19/19 passing (6 new tests for the sub: filter shape, kind-routing, teardown closes all subs, throw-resilient unsubscribe, re-subscribe opens fresh subs, handler-throw isolation)
- [ ] Real-device: messages from a peer arrive in inbox without tab focus / pull-to-refresh (verify via grep `[Nostr] starting persistent DM subscription` in logcat)
- [ ] Real-device: log out → log back in → confirm one `starting…` and one `stopped…` line per session (no leaked sub from previous identity)
- [ ] Real-device: toggle a relay off in Settings → confirm sub re-fires against the new relay set
- [ ] Real-device: app background / foreground → relay sockets resume and events still stream (SimplePool reconnect)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)