### PR TITLE
perf(nostr): defer fetchProfiles onBatch via InteractionManager (#372)

### DIFF
--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1,3 +1,4 @@
+import { InteractionManager } from 'react-native';
 import { SimplePool } from 'nostr-tools/pool';
 import {
   generateSecretKey,
@@ -416,12 +417,27 @@ export async function fetchProfiles(
   // The pending timer is tracked so the per-round flush below can clear
   // it (otherwise the flush + a still-pending coalesced fire would
   // double-emit the same snapshot a few hundred ms apart).
+  //
+  // Defer the actual onBatch call via InteractionManager.runAfterInteractions
+  // so a setContacts re-render doesn't land mid-animation (e.g. while the
+  // FriendPicker bottom-sheet is opening). PR #385's perf-suite trace
+  // showed FAB → FriendPicker open jumping from 1.49% → 10.16% modern
+  // jank, almost certainly because onBatch was invalidating the picker's
+  // memoized rows during its slide-up animation. runAfterInteractions
+  // queues the work behind any active animation/gesture/scroll and lets
+  // RN coalesce stacked updates. Worst case adds ~16-300 ms latency to
+  // a profile name/avatar appearing — invisible to the eye, well below
+  // the 200 ms coalesce floor we already accept.
   let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  const deferredEmit = (snapshot: Map<string, NostrProfile>): void => {
+    if (!onBatch) return;
+    InteractionManager.runAfterInteractions(() => onBatch(snapshot));
+  };
   const scheduleEmit = (): void => {
     if (!onBatch || pendingTimer !== null) return;
     pendingTimer = setTimeout(() => {
       pendingTimer = null;
-      onBatch(new Map(profiles));
+      deferredEmit(new Map(profiles));
     }, 200);
   };
   const flushNow = (): void => {
@@ -429,7 +445,7 @@ export async function fetchProfiles(
       clearTimeout(pendingTimer);
       pendingTimer = null;
     }
-    if (onBatch) onBatch(new Map(profiles));
+    deferredEmit(new Map(profiles));
   };
 
   const ingest = (event: { pubkey: string; content: string; created_at: number }): void => {


### PR DESCRIPTION
## Summary

Follow-up to PR #385. The streaming `setContacts` updates introduced by that PR caused the **FAB → FriendPicker open** surface to regress on modern-jank: **1.49 % → 10.16 %** in PR #385's perf-suite trace. Almost certainly the picker's memoized contact rows were being invalidated mid-slide-up because `onBatch` fired during the sheet's open animation.

## Change

Wrap the `onBatch` call in `InteractionManager.runAfterInteractions` so a profile-snapshot emit queues behind any active animation/gesture/scroll and RN gets to coalesce stacked updates. Worst-case latency for a name/avatar to appear bumps by ~16-300 ms — invisibly small next to the 200 ms coalesce floor we already accept.

## Why this is the right shape

- **Targeted**: only the React-side `setContacts` invocation is deferred. The internal `Map<pubkey, NostrProfile>` is updated synchronously as events arrive, so the data layer stays current.
- **Bounded**: `InteractionManager.runAfterInteractions` runs as soon as the JS thread is idle of interactions. A user constantly scrolling delays the emit, but only by the duration of the gesture — the next idle frame fires it.
- **Safe to revert**: single import + 4-line wrapper. If anything regresses, drop the `runAfterInteractions` and we're back to PR #385 behaviour.

## Expected impact (NOT YET MEASURED)

> ⚠️ Will run perf-suite-pixel on a cold start once this lands and post a before/after comment, matching the format used on PR #385.

Projected based on the diagnosis:

| Surface | After PR #385 | Expected after this PR |
|---|---:|---:|
| FAB → FriendPicker open jank | 10.16% | <5% (back near the 1.49% baseline) |
| FAB → FriendPicker open p99 | 85 ms | similar (this PR doesn't change frame timing) |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [ ] perf-suite-pixel re-run on cold start: FAB → FriendPicker open modern-jank back under 5 % (target: closer to PR #385's baseline of 1.49 %, accepting 10-30 pp single-sample noise)
- [ ] Profile name + avatar still populate live during cold start (defer is bounded by InteractionManager, not infinite)

Closes #372 — at least the FriendPicker-jank slice of it.
