### PR TITLE
perf(nostr): stream fetchProfiles via subscribeMany instead of querySync

### DIFF
--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -413,14 +413,23 @@ export async function fetchProfiles(
   // Surface incrementally via the caller's onBatch hook. Coalesce sub
   // events that arrive in tight bursts so we don't trigger 100s of
   // setContacts re-renders — once every 200 ms is enough to feel live.
-  let pendingEmit = false;
+  // The pending timer is tracked so the per-round flush below can clear
+  // it (otherwise the flush + a still-pending coalesced fire would
+  // double-emit the same snapshot a few hundred ms apart).
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
   const scheduleEmit = (): void => {
-    if (!onBatch || pendingEmit) return;
-    pendingEmit = true;
-    setTimeout(() => {
-      pendingEmit = false;
+    if (!onBatch || pendingTimer !== null) return;
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
       onBatch(new Map(profiles));
     }, 200);
+  };
+  const flushNow = (): void => {
+    if (pendingTimer !== null) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    if (onBatch) onBatch(new Map(profiles));
   };
 
   const ingest = (event: { pubkey: string; content: string; created_at: number }): void => {
@@ -438,12 +447,15 @@ export async function fetchProfiles(
     // batch; this is the upper bound for the whole multi-batch run.
     const overallDeadline = Date.now() + 120000;
 
-    // Batch in groups of 50, run up to 3 batches concurrently. The
-    // per-batch streaming sub has a 5 s soft timeout — well below the
-    // old 15 s pool.querySync ceiling because most profiles arrive
-    // within the first second; the residual 4 s is just for slow
-    // relays. Missing profiles are picked up by the retry pass below
-    // with a 3 s timeout.
+    // Batch in groups of 50, run up to 3 batches concurrently. Per-batch
+    // soft timeout is 10s for the main pass — same ceiling as the old
+    // pool.querySync ceiling (15s minus a couple of seconds), since
+    // shrinking it further turned a slow-but-valid profile into a 24h
+    // miss when loadContacts() bumps PROFILES_TIMESTAMP_KEY on partial
+    // fetches (Copilot review on PR #385). The streaming pattern is
+    // still the win — events surface to the UI as they arrive instead
+    // of all-at-batch-end, so cold start FEELS fast even though the
+    // worst-case wait per batch is unchanged.
     const batchSize = 50;
     const concurrency = 3;
     const batches: string[][] = [];
@@ -460,17 +472,15 @@ export async function fetchProfiles(
       if (i > 0) await new Promise((r) => setTimeout(r, 50));
       const concurrent = batches.slice(i, i + concurrency);
       await Promise.all(
-        concurrent.map((batch) => fetchProfilesBatch(batch, allRelays, 5000, ingest)),
+        concurrent.map((batch) => fetchProfilesBatch(batch, allRelays, 10000, ingest)),
       );
-      // Force a synchronous flush at batch-round boundary so callers
-      // get a guaranteed update even if no new events arrived inside
-      // the 200 ms coalesce window.
-      if (onBatch) onBatch(new Map(profiles));
+      flushNow();
     }
 
-    // Retry pass for missing profiles (smaller batches, shorter timeout
-    // — relays that didn't have it on the first round usually don't
-    // have it at all, so we only burn 3 s before giving up).
+    // Retry pass for missing profiles. 8s timeout — slow relays that
+    // missed the first round window may still produce on a second look,
+    // and the cost of cache-missing a profile for 24h is much higher
+    // than 8s of additional sub time on cold start.
     const missing = pubkeys.filter((pk) => !profiles.has(pk));
     if (missing.length > 0 && missing.length < pubkeys.length && Date.now() < overallDeadline) {
       if (__DEV__)
@@ -483,13 +493,21 @@ export async function fetchProfiles(
         if (Date.now() > overallDeadline) break;
         const concurrent = retryBatches.slice(i, i + concurrency);
         await Promise.all(
-          concurrent.map((batch) => fetchProfilesBatch(batch, allRelays, 3000, ingest)),
+          concurrent.map((batch) => fetchProfilesBatch(batch, allRelays, 8000, ingest)),
         );
-        if (onBatch) onBatch(new Map(profiles));
+        flushNow();
       }
     }
   } catch (error) {
     console.warn('Failed to batch fetch profiles:', error);
+  } finally {
+    // Make sure we don't leave a pending coalesce timer alive after the
+    // function resolves — the caller has the final state in the return
+    // value, so a late fire would just be a duplicate emit.
+    if (pendingTimer !== null) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
   }
 
   return profiles;

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -355,6 +355,50 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
   ]);
 }
 
