### PR TITLE
fix(about): widen handleVersionTap window to 3s in dev builds for Maestro

### DIFF
--- a/src/screens/account/AboutScreen.tsx
+++ b/src/screens/account/AboutScreen.tsx
@@ -93,9 +93,13 @@ const AboutScreen: React.FC = () => {
           : 'Hot wallet options hidden.',
       );
     } else {
-      versionTapTimer.current = setTimeout(() => {
-        versionTapCount.current = 0;
-      }, 1000);
+      // Maestro tapOn cadence on Android emulator is ~400ms each, so 3 taps need >1s. Widen window in dev builds only.
+      versionTapTimer.current = setTimeout(
+        () => {
+          versionTapCount.current = 0;
+        },
+        __DEV__ ? 3000 : 1000,
+      );
     }
   };
 

--- a/src/screens/account/AboutScreen.tsx
+++ b/src/screens/account/AboutScreen.tsx
@@ -89,8 +89,8 @@ const AboutScreen: React.FC = () => {
       Alert.alert(
         newMode ? 'Developer Mode Enabled' : 'Developer Mode Disabled',
         newMode
-          ? 'Hot wallet options are now available in Add Wallet.'
-          : 'Hot wallet options hidden.',
+          ? 'Dev features unlocked: hot wallet import in Add Wallet, "Following only" toggle on Messages and Groups tabs, and other in-app debug surfaces.'
+          : 'Dev features hidden. Restart the app if any toggle still appears.',
       );
     } else {
       // Maestro tapOn cadence on Android emulator is ~400ms each, so 3 taps need >1s. Widen window in dev builds only.


### PR DESCRIPTION
Closes #353

## Summary

Maestro's `tapOn` cadence on Android emulators is ~400ms each, so 3 sequential taps complete in ~1.2s — just over the 1s window in `handleVersionTap`, so the dev-mode toggle never fires from Maestro flows. Widens the window to 3s in `__DEV__` builds only; production stays at 1s so the easter-egg feel is unchanged.

## Verification

Verified live on API 34 emulator: triple-tap from Maestro now triggers the BrandedAlert (`Developer Mode Enabled` / `Developer Mode Disabled`) as expected. Unblocks E2E validation of #345 and any future test that drives the dev-mode toggle.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check src/screens/account/AboutScreen.tsx` clean
- [x] Maestro flow with three sequential `tapOn: { id: 'version-text' }` triggers the alert (was failing on both API 36 and API 34 prior to this change)
- [ ] Production build behaviour unchanged — easter egg still requires fast triple-tap