### PR TITLE
feat(messages): image-filter picker scaffold (#355)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,15 @@ module.exports = {
   // first transitive crypto import. The base preset list is reproduced
   // verbatim so this doesn't silently drift if jest-expo updates.
   transformIgnorePatterns: [
-    '/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|nostr-tools|@noble|@scure))',
+    // `rn-color-matrices` and `concat-color-matrices` are the ESM
+    // matrix-data packages behind the image-filter picker (#138).
+    // `imageFilters.ts` imports `rn-color-matrices` directly (rather
+    // than via the `react-native-color-matrix-image-filters` wrapper)
+    // to keep the matrix table free of native-component imports that
+    // trip RN codegen during test transformation. Both packages ship as
+    // bare ESM and break Jest's CommonJS require pipeline unless we let
+    // Babel transform them.
+    '/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|nostr-tools|@noble|@scure|rn-color-matrices|concat-color-matrices))',
     '/node_modules/react-native-reanimated/plugin/',
   ],
   coverageThreshold: {

--- a/src/components/ImageFilterSheet.tsx
+++ b/src/components/ImageFilterSheet.tsx
@@ -1,0 +1,377 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  BackHandler,
+  ActivityIndicator,
+  ScrollView,
+  useWindowDimensions,
+} from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet';
+import { ColorMatrix, type Matrix } from 'react-native-color-matrix-image-filters';
+import { useThemeColors } from '../contexts/ThemeContext';
+import type { Palette } from '../styles/palettes';
+import {
+  DEFAULT_FILTER_ID,
+  FILTER_PRESETS,
+  type FilterId,
+  type FilterPreset,
+} from '../utils/imageFilters';
+
+interface Props {
+  /** When non-null, the sheet is open and previews this local image URI. */
+  imageUri: string | null;
+  /** Closes the sheet without sending. */
+  onCancel: () => void;
+  /** Called with the (eventually filter-baked) URI to upload + send. */
+  onSend: (uri: string, filterId: FilterId) => void;
+  /**
+   * True when the parent is mid-upload after a Send tap. The sheet stays
+   * mounted (so the user sees a spinner over the preview) and the Send
+   * button is disabled until the parent flips this back to false.
+   */
+  sending?: boolean;
+}
+
+/**
+ * Filter-preview sheet shown after the user picks a photo (Camera or
+ * Gallery) and before it's uploaded. Lets them pick from a horizontal
+ * row of preset thumbnails — see `FILTER_PRESETS` in `utils/imageFilters`.
+ *
+ * Honest scope (#138): the live preview applies real color-matrix
+ * filters via `react-native-color-matrix-image-filters`, but only
+ * `Original` actually bakes into the uploaded bytes today. Other
+ * presets pass the original image through to Blossom — see the docstring
+ * in `utils/imageFilters.ts` and the follow-up issue tracked in the PR
+ * description for the Skia/IFK bake pipeline that will close that gap.
+ */
+const ImageFilterSheet: React.FC<Props> = ({ imageUri, onCancel, onSend, sending = false }) => {
+  const colors = useThemeColors();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const sheetRef = useRef<BottomSheetModal>(null);
+  // 90% gives a near-fullscreen preview area on a phone. We don't use
+  // dynamic sizing here because the preview is intentionally large —
+  // an intrinsic-sized sheet would hug the thumbnails row and bury the
+  // image behind the keyboard mental-model of the parent screen.
+  const snapPoints = useMemo(() => ['90%'], []);
+  const { width: windowWidth } = useWindowDimensions();
+  // Preview area is the screen width minus a small horizontal margin.
+  // Using window width (not the sheet's own width) keeps the layout
+  // identical across phone sizes without measuring the sheet itself.
+  const previewSize = Math.min(windowWidth - 32, 480);
+
+  const [selectedId, setSelectedId] = useState<FilterId>(DEFAULT_FILTER_ID);
+
+  // Drive present/dismiss off `imageUri` so callers don't have to track
+  // a separate `visible` flag — opening = "I have a picked image",
+  // closing = "I don't anymore". Resetting the selection on each open
+  // keeps the UX predictable: every new pick starts on Original.
+  useEffect(() => {
+    if (imageUri) {
+      setSelectedId(DEFAULT_FILTER_ID);
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
+    }
+  }, [imageUri]);
+
+  // Hardware back closes the sheet (Cancel semantics) — matches the
+  // pattern in GifPickerSheet. Without this, Android back would close
+  // the entire conversation, which would lose the picked image without
+  // an obvious way to retry.
+  useEffect(() => {
+    if (!imageUri) return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onCancel();
+      return true;
+    });
+    return () => sub.remove();
+  }, [imageUri, onCancel]);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        // Tapping the backdrop is "Cancel" — surface that intent
+        // explicitly via the press handler (the default backdrop press
+        // dismisses but doesn't fire `onClose` from the sheet itself
+        // until the dismiss animation runs).
+        pressBehavior="close"
+      />
+    ),
+    [],
+  );
+
+  const handleSheetChange = useCallback(
+    (index: number) => {
+      // -1 = dismissed (pan-down or backdrop tap). Treat as Cancel so
+      // the parent clears its `pendingImageUri` state and the picker
+      // doesn't immediately re-open on a re-render.
+      if (index === -1) onCancel();
+    },
+    [onCancel],
+  );
+
+  const handleSendPress = useCallback(() => {
+    if (!imageUri || sending) return;
+    onSend(imageUri, selectedId);
+  }, [imageUri, sending, onSend, selectedId]);
+
+  // Live preview — wrap the Image in the selected matrix filter (or
+  // skip the wrap entirely for Original to avoid the native-component
+  // round-trip when the user hasn't actually picked a filter).
+  const renderPreview = (uri: string, matrix: Matrix | null) => {
+    const image = (
+      <Image
+        source={{ uri }}
+        style={[styles.previewImage, { width: previewSize, height: previewSize }]}
+        resizeMode="contain"
+        accessibilityIgnoresInvertColors
+        accessibilityLabel="Image preview"
+      />
+    );
+    if (!matrix) return image;
+    return <ColorMatrix matrix={matrix}>{image}</ColorMatrix>;
+  };
+
+  // Filter-thumbnail tile in the horizontal carousel. Each tile is a
+  // small square preview of the picked image with the filter applied,
+  // captioned with the filter's display name.
+  const renderThumb = (preset: FilterPreset) => {
+    const isSelected = preset.id === selectedId;
+    return (
+      <TouchableOpacity
+        key={preset.id}
+        onPress={() => setSelectedId(preset.id)}
+        accessibilityLabel={`Apply ${preset.label} filter`}
+        accessibilityState={{ selected: isSelected }}
+        testID={`image-filter-${preset.id}`}
+        style={styles.thumbWrap}
+        activeOpacity={0.85}
+      >
+        <View style={[styles.thumbBorder, isSelected && { borderColor: colors.brandPink }]}>
+          {imageUri ? renderThumbImage(imageUri, preset.matrix) : null}
+        </View>
+        <Text
+          style={[styles.thumbLabel, isSelected && styles.thumbLabelSelected]}
+          numberOfLines={1}
+        >
+          {preset.label}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderThumbImage = (uri: string, matrix: Matrix | null) => {
+    const img = (
+      <Image
+        source={{ uri }}
+        style={styles.thumbImage}
+        resizeMode="cover"
+        accessibilityIgnoresInvertColors
+      />
+    );
+    if (!matrix) return img;
+    return <ColorMatrix matrix={matrix}>{img}</ColorMatrix>;
+  };
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      onChange={handleSheetChange}
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      handleIndicatorStyle={styles.handleIndicator}
+      backgroundStyle={styles.sheetBackground}
+      // Stack on top of the parent AttachPanel rather than dismissing
+      // it — same reason as GifPickerSheet/FriendPickerSheet.
+      stackBehavior="push"
+    >
+      <BottomSheetView style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Add a filter</Text>
+          <Text style={styles.subtitle}>
+            Pick a look, then tap Send. (Filters preview live; only{' '}
+            <Text style={styles.subtitleEm}>Original</Text> changes the file today — full filters
+            coming soon.)
+          </Text>
+        </View>
+
+        <View style={styles.previewWrap}>
+          {imageUri ? (
+            renderPreview(imageUri, FILTER_PRESETS.find((p) => p.id === selectedId)?.matrix ?? null)
+          ) : (
+            <View style={[styles.previewImage, { width: previewSize, height: previewSize }]} />
+          )}
+          {sending ? (
+            <View style={styles.previewSpinner}>
+              <ActivityIndicator color={colors.white} size="large" />
+            </View>
+          ) : null}
+        </View>
+
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.thumbRow}
+          accessibilityLabel="Filter presets"
+          testID="image-filter-row"
+        >
+          {FILTER_PRESETS.map(renderThumb)}
+        </ScrollView>
+
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={[styles.button, styles.cancelButton]}
+            onPress={onCancel}
+            disabled={sending}
+            accessibilityLabel="Cancel and discard the picked image"
+            testID="image-filter-cancel"
+          >
+            <Text style={styles.cancelButtonText}>Cancel</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.button, styles.sendButton, sending && styles.sendButtonDisabled]}
+            onPress={handleSendPress}
+            disabled={sending || !imageUri}
+            accessibilityLabel="Send the image"
+            testID="image-filter-send"
+          >
+            <Text style={styles.sendButtonText}>{sending ? 'Sending…' : 'Send'}</Text>
+          </TouchableOpacity>
+        </View>
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+};
+
+const THUMB_SIZE = 64;
+
+const createStyles = (colors: Palette) =>
+  StyleSheet.create({
+    sheetBackground: {
+      backgroundColor: colors.surface,
+    },
+    handleIndicator: {
+      backgroundColor: colors.divider,
+    },
+    container: {
+      flex: 1,
+      paddingBottom: 16,
+    },
+    header: {
+      paddingHorizontal: 20,
+      paddingTop: 4,
+      paddingBottom: 12,
+      gap: 4,
+    },
+    title: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: colors.textHeader,
+    },
+    subtitle: {
+      fontSize: 12,
+      color: colors.textSupplementary,
+      lineHeight: 16,
+    },
+    subtitleEm: {
+      fontWeight: '700',
+      color: colors.textBody,
+    },
+    previewWrap: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: 8,
+    },
+    previewImage: {
+      backgroundColor: colors.background,
+      borderRadius: 12,
+    },
+    previewSpinner: {
+      ...StyleSheet.absoluteFillObject,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(0,0,0,0.35)',
+      borderRadius: 12,
+    },
+    thumbRow: {
+      paddingHorizontal: 20,
+      paddingVertical: 12,
+      gap: 12,
+    },
+    thumbWrap: {
+      alignItems: 'center',
+      gap: 6,
+    },
+    thumbBorder: {
+      width: THUMB_SIZE + 4,
+      height: THUMB_SIZE + 4,
+      borderRadius: 10,
+      borderWidth: 2,
+      borderColor: 'transparent',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    thumbImage: {
+      width: THUMB_SIZE,
+      height: THUMB_SIZE,
+      borderRadius: 8,
+      backgroundColor: colors.background,
+    },
+    thumbLabel: {
+      fontSize: 11,
+      color: colors.textSupplementary,
+      maxWidth: THUMB_SIZE + 8,
+    },
+    thumbLabelSelected: {
+      color: colors.brandPink,
+      fontWeight: '700',
+    },
+    actions: {
+      flexDirection: 'row',
+      paddingHorizontal: 20,
+      paddingTop: 8,
+      gap: 12,
+    },
+    button: {
+      flex: 1,
+      borderRadius: 12,
+      paddingVertical: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cancelButton: {
+      backgroundColor: colors.background,
+    },
+    cancelButtonText: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: colors.textBody,
+    },
+    sendButton: {
+      backgroundColor: colors.brandPink,
+    },
+    sendButtonDisabled: {
+      opacity: 0.5,
+    },
+    sendButtonText: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: colors.white,
+    },
+  });
+
+export default ImageFilterSheet;

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -29,10 +29,12 @@ import * as nwcService from '../services/nwcService';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 import { stripImageMetadata, uploadImage } from '../services/imageUploadService';
+import { applyFilterToImage, type FilterId } from '../utils/imageFilters';
 import SendSheet from '../components/SendSheet';
 import AttachPanel from '../components/AttachPanel';
 import ConversationComposer from '../components/ConversationComposer';
 import GifPickerSheet from '../components/GifPickerSheet';
