### PR TITLE
fix(dm): drop since filter from kind-1059 inbox query (NIP-59 timestamps are random)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -1969,12 +1969,11 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
       // Persist merged list + new per-peer last-seen so next open of
       // THIS thread sees only the delta. Fire-and-forget; the caller
-      // gets its data immediately via `merged`.
-      const newConvLastSeen = Math.max(
-        convLastSeen ?? 0,
-        ...kind4Events.map((e) => e.created_at),
-        ...kind1059.map((e) => e.created_at),
-      );
+      // gets its data immediately via `merged`. kind-1059 deliberately
+      // excluded — wrap timestamps are randomized per NIP-59 and would
+      // poison the kind-4 since cursor (same reasoning as the inbox
+      // path; see fetchInboxDmEvents + refreshDmInbox).
+      const newConvLastSeen = Math.max(convLastSeen ?? 0, ...kind4Events.map((e) => e.created_at));
       Promise.all([
         AsyncStorage.setItem(convCacheKey(pubkey, normalized), JSON.stringify(merged)).catch(
           () => {},
@@ -2367,15 +2366,17 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
           setDmInbox(filteredFinal);
 
-          // Persist merged list + new last-seen (max created_at across
-          // fresh entries, kind-4 + kind-1059 both contribute). Debounced
-          // writes would be nicer but AsyncStorage setItem is async and
-          // rarely blocking at this scale; keep simple for now.
-          const newLastSeen = Math.max(
-            lastSeen ?? 0,
-            ...kind4.map((e) => e.created_at),
-            ...kind1059.map((e) => e.created_at),
-          );
+          // Persist merged list + new last-seen. Only kind-4 contributes
+          // here — NIP-59 wraps have randomized timestamps (~2 days in
+          // either direction of the real publish time) for plausible
+          // deniability, so wrap.created_at can't be used as a
+          // monotonic publish-time cursor. Including them here would
+          // ratchet lastSeen into the future on the first wrap with a
+          // forward-dated ts, then cause subsequent kind-4 since-filters
+          // to drop legitimate recent NIP-04 messages. fetchInboxDmEvents
+          // already drops the `since` filter for kind-1059 entirely (see
+          // the matching comment there); the cache dedupes wraps by id.
+          const newLastSeen = Math.max(lastSeen ?? 0, ...kind4.map((e) => e.created_at));
           await Promise.all([
             AsyncStorage.setItem(inboxCacheKey(refreshForPubkey), JSON.stringify(merged)).catch(
               () => {},

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -645,9 +645,7 @@ export async function fetchInboxDmEvents(
   const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
   trackRelays(allRelays);
   const limit = options.limit ?? 500;
-  // `since` shifted back 2 minutes (Damus clock-drift pad). All three
-  // inbox sub-queries share the same since floor: any relay that
-  // stamped an event slightly-in-our-past still returns it.
+  // `since` shifted back 2 min (Damus clock-drift pad). Applied only to kind-4 filters below; wraps deliberately skip it (see next comment).
   const since = options.since !== undefined ? Math.max(0, options.since - 120) : undefined;
   const sentK4Filter: Filter = { kinds: [4], authors: [myPubkey], limit };
   const recvK4Filter: Filter = { kinds: [4], '#p': [myPubkey], limit };

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -651,11 +651,26 @@ export async function fetchInboxDmEvents(
   const since = options.since !== undefined ? Math.max(0, options.since - 120) : undefined;
   const sentK4Filter: Filter = { kinds: [4], authors: [myPubkey], limit };
   const recvK4Filter: Filter = { kinds: [4], '#p': [myPubkey], limit };
+  // NIP-59 (gift-wrap) wraps have RANDOMIZED timestamps within ~2 days
+  // of the real publish time in either direction (per spec, for
+  // plausible deniability). So `wrap.created_at` does NOT track when
+  // the underlying message was sent. Applying `since` to the wraps
+  // filter caused recently-published wraps to be silently dropped at
+  // the relay whenever their random ts < lastSeen — and lastSeen could
+  // itself be a future-dated wrap's random ts (see callers using
+  // Math.max over kind1059.created_at), so the inbox query would
+  // progressively skip more and more wraps as the future-dated cap
+  // ratcheted forward. Symptom: a contact's recent DM is visible inside
+  // the per-conversation thread (which fetches peer-scoped without
+  // `since`) but never appears on the Messages tab inbox list.
+  // Resolution: don't filter wraps by `since` at all. The relay query
+  // is bounded by limit + the `#p:[myPubkey]` filter, and the consumer
+  // dedupes against the persisted wrap-id cache so already-decrypted
+  // wraps short-circuit cheaply.
   const wrapsFilter: Filter = { kinds: [1059], '#p': [myPubkey], limit };
   if (since !== undefined) {
     sentK4Filter.since = since;
     recvK4Filter.since = since;
-    wrapsFilter.since = since;
   }
   try {
     const [sentK4, receivedK4, wraps] = await Promise.all([


### PR DESCRIPTION
Closes #351

## Summary

Fixes a silent DM-loss bug in the inbox query.

NIP-59 gift wraps have RANDOMIZED timestamps within ~2 days of the real publish time in either direction (per spec, for plausible deniability). `wrap.created_at` therefore can't be used as a monotonic publish-time cursor.

Two compounding bugs created the silent-drop:

1. `fetchInboxDmEvents` applied `since` to the kind-1059 wraps filter. Relays correctly returned only wraps with `created_at >= since` — but a wrap published just now with a random timestamp 1.5 days in the past would be dropped.
2. `refreshDmInbox` and `fetchConversation` both computed their stored `lastSeen` as `Math.max(...kind4, ...kind1059)`. Once a wrap with a future-dated random timestamp landed, `lastSeen` ratcheted into the future, and every subsequent inbox refresh silently dropped a growing share of newly-published wraps.

`fetchConversation` accidentally avoided the bug because its peer-scoped fetch path doesn't apply `since` to the wraps query — that's why opening the per-conversation thread always resolved the missing message.

## Fix

- Drop `since` from the wraps filter in `fetchInboxDmEvents`. Consumer dedupes wraps by id against the persisted `Nip17CacheEntry` cache, so re-fetching old wraps is cheap.
- Exclude `kind-1059` from both `lastSeen` `Math.max` calls (inbox-wide and per-conversation).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [x] Symptom verified live before fix (counterparty on Primal sent DM, didn't appear on Messages tab list, did appear when conversation opened).