### PR TITLE
perf(dm): cap inbox sub at 1000 events / 90 days on kind-4 (#383)

### DIFF
--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -765,10 +765,10 @@ export async function fetchInboxDmEvents(
 ): Promise<FetchedInboxEvents> {
   const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
   trackRelays(allRelays);
-  // 1000 matches the live-DM-sub cap (subscribeInboxDmsForViewer); both
-  // sit at the typical relay default. Callers can lower with `options.limit`.
-  // (#383)
-  const limit = options.limit ?? 1000;
+  // Default to the same cap the live sub uses, so the two paths can't
+  // drift. Callers can lower with `options.limit` if they want to be
+  // explicit. (#383)
+  const limit = options.limit ?? DM_INBOX_LIMIT;
   // `since` shifted back 2 min (Damus clock-drift pad). Applied only to kind-4 filters below; wraps deliberately skip it (see next comment).
   const since = options.since !== undefined ? Math.max(0, options.since - 120) : undefined;
   const sentK4Filter: Filter = { kinds: [4], authors: [myPubkey], limit };
@@ -1214,7 +1214,10 @@ export type RawInboxDmEvent = RawGiftWrapEvent;
 //    NIP-17 wrap-id cache + the NIP-04 RAM LRU populated by
 //    refreshDmInbox).
 
-const DM_INBOX_LIMIT = 1000;
+// Shared between the live sub (subscribeInboxDmsForViewer) and the bulk
+// fetch (fetchInboxDmEvents) so the two paths can't drift in cap on a
+// future tweak. (#383, Copilot review on PR #384)
+export const DM_INBOX_LIMIT = 1000;
 const DM_INBOX_SINCE_WINDOW_SECONDS = 90 * 24 * 60 * 60; // 90 days
 
 export function subscribeInboxDmsForViewer(input: {
@@ -1223,15 +1226,8 @@ export function subscribeInboxDmsForViewer(input: {
   onEvent: (ev: RawInboxDmEvent) => void;
 }): () => void {
   trackRelays(input.relays);
-  const onevent = (ev: {
-    id: string;
-    kind: number;
-    pubkey: string;
-    tags: string[][];
-    content: string;
-    created_at: number;
-  }): void => {
-    input.onEvent(ev as unknown as RawInboxDmEvent);
+  const onevent = (ev: Parameters<typeof input.onEvent>[0]): void => {
+    input.onEvent(ev);
   };
   const sinceK4 = Math.floor(Date.now() / 1000) - DM_INBOX_SINCE_WINDOW_SECONDS;
   const subK4 = pool.subscribeMany(

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -765,7 +765,10 @@ export async function fetchInboxDmEvents(
 ): Promise<FetchedInboxEvents> {
   const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
   trackRelays(allRelays);
-  const limit = options.limit ?? 500;
+  // 1000 matches the live-DM-sub cap (subscribeInboxDmsForViewer); both
+  // sit at the typical relay default. Callers can lower with `options.limit`.
+  // (#383)
+  const limit = options.limit ?? 1000;
   // `since` shifted back 2 min (Damus clock-drift pad). Applied only to kind-4 filters below; wraps deliberately skip it (see next comment).
   const since = options.since !== undefined ? Math.max(0, options.since - 120) : undefined;
   const sentK4Filter: Filter = { kinds: [4], authors: [myPubkey], limit };
@@ -1194,33 +1197,70 @@ export type RawInboxDmEvent = RawGiftWrapEvent;
 //    second device authored by the viewer wouldn't tag the viewer in
 //    `#p`, so multi-device sent-event sync still flows through
 //    pull-to-refresh / the next focus-driven `refreshDmInbox`.
-//  - No `since` filter — NIP-59 randomises wrap.created_at by ~2 days
-//    for plausible deniability, so a since cutoff would silently drop
-//    fresh wraps. Same reasoning as fetchInboxDmEvents above; kind-4
-//    inherits the same no-since policy for symmetry.
+//  - Two SEPARATE subs (one per kind) so we can apply `since` to kind-4
+//    only — NIP-59 randomises kind-1059 wrap.created_at by ±2 days for
+//    plausible deniability, so a server-side `since` cutoff on wraps
+//    silently drops legit fresh messages whose fake timestamp is older
+//    than the cutoff. kind-4 uses real timestamps and tolerates `since`.
+//    See fetchInboxDmEvents at lines ~769-785 for the same reasoning in
+//    the bulk-fetch path. (#383)
+//  - Both kinds get a 1000-event `limit`. Most relays cap at this
+//    anyway; making it explicit aligns the contract and stops a fresh
+//    install from being flooded with the user's entire DM history. (#383)
+//  - 90 days on kind-4 matches the largest UI filter chip ("Last
+//    30/90 days"). Older threads stay reachable via per-conversation
+//    queries when the user opens the thread (those have no `since`).
 //  - Caller is responsible for deduping (e.g. against the persistent
 //    NIP-17 wrap-id cache + the NIP-04 RAM LRU populated by
 //    refreshDmInbox).
+
+const DM_INBOX_LIMIT = 1000;
+const DM_INBOX_SINCE_WINDOW_SECONDS = 90 * 24 * 60 * 60; // 90 days
+
 export function subscribeInboxDmsForViewer(input: {
   viewerPubkey: string;
   relays: string[];
   onEvent: (ev: RawInboxDmEvent) => void;
 }): () => void {
   trackRelays(input.relays);
-  const sub = pool.subscribeMany(
+  const onevent = (ev: {
+    id: string;
+    kind: number;
+    pubkey: string;
+    tags: string[][];
+    content: string;
+    created_at: number;
+  }): void => {
+    input.onEvent(ev as unknown as RawInboxDmEvent);
+  };
+  const sinceK4 = Math.floor(Date.now() / 1000) - DM_INBOX_SINCE_WINDOW_SECONDS;
+  const subK4 = pool.subscribeMany(
     input.relays,
-    { kinds: [4, 1059], '#p': [input.viewerPubkey] } as Filter,
     {
-      onevent: (ev) => {
-        input.onEvent(ev as unknown as RawInboxDmEvent);
-      },
-    },
+      kinds: [4],
+      '#p': [input.viewerPubkey],
+      since: sinceK4,
+      limit: DM_INBOX_LIMIT,
+    } as Filter,
+    { onevent },
+  );
+  const subWraps = pool.subscribeMany(
+    input.relays,
+    {
+      kinds: [1059],
+      '#p': [input.viewerPubkey],
+      // No `since` — NIP-59 random timestamps would drop fresh wraps.
+      limit: DM_INBOX_LIMIT,
+    } as Filter,
+    { onevent },
   );
   return () => {
-    try {
-      sub.close();
-    } catch {
-      // best-effort
+    for (const s of [subK4, subWraps]) {
+      try {
+        s.close();
+      } catch {
+        // best-effort
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary

Live DM subscription was unbounded — `subscribeInboxDmsForViewer` asked the relay for **every** kind-4 + kind-1059 event ever that p-tags the viewer, with no `since` and no `limit`. On a fresh install with a long-lived npub the relay dumps the entire DM history in one burst; every kind-1059 wrap requires three crypto operations on the JS thread (NIP-44 decrypt → kind-13 unseal → kind-14 read), which compounds with the cold-start contact-list fetch fixed in PR #380 to make the Messages tab feel dead for ~minutes.

## Changes

### `subscribeInboxDmsForViewer` — split into two subs

Previously one combined `{ kinds: [4, 1059], '#p': [viewer] }` filter. Now two separate `subscribeMany` calls:

- **kind-4**: `{ kinds: [4], '#p': [viewer], since: now - 90d, limit: 1000 }` — 90 days matches the largest UI filter chip; older threads stay reachable via per-conversation queries.
- **kind-1059**: `{ kinds: [1059], '#p': [viewer], limit: 1000 }` — **deliberately no `since`**. NIP-59 randomises wrap.created_at by ±2 days for plausible deniability, so a server-side cutoff would silently drop legit fresh wraps. Same reasoning the bulk-fetch path (`fetchInboxDmEvents`) already documents at lines ~769-785.

Both subs share a single `onevent` callback so the caller's contract is unchanged.

### `fetchInboxDmEvents` default limit 500 → 1000

Aligns the bulk path with the live sub. Callers can still override.

## Expected impact (NOT YET MEASURED)

> ⚠️ **The numbers below are projections from the #372 trace + reasoning, not measurements on this branch.** A real before/after will land as a comment on this PR before merge — see "Measurement status" below.

| Symptom on long-lived npub | Before | Projected after |
|---|---|---|
| First-paint kind-1059 events to decrypt | thousands | ≤1000 |
| First-paint kind-4 events to render | thousands (years of history) | ≤1000 from last 90 days |
| Crypto ops on JS thread before inbox paints | ~3× wraps + parse all kind-4 | ~3× ≤1000 + parse ≤1000 |
| Time to first inbox row | ~minutes | seconds |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [ ] **Cold-start trace not yet captured on this branch.** A before/after comparison comment from `perf-suite-pixel` + logcat timings (matching the format used on PR #380) will be posted on this PR before merge.
- [ ] Cold-start a freshly cleared dev install with a multi-year npub: first inbox paint in seconds rather than minutes
- [ ] Open a 4+ month old per-conversation thread → full thread history still loads
- [ ] Send + receive a new DM → arrives via the live sub
- [ ] After 90 days, the relay-side cap on kind-4 should not drop messages from a recent thread that has older first messages — those land via per-conversation queries on open

## Out of scope

- Per-conversation queries (opening a thread) — still unbounded; deliberate, so the user can scroll back to old conversations.
- The follow-gate dropping non-followed senders permanently — that's #381, separate concern.
- A scroll-back-loads-more pagination for users who do want >1000 inbox rows.

Closes #383.