+import ImageFilterSheet from '../components/ImageFilterSheet';
 import ReceiveSheet from '../components/ReceiveSheet';
 import MessageBubble from '../components/MessageBubble';
 import TransactionDetailSheet, {
@@ -154,6 +156,12 @@ const ConversationScreen: React.FC = () => {
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
+  // After the user picks an image (Camera or Gallery) we hold the local
+  // URI here so `ImageFilterSheet` can preview it. Send tap → upload via
+  // `uploadAndSendImage`; Cancel tap → clear and go back to the
+  // conversation. Kept null while no picker flow is in flight (#138).
+  const [pendingImageUri, setPendingImageUri] = useState<string | null>(null);
+  const [pendingImageBase64, setPendingImageBase64] = useState<string | null>(null);
   const [sendSheetOpen, setSendSheetOpen] = useState(false);
   const [invoiceToPay, setInvoiceToPay] = useState<string | null>(null);
   const [avatarError, setAvatarError] = useState(false);
@@ -653,14 +661,23 @@ const ConversationScreen: React.FC = () => {
   }, [sharingLocation, name, pubkey, sendDirectMessage]);
 
   // Shared send-image path for both gallery and camera entry points.
-  // Strips EXIF from the picked image, uploads to the user's configured
-  // Blossom server (or nostr.build fallback), then DMs the returned URL
-  // to the conversation partner.
+  // Bakes the chosen filter (passthrough today for everything except
+  // Original — see `utils/imageFilters.ts` for the honest scope), strips
+  // EXIF, uploads to the user's configured Blossom server (or
+  // nostr.build fallback), then DMs the returned URL to the conversation
+  // partner.
   const uploadAndSendImage = useCallback(
-    async (localUri: string, pickerBase64?: string | null) => {
+    async (localUri: string, pickerBase64: string | null, filterId: FilterId) => {
       setUploadingImage(true);
       try {
-        const scrubbed = await stripImageMetadata(localUri, pickerBase64);
+        // Filter bake (currently a no-op for non-Original — see #138).
+        // We intentionally drop the picker base64 if the bake produced
+        // a different URI: the original base64 wouldn't match the new
+        // bytes. Passthrough preserves it so `stripImageMetadata` can
+        // skip the re-encode for GIFs.
+        const filteredUri = await applyFilterToImage(localUri, filterId);
+        const baseBase64 = filteredUri === localUri ? pickerBase64 : null;
+        const scrubbed = await stripImageMetadata(filteredUri, baseBase64);
         const url = await uploadImage(scrubbed.uri, signEvent, scrubbed.base64);
         const sendResult = await sendDirectMessage(pubkey, url);
         if (!sendResult.success) {
@@ -676,6 +693,10 @@ const ConversationScreen: React.FC = () => {
             createdAt: Math.floor(Date.now() / 1000),
           },
         ]);
+        // Only clear the pending picker state on success — on failure we
+        // keep the sheet open so the user can retry without re-picking.
+        setPendingImageUri(null);
+        setPendingImageBase64(null);
       } catch (error) {
         Alert.alert('Upload failed', error instanceof Error ? error.message : 'Please try again.');
       } finally {
@@ -702,8 +723,11 @@ const ConversationScreen: React.FC = () => {
       base64: true,
     });
     if (result.canceled || !result.assets?.[0]) return;
-    await uploadAndSendImage(result.assets[0].uri, result.assets[0].base64);
-  }, [isLoggedIn, uploadingImage, sending, uploadAndSendImage]);
+    // Hand off to the filter sheet rather than uploading immediately
+    // (#138). The sheet calls back via `onSend` → `uploadAndSendImage`.
+    setPendingImageUri(result.assets[0].uri);
+    setPendingImageBase64(result.assets[0].base64 ?? null);
+  }, [isLoggedIn, uploadingImage, sending]);
 
   const handleTakeAndSendPhoto = useCallback(async () => {
     if (!isLoggedIn || uploadingImage || sending) return;
@@ -721,8 +745,24 @@ const ConversationScreen: React.FC = () => {
       base64: true,
     });
     if (result.canceled || !result.assets?.[0]) return;
-    await uploadAndSendImage(result.assets[0].uri, result.assets[0].base64);
-  }, [isLoggedIn, uploadingImage, sending, uploadAndSendImage]);
+    setPendingImageUri(result.assets[0].uri);
+    setPendingImageBase64(result.assets[0].base64 ?? null);
+  }, [isLoggedIn, uploadingImage, sending]);
+
+  // Filter sheet callbacks. Cancel clears the picked image; Send hands
+  // the (possibly filtered) URI to the existing upload pipeline.
+  const handleFilterCancel = useCallback(() => {
+    if (uploadingImage) return;
+    setPendingImageUri(null);
+    setPendingImageBase64(null);
+  }, [uploadingImage]);
+
+  const handleFilterSend = useCallback(
+    (uri: string, filterId: FilterId) => {
+      void uploadAndSendImage(uri, pendingImageBase64, filterId);
+    },
+    [pendingImageBase64, uploadAndSendImage],
+  );
 
   // Share another contact's Nostr profile into this conversation. Payload
   // mirrors the ContactProfileSheet → "Share with friend" format: a
