### PR TITLE
chore(deps): point bdk-rn lock at the lightning-piggy fork branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@scure/btc-signer": "^2.0.1",
         "@shopify/flash-list": "^2.3.1",
         "babel-preset-expo": "~55.0.8",
-        "bdk-rn": "github:BenGWeeks/bdk-rn#fix/rn083-gettype-compat",
+        "bdk-rn": "github:BenGWeeks/bdk-rn#lightning-piggy",
         "bip32": "^5.0.1",
         "bip39": "^3.1.0",
         "bitcoinjs-lib": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@scure/btc-signer": "^2.0.1",
     "@shopify/flash-list": "^2.3.1",
     "babel-preset-expo": "~55.0.8",
-    "bdk-rn": "github:BenGWeeks/bdk-rn#fix/rn083-gettype-compat",
+    "bdk-rn": "github:BenGWeeks/bdk-rn#lightning-piggy",
     "bip32": "^5.0.1",
     "bip39": "^3.1.0",
     "bitcoinjs-lib": "^7.0.1",


### PR DESCRIPTION
## Summary

Renames the consumed `bdk-rn` fork branch from `fix/rn083-gettype-compat` to `lightning-piggy` — same commit, new stable name. Pure rename: lockfile resolves to the identical `bdk-rn` commit (`cbd2623`), no behaviour change.

## Why

The fix-branch in `BenGWeeks/bdk-rn` was misnamed for the role it had grown into. It started as a single-purpose RN 0.83 compat fix, but has since accumulated unrelated work (the `efda213` `getInternalAddress` Android bug fix, soon a 16 KB ELF realignment of `libbdkffi.so` for #377).

`lightning-piggy` is now the explicit "everything LP needs, ready to consume" branch in the fork. Future fork work splits cleanly:

| Branch in `BenGWeeks/bdk-rn` | Purpose |
|---|---|
| `fix/rn083-gettype-compat` | 3 RN 0.83+ commits only — mirrors an upstream PR to `LtbLightning/bdk-rn` |
| `fix/get-internal-address` | `efda213` only — mirrors a 2nd upstream PR |
| `rebuild/16kb-aligned-libbdkffi` | 16 KB-realigned `libbdkffi.so` (probably not upstream-PR'd, since it's a binary) |
| **`lightning-piggy`** | **Merge of the above — what `lightning-piggy-mobile` pins to** |

## Files

- `package.json` — branch ref: `#fix/rn083-gettype-compat` → `#lightning-piggy`
- `package-lock.json` — resolves to the same SHA, just under the new ref

## Test plan

- [x] `npx prettier --check` — clean
- [x] Diff confirms no code-level change beyond the branch ref
- [ ] `npm install` (in CI) re-resolves the dep cleanly
- [ ] `npm run android:dev` (after PR #376 lands) still produces a working dev build with the `bdk-rn` native FFI loaded — same `libbdkffi.so` as today, just sourced from the renamed branch

Refs #377.