+// Stream a single batch of profile events. Replaces the previous
+// `pool.querySync()`-based pattern which waited for EVERY relay in the
+// set to send EOSE before returning anything. With long lists like
+// Ben's 590-contact set this measured ~31 s for 580/590 profiles in
+// the #372 trace, dominated by per-batch waits against the slowest
+// relay. We instead open a sub, collect events as they arrive (tracking
+// the newest kind-0 per pubkey by created_at), and close after a soft
+// timeout. Events are surfaced to the caller via `onEvent` so the UI
+// can paint each name/avatar the moment it lands instead of waiting
+// for the batch to finish. (#372 follow-up)
+async function fetchProfilesBatch(
+  pubkeys: string[],
+  relays: string[],
+  softTimeoutMs: number,
+  onEvent: (event: { pubkey: string; content: string; created_at: number }) => void,
+): Promise<void> {
+  if (pubkeys.length === 0) return;
+  trackRelays(relays);
+  return new Promise<void>((resolve) => {
+    const best = new Map<string, number>(); // pubkey → best created_at seen
+    let closed = false;
+    const sub = pool.subscribeMany(relays, { kinds: [0], authors: pubkeys } as Filter, {
+      onevent: (ev: { pubkey: string; content: string; created_at: number }) => {
+        // Keep only the newest kind-0 per pubkey — Nostr clients can
+        // re-publish kind-0 with edits and we want the latest.
+        const prev = best.get(ev.pubkey);
+        if (prev !== undefined && ev.created_at <= prev) return;
+        best.set(ev.pubkey, ev.created_at);
+        onEvent(ev);
+      },
+    });
+    setTimeout(() => {
+      if (closed) return;
+      closed = true;
+      try {
+        sub.close();
+      } catch {
+        // best-effort
+      }
+      resolve();
+    }, softTimeoutMs);
+  });
+}
+
 export async function fetchProfiles(
   pubkeys: string[],
   relays: string[],
@@ -366,23 +410,40 @@ export async function fetchProfiles(
   // Include profile aggregator relays for better coverage
   const allRelays = [...new Set([...relays, ...PROFILE_RELAYS])];
 
-  const processEvents = (events: { pubkey: string; content: string }[]) => {
-    for (const event of events) {
-      if (profiles.has(event.pubkey)) continue;
-      const parsed = parseProfileContent(event.content);
-      profiles.set(event.pubkey, {
-        pubkey: event.pubkey,
-        npub: npubEncode(event.pubkey),
-        ...parsed,
-      });
-    }
+  // Surface incrementally via the caller's onBatch hook. Coalesce sub
+  // events that arrive in tight bursts so we don't trigger 100s of
+  // setContacts re-renders — once every 200 ms is enough to feel live.
+  let pendingEmit = false;
+  const scheduleEmit = (): void => {
+    if (!onBatch || pendingEmit) return;
+    pendingEmit = true;
+    setTimeout(() => {
+      pendingEmit = false;
+      onBatch(new Map(profiles));
+    }, 200);
+  };
+
+  const ingest = (event: { pubkey: string; content: string; created_at: number }): void => {
+    const parsed = parseProfileContent(event.content);
+    profiles.set(event.pubkey, {
+      pubkey: event.pubkey,
+      npub: npubEncode(event.pubkey),
+      ...parsed,
+    });
+    scheduleEmit();
   };
 
   try {
-    // Overall timeout: 120s max for all profile fetching
+    // Overall deadline cap. The streaming sub already times out per
+    // batch; this is the upper bound for the whole multi-batch run.
     const overallDeadline = Date.now() + 120000;
 
-    // Batch in groups of 50, run 3 batches concurrently, 15s timeout per batch
+    // Batch in groups of 50, run up to 3 batches concurrently. The
+    // per-batch streaming sub has a 5 s soft timeout — well below the
+    // old 15 s pool.querySync ceiling because most profiles arrive
+    // within the first second; the residual 4 s is just for slow
+    // relays. Missing profiles are picked up by the retry pass below
+    // with a 3 s timeout.
     const batchSize = 50;
     const concurrency = 3;
     const batches: string[][] = [];
@@ -391,29 +452,25 @@ export async function fetchProfiles(
     }
 
     for (let i = 0; i < batches.length; i += concurrency) {
-      // Bail if overall deadline exceeded
       if (Date.now() > overallDeadline) {
         if (__DEV__) console.warn('[Nostr] fetchProfiles: overall timeout reached');
         break;
       }
-      // Yield to event loop between batch rounds so UI stays responsive
-      // Use 50ms delay to give React time to process renders and user input
+      // Yield 50 ms between rounds so React can process renders + user input.
       if (i > 0) await new Promise((r) => setTimeout(r, 50));
-
       const concurrent = batches.slice(i, i + concurrency);
-      const results = await Promise.all(
-        concurrent.map((batch) =>
-          withTimeout(pool.querySync(allRelays, { kinds: [0], authors: batch }), 15000),
-        ),
+      await Promise.all(
+        concurrent.map((batch) => fetchProfilesBatch(batch, allRelays, 5000, ingest)),
       );
-      for (const events of results) {
-        if (events) processEvents(events);
-      }
-      // Notify caller with partial results so UI updates incrementally
+      // Force a synchronous flush at batch-round boundary so callers
+      // get a guaranteed update even if no new events arrived inside
+      // the 200 ms coalesce window.
       if (onBatch) onBatch(new Map(profiles));
     }
 
-    // Retry pass for missing profiles (smaller batches, longer timeout)
+    // Retry pass for missing profiles (smaller batches, shorter timeout
+    // — relays that didn't have it on the first round usually don't
+    // have it at all, so we only burn 3 s before giving up).
     const missing = pubkeys.filter((pk) => !profiles.has(pk));
     if (missing.length > 0 && missing.length < pubkeys.length && Date.now() < overallDeadline) {
       if (__DEV__)
@@ -425,14 +482,9 @@ export async function fetchProfiles(
       for (let i = 0; i < retryBatches.length; i += concurrency) {
         if (Date.now() > overallDeadline) break;
         const concurrent = retryBatches.slice(i, i + concurrency);
-        const results = await Promise.all(
-          concurrent.map((batch) =>
-            withTimeout(pool.querySync(allRelays, { kinds: [0], authors: batch }), 10000),
-          ),
+        await Promise.all(
+          concurrent.map((batch) => fetchProfilesBatch(batch, allRelays, 3000, ingest)),
         );
-        for (const events of results) {
-          if (events) processEvents(events);
-        }
         if (onBatch) onBatch(new Map(profiles));
       }
     }


### PR DESCRIPTION
## Summary

Cold-start `fetchProfiles` for a 590-contact follow list measured **~31 s** in the #372 Pixel 8 trace, dominated by per-batch `pool.querySync()` calls waiting for every relay's EOSE up to a 15 s timeout. Most kind-0 events arrive within the first second; the residual ~14 s per round was pure waste paid against the slowest relay.

This PR mirrors PR #380's fix for `fetchContactList` — replace `querySync` with a streaming `subscribeMany` that surfaces events as they arrive and closes after a soft timeout instead of waiting for EOSE.

## Change

New internal helper `fetchProfilesBatch()` opens a sub per batch, tracks the newest kind-0 per pubkey by `created_at`, and surfaces each event to the caller via an `onEvent` hook. The batch closes after a soft timeout — 5 s for the main pass (down from 15 s), 3 s for the retry pass (down from 10 s).

`fetchProfiles()` callers' `onBatch` hook now fires:
- Coalesced every 200 ms during streaming (smooth incremental paint of names + avatars in the Friends tab + DM headers)
- Once per batch round at the boundary (guaranteed flush)

This means a contact's name + avatar populate in the UI as soon as ANY relay returns the kind-0 — not at batch-end.

## Expected impact (NOT YET MEASURED on this branch)

> ⚠️ **The numbers below are projections derived from the #372 baseline + reasoning, not measurements on this branch.** Before/after will land as a comment on this PR before merge — see "Measurement status" below.

Per the #372 trace: 590 contacts → 12 batches → 4 rounds of 3 concurrent.

| | Baseline (`#372` trace) | Projected after |
|---|---:|---:|
| Per-batch wait (worst case) | 15 s | 5 s |
| Total main pass | ~60 s worst, ~30 s observed | ~20 s worst, ~5-10 s expected |
| Retry pass timeout | 10 s | 3 s |
| First profile painted in UI | end of first round (~5-10 s) | first event (~1 s) |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [ ] **Cold-start trace not yet captured on this branch.** A before/after comparison comment from `perf-suite-pixel` + logcat timings (matching the format used on PR #380) will be posted on this PR before merge.
- [ ] Cold-start a freshly cleared dev install, login, watch logcat for `[Nostr] fetchProfiles: <N>ms, <K>/590 profiles loaded` — expect <10 s for the main pass instead of ~30 s
- [ ] Friends tab populates name + avatar incrementally as relays drip them, not all-or-nothing
- [ ] Kind-0 freshness preserved: older republish from a slow relay shouldn't overwrite newer kind-0 from a fast relay

## Out of scope

- The `refreshDmInbox` 53 s cold-start wait — same pattern, separate PR after this lands
- The cache hydration + persistence layer above `fetchProfiles` is unchanged; only the relay-side fetch is rewritten

Closes #372.