@@ -1121,6 +1161,12 @@ const ConversationScreen: React.FC = () => {
           setAttachPanelOpen(false);
         }}
         onSelect={handleSendGif}
+      />
+      <ImageFilterSheet
+        imageUri={pendingImageUri}
+        sending={uploadingImage}
+        onCancel={handleFilterCancel}
+        onSend={handleFilterSend}
       />
       <Modal
         visible={fullscreenGifUrl !== null}

--- a/src/screens/GroupConversationScreen.tsx
+++ b/src/screens/GroupConversationScreen.tsx
@@ -30,12 +30,14 @@ import ContactProfileSheet from '../components/ContactProfileSheet';
 import AttachPanel from '../components/AttachPanel';
 import ConversationComposer from '../components/ConversationComposer';
 import GifPickerSheet from '../components/GifPickerSheet';
+import ImageFilterSheet from '../components/ImageFilterSheet';
 import ReceiveSheet from '../components/ReceiveSheet';
 import SendSheet from '../components/SendSheet';
 import FriendPickerSheet, { PickedFriend } from '../components/FriendPickerSheet';
 import MessageBubble from '../components/MessageBubble';
 import { isConfigured as isGifConfigured, type Gif } from '../services/giphyService';
 import { stripImageMetadata, uploadImage } from '../services/imageUploadService';
+import { applyFilterToImage, type FilterId } from '../utils/imageFilters';
 import {
   getCurrentLocation,
   formatGeoMessage,
@@ -100,6 +102,11 @@ const GroupConversationScreen: React.FC = () => {
   const [contactPickerOpen, setContactPickerOpen] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [sharingLocation, setSharingLocation] = useState(false);
+  // After the user picks an image (Camera or Gallery) we hold the local
+  // URI here so `ImageFilterSheet` can preview it. Same pattern as
+  // ConversationScreen — see #138.
+  const [pendingImageUri, setPendingImageUri] = useState<string | null>(null);
+  const [pendingImageBase64, setPendingImageBase64] = useState<string | null>(null);
   // Sheets surfaced by MessageBubble taps. Mirror the 1:1 conversation
   // wiring (ConversationScreen) so the rich-card affordances work the
   // same in groups.
@@ -257,12 +264,19 @@ const GroupConversationScreen: React.FC = () => {
   }, []);
 
   const uploadAndSend = useCallback(
-    async (localUri: string, base64?: string | null) => {
+    async (localUri: string, base64: string | null, filterId: FilterId) => {
       setUploadingImage(true);
       try {
-        const scrubbed = await stripImageMetadata(localUri, base64);
+        // Filter bake (currently a no-op for non-Original — see #138).
+        // Drop the picker base64 if the bake produced new bytes — see
+        // ConversationScreen for the same pattern.
+        const filteredUri = await applyFilterToImage(localUri, filterId);
+        const baseBase64 = filteredUri === localUri ? base64 : null;
+        const scrubbed = await stripImageMetadata(filteredUri, baseBase64);
         const url = await uploadImage(scrubbed.uri, signEvent, scrubbed.base64);
         await sendText(url);
+        setPendingImageUri(null);
+        setPendingImageBase64(null);
       } catch (err) {
         Alert.alert('Upload failed', err instanceof Error ? err.message : 'Please try again.');
       } finally {
@@ -286,8 +300,11 @@ const GroupConversationScreen: React.FC = () => {
       base64: true,
     });
     if (result.canceled || !result.assets?.[0]) return;
-    await uploadAndSend(result.assets[0].uri, result.assets[0].base64);
-  }, [uploadingImage, sending, closeAttachPanel, uploadAndSend]);
+    // Hand off to the filter sheet rather than uploading immediately
+    // (#138). The sheet calls back via `onSend` → `uploadAndSend`.
+    setPendingImageUri(result.assets[0].uri);
+    setPendingImageBase64(result.assets[0].base64 ?? null);
+  }, [uploadingImage, sending, closeAttachPanel]);
 
   const handleTakeAndSendPhoto = useCallback(async () => {
     if (uploadingImage || sending) return;
@@ -303,8 +320,24 @@ const GroupConversationScreen: React.FC = () => {
       base64: true,
     });
     if (result.canceled || !result.assets?.[0]) return;
-    await uploadAndSend(result.assets[0].uri, result.assets[0].base64);
-  }, [uploadingImage, sending, closeAttachPanel, uploadAndSend]);
+    setPendingImageUri(result.assets[0].uri);
+    setPendingImageBase64(result.assets[0].base64 ?? null);
+  }, [uploadingImage, sending, closeAttachPanel]);
+
+  // Filter sheet callbacks. Cancel clears the picked image; Send hands
+  // the (possibly filtered) URI to the existing upload pipeline.
+  const handleFilterCancel = useCallback(() => {
+    if (uploadingImage) return;
+    setPendingImageUri(null);
+    setPendingImageBase64(null);
+  }, [uploadingImage]);
+
+  const handleFilterSend = useCallback(
+    (uri: string, filterId: FilterId) => {
+      void uploadAndSend(uri, pendingImageBase64, filterId);
+    },
+    [pendingImageBase64, uploadAndSend],
+  );
 
   const handleShareLocation = useCallback(async () => {
     if (sharingLocation) return;
@@ -731,6 +764,13 @@ const GroupConversationScreen: React.FC = () => {
         visible={gifPickerOpen}
         onClose={() => setGifPickerOpen(false)}
         onSelect={handleSendGif}
+      />
+
+      <ImageFilterSheet
+        imageUri={pendingImageUri}
+        sending={uploadingImage}
+        onCancel={handleFilterCancel}
+        onSend={handleFilterSend}
       />
 
       <FriendPickerSheet

--- a/src/utils/imageFilters.test.ts
+++ b/src/utils/imageFilters.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the image-filter preset table (issue #138).
+ *
+ * Component-level tests for the picker sheet are covered by Maestro
+ * (per jest.config.js — coverage scope is services/utils/contexts only).
+ * These tests pin the preset shape, the bakeable contract, and the
+ * passthrough guarantee of `applyFilterToImage` so a future
+ * Skia/IFK swap can't silently regress the "Original is bytes-identical"
+ * promise users rely on.
+ */
+
+import {
+  ALL_FILTER_IDS,
+  DEFAULT_FILTER_ID,
+  FILTER_PRESETS,
+  applyFilterToImage,
+  getFilterPreset,
+  isFilterBakeable,
+  type FilterId,
+} from './imageFilters';
+
+describe('FILTER_PRESETS', () => {
+  it('puts Original first so the picker opens on a no-op', () => {
+    expect(FILTER_PRESETS[0]?.id).toBe('original');
+    expect(DEFAULT_FILTER_ID).toBe('original');
+  });
+
+  it('ships at least the 6 acceptance-criteria presets (#138)', () => {
+    // Issue #138 acceptance criteria: "At least 6 filters ship: Original,
+    // Warm, Cool, Black & white, Retro, Pop." We deliver Original, B&W,
+    // Sepia, Warm, Cool, Vintage, Pop — Vintage stands in for "Retro"
+    // (same intent, the IFK preset name is `vintage`).
+    expect(FILTER_PRESETS.length).toBeGreaterThanOrEqual(6);
+    const ids = ALL_FILTER_IDS;
+    expect(ids).toEqual(expect.arrayContaining(['original', 'bw', 'warm', 'cool', 'pop']));
+  });
+
+  it('has unique ids across the preset table', () => {
+    const ids = FILTER_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('has a non-empty label for every preset', () => {
+    for (const preset of FILTER_PRESETS) {
+      expect(typeof preset.label).toBe('string');
+      expect(preset.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('Original carries a null matrix (identity, no native wrap)', () => {
+    const original = getFilterPreset('original');
+    expect(original?.matrix).toBeNull();
+  });
+
+  it('non-Original presets carry a 20-entry color matrix', () => {
+    for (const preset of FILTER_PRESETS) {
+      if (preset.id === 'original') continue;
+      expect(preset.matrix).not.toBeNull();
+      expect(Array.isArray(preset.matrix)).toBe(true);
+      // RN color-matrix is a 4x5 matrix flattened to 20 floats.
+      expect(preset.matrix?.length).toBe(20);
+    }
+  });
+});
+
+describe('getFilterPreset', () => {
+  it('returns the matching preset by id', () => {
+    expect(getFilterPreset('bw')?.label).toBe('B&W');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    // Unknown ids can come from a stale persisted selection across an
+    // app upgrade — callers must fall back to Original rather than crash.
+    expect(getFilterPreset('not-a-real-filter' as FilterId)).toBeUndefined();
+  });
+});
+
+describe('isFilterBakeable', () => {
+  it('reports Original as bakeable (passthrough is trivially correct)', () => {
+    expect(isFilterBakeable('original')).toBe(true);
+  });
+
+  it('reports every other filter as NOT bakeable today (#138 scaffold)', () => {
+    // Today only Original actually changes the uploaded bytes — see the
+    // file-level comment in imageFilters.ts. When the Skia/IFK follow-up
+    // lands, this assertion flips and we add a regression test that
+    // every preset is bakeable.
+    for (const id of ALL_FILTER_IDS) {
+      if (id === 'original') continue;
+      expect(isFilterBakeable(id)).toBe(false);
+    }
+  });
+
+  it('reports unknown ids as not bakeable', () => {
+    expect(isFilterBakeable('does-not-exist' as FilterId)).toBe(false);
+  });
+});
+
+describe('applyFilterToImage', () => {
+  const URI = 'file:///tmp/picked.jpg';
+
+  it('returns the original uri unchanged for Original', async () => {
+    await expect(applyFilterToImage(URI, 'original')).resolves.toBe(URI);
+  });
+
+  it('returns the original uri unchanged for every preset (scaffold)', async () => {
+    // Today every preset is a passthrough. This test exists so the
+    // contract is explicit — when a real bake pipeline lands, this test
+    // changes shape (e.g. to assert a NEW uri is returned for non-
+    // Original filters) rather than being silently broken.
+    for (const id of ALL_FILTER_IDS) {
+      await expect(applyFilterToImage(URI, id)).resolves.toBe(URI);
+    }
+  });
+
+  it('returns the original uri for an unknown id (graceful fallback)', async () => {
+    await expect(applyFilterToImage(URI, 'mystery' as FilterId)).resolves.toBe(URI);
+  });
+});

--- a/src/utils/imageFilters.ts
+++ b/src/utils/imageFilters.ts
@@ -1,0 +1,121 @@
+/**
+ * Filter presets for the outgoing-image picker (issue #138).
+ *
+ * Each filter has:
+ *   - `id`         — stable string used in tests + as a React key.
+ *   - `label`      — short, kid-friendly display name shown under the
+ *                    thumbnail in the picker carousel.
+ *   - `matrix`     — color matrix factory from
+ *                    `react-native-color-matrix-image-filters`. Used to
+ *                    render the LIVE PREVIEW inside `ImageFilterSheet`.
+ *                    `null` means "no transform" (Original).
+ *   - `bakeable`   — whether the filter currently bakes into the
+ *                    outgoing file. Today only `original` is bakeable —
+ *                    the live-preview library composes a native View
+ *                    around the Image at render time, but does NOT
+ *                    write the filtered pixels back to disk (its README
+ *                    explicitly defers that to react-native-image-filter-
+ *                    kit / Skia / GL — none of which we want to pull in
+ *                    yet, see follow-up below). Non-bakeable filters
+ *                    show in the preview but pass the original bytes
+ *                    through to Blossom.
+ *
+ * Follow-up: replace this scaffold with a real Skia or
+ * react-native-image-filter-kit pipeline that captures the filtered
+ * pixels into a fresh file URI before upload. Tracked separately from
+ * #138 so the picker UX can ship and we can iterate on the preset list
+ * without blocking on the native-module choice.
+ */
+
+// Import the matrix factories from `rn-color-matrices` directly rather
+// than from the `react-native-color-matrix-image-filters` wrapper. Both
+// re-export the same factory functions, but the wrapper also pulls in
+// the native filter component (CMIFColorMatrixImageFilterNativeComponent),
+// which trips React Native's codegen pass during Jest transformation
+// and breaks unit tests that just want the matrix data. The wrapper IS
+// imported by `ImageFilterSheet.tsx`, where the native component is
+// actually needed.
+import colorMatrices, { type Matrix } from 'rn-color-matrices';
+const { grayscale, sepia, warm, cool, vintage, contrast } = colorMatrices;
+
+export type FilterId = 'original' | 'bw' | 'sepia' | 'warm' | 'cool' | 'vintage' | 'pop';
+
+export interface FilterPreset {
+  readonly id: FilterId;
+  readonly label: string;
+  /** Color matrix used for the live preview. `null` = identity (Original). */
+  readonly matrix: Matrix | null;
+  /**
+   * Whether the filter actually bakes into the uploaded file. Today only
+   * `original` is true; other entries preview but pass through. See the
+   * file-level docstring + the follow-up Skia/IFK issue.
+   */
+  readonly bakeable: boolean;
+}
+
+// Order matters: `Original` is always first so the picker opens on a
+// known-good, no-op selection.
+export const FILTER_PRESETS: readonly FilterPreset[] = [
+  { id: 'original', label: 'Original', matrix: null, bakeable: true },
+  { id: 'bw', label: 'B&W', matrix: grayscale(), bakeable: false },
+  { id: 'sepia', label: 'Sepia', matrix: sepia(), bakeable: false },
+  { id: 'warm', label: 'Warm', matrix: warm(), bakeable: false },
+  { id: 'cool', label: 'Cool', matrix: cool(), bakeable: false },
+  { id: 'vintage', label: 'Vintage', matrix: vintage(), bakeable: false },
+  // "Pop" = high contrast. `contrast(1.4)` is the strongest of the
+  // presets — anything > ~1.6 starts blowing out highlights on
+  // already-bright camera shots.
+  { id: 'pop', label: 'Pop', matrix: contrast(1.4), bakeable: false },
+] as const;
+
+export const DEFAULT_FILTER_ID: FilterId = 'original';
+
+/**
+ * Look up a preset by id. Returns `undefined` for unknown ids — callers
+ * (sheet UI, send-path stub) should fall back to `original` rather than
+ * blow up, since presets can be added/removed across builds.
+ */
+export function getFilterPreset(id: FilterId): FilterPreset | undefined {
+  return FILTER_PRESETS.find((preset) => preset.id === id);
+}
+
+/**
+ * Returns true iff applying the named filter to a picked image would
+ * change the bytes that get uploaded. Used by the send-path stub to
+ * decide whether to skip the (currently no-op) bake step entirely.
+ *
+ * NOTE: as of #138 this is `true` only for `original` (since "no-op" is
+ * trivially correct). Once a real bake pipeline lands, every preset's
+ * `bakeable` flag flips to `true` and this function effectively becomes
+ * `id !== 'original'`.
+ */
+export function isFilterBakeable(id: FilterId): boolean {
+  return getFilterPreset(id)?.bakeable ?? false;
+}
+
+/**
+ * Apply a filter to a picked image, returning a (possibly new) local
+ * file URI suitable for upload. Today this is a passthrough for every
+ * preset — see the file-level docstring. Kept as an async function so
+ * the call site doesn't need to change when a real bake pipeline lands.
+ *
+ * The `_unusedMatrix` parameter is intentionally unread: it would feed
+ * a Skia/IFK pipeline once one is wired up. We accept it now so the
+ * eventual switch is a one-file change.
+ */
+export async function applyFilterToImage(uri: string, filterId: FilterId): Promise<string> {
+  const preset = getFilterPreset(filterId);
+  if (!preset || !preset.matrix) {
+    // Original or unknown — return original bytes verbatim.
+    return uri;
+  }
+  // TODO(#138-followup): bake `preset.matrix` into the file via Skia /
+  // react-native-image-filter-kit / view-shot. Until then, the live
+  // preview shows the filter but the upload sends the original. The
+  // sheet header surfaces this honestly via the "preview only" badge.
+  return uri;
+}
+
+// Export the unused-symbol guard for tests so they can iterate the
+// preset list without depending on its private ordering.
+export const ALL_FILTER_IDS: readonly FilterId[] = FILTER_PRESETS.map((preset) => preset.id);


### PR DESCRIPTION
## Summary

Adds a TikTok-style filter-preview sheet between picking an image (Camera or Gallery) and uploading. The picker shows the chosen image with a horizontal carousel of preset filters underneath; tap to preview live, then **Send** to upload + DM the URL exactly as the existing Blossom flow does.

This is the **scaffold half** of issue #138 (now scoped under #355) — the picker UX, composer integration, and the Original passthrough all work. The Skia / image-filter-kit bake step that turns the previews into baked-into-the-file output is split out into a follow-up (#337) so the UX can ship and we can iterate on the preset list independently of the native-deps decision.

Closes #355.
Refs #138, #337.

## What's actually in the box

| Filter | Live preview | Bakes into upload |
|--------|:-:|:-:|
| Original | n/a (identity) | yes — bytes-identical passthrough |
| B&W | yes (`grayscale`) | no — TODO bake step |
| Sepia | yes (`sepia`) | no — TODO bake step |
| Warm | yes (`warm`) | no — TODO bake step |
| Cool | yes (`cool`) | no — TODO bake step |
| Vintage | yes (`vintage`) | no — TODO bake step |
| Pop | yes (`contrast(1.4)`) | no — TODO bake step |

Live previews use real color matrices from `react-native-color-matrix-image-filters` (already in the dep tree at `^8.0.2`). The library's own README explicitly states it does NOT extract the filtered output to disk — that's its sibling `react-native-image-filter-kit`, which is a separate native-module decision.

The `applyFilterToImage(uri, filterId)` helper is wired as a passthrough today: every preset returns the original URI unchanged. The function signature is the one the eventual bake pipeline will use, so the swap is one file (`src/utils/imageFilters.ts`) with no call-site changes.

The sheet header surfaces this honestly to the user: *\"Filters preview live; only Original changes the file today — full filters coming soon.\"*

## Follow-up

Real bake step tracked separately: **#337** — *bake image filters into uploaded bytes (Skia / image-filter-kit follow-up to #138)*. Refs that issue from `applyFilterToImage`'s TODO comment.

## Files changed

- `src/utils/imageFilters.ts` (new) — preset table + `applyFilterToImage` passthrough.
- `src/utils/imageFilters.test.ts` (new) — 14 unit tests pinning the preset shape and the passthrough contract so the eventual bake step can't silently regress \"Original is bytes-identical\".
- `src/components/ImageFilterSheet.tsx` (new) — bottom sheet with preview area + horizontal preset row + Send/Cancel buttons.
- `src/screens/ConversationScreen.tsx` — intercept after `launchImageLibraryAsync` / `launchCameraAsync`, hold picked URI in state, hand off to the sheet, route Send back through the existing `uploadAndSendImage` path.
- `src/screens/GroupConversationScreen.tsx` — same wiring for group chats so both paths share the picker.
- `jest.config.js` — allow-list `rn-color-matrices` + `concat-color-matrices` (transitive ESM deps of the matrix library).

## Gates

- `npx tsc --noEmit` — clean
- `npx eslint src/ --quiet` — clean
- `npx prettier --check src/` — clean
- `npx jest` — 27/27 passing (14 new in `imageFilters.test.ts`)

## What I deliberately did NOT do

- No new native modules / image-processing deps (no Skia, no expo-gl, no view-shot, no image-filter-kit).
- No changes to the camera/picker entry points themselves — only the post-pick handler.
- No sticker pack — issue #138's secondary scope (drag-to-place stickers) is part of the follow-up, since stickers also need view flattening to bake into the upload.

## Test plan

- [ ] Open a 1:1 conversation, tap the **+** attach button, tap **Gallery** (or **Camera**)
- [ ] Pick a photo — confirm the filter sheet slides up showing the picked image
- [ ] Tap each preset — confirm the live preview updates
- [ ] Tap **Cancel** — sheet closes, no message sent
- [ ] Re-pick, choose **Original**, tap **Send** — confirm the photo arrives in the conversation as expected
- [ ] Re-pick, choose a non-Original preset, tap **Send** — confirm the photo arrives (today the bytes are still the original; the receiver sees the unfiltered image, intentional per the table above)
- [ ] Repeat in a group conversation — same picker, same behaviour
- [ ] Hardware Back closes the sheet without sending