### PR TITLE
perf(nostr): bump fetchProfiles coalesce window 200 → 500 ms (#372)

### DIFF
--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -412,7 +412,12 @@ export async function fetchProfiles(
 
   // Surface incrementally via the caller's onBatch hook. Coalesce sub
   // events that arrive in tight bursts so we don't trigger 100s of
-  // setContacts re-renders — once every 200 ms is enough to feel live.
+  // setContacts re-renders — 500 ms is far enough apart that a typical
+  // bottom-sheet open animation (~250-350 ms) doesn't get re-rendered
+  // mid-slide, but close enough to still feel live to the user. PR #385
+  // originally used 200 ms which caused a visible regression in
+  // FriendPicker open jank (1.49 % → 10.16 %); this is the simpler
+  // alternative to PR #386's InteractionManager defer.
   // The pending timer is tracked so the per-round flush below can clear
   // it (otherwise the flush + a still-pending coalesced fire would
   // double-emit the same snapshot a few hundred ms apart).
@@ -422,7 +427,7 @@ export async function fetchProfiles(
     pendingTimer = setTimeout(() => {
       pendingTimer = null;
       onBatch(new Map(profiles));
-    }, 200);
+    }, 500);
   };
   const flushNow = (): void => {
     if (pendingTimer !== null) {


### PR DESCRIPTION
## Summary

Alternative to PR #386 for the same problem: PR #385's streaming `setContacts` calls regressed the FAB → FriendPicker open jank from 1.49 % to 10.16 %.

Single-line change: bump the `fetchProfiles` onBatch coalesce window from **200 ms → 500 ms**.

## Why this might work better than #386

PR #386 uses `InteractionManager.runAfterInteractions` to fully defer the emit until the JS thread is idle. That fixes the small frame drops but **queues snapshots** so they fire all-at-once after the animation, producing a single bigger hitch (measured 117 ms p99 vs 85 ms before — over the >100 ms "visible hitch" threshold).

A simple coalesce-window bump just emits less often. No queueing. Each emit has the same cost as before, just spaced 500 ms apart instead of 200 ms.

A typical bottom-sheet open animation in this app is **~250-350 ms**. With a 200 ms coalesce, every sheet animation overlapping the cold-start fetch hits at least one mid-animation re-render. With 500 ms, most animations complete before the next emit.

## Cost

A name/avatar takes up to 500 ms longer to appear during cold start. Well below the live-update perception threshold for non-critical UI.

## Expected impact (NOT YET MEASURED)

> ⚠️ Will run perf-suite-pixel on this branch and post the comparison vs both PR #385 (baseline regression) and PR #386 (InteractionManager fix). Aim is to pick whichever produces the cleanest FriendPicker numbers.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [ ] perf-suite-pixel re-run on cold start: FAB → FriendPicker open modern-jank back under 5% AND 99th frame under 100 ms (PR #386 fix gets us under 10% jank but pushes 99th to 117 ms)
- [ ] Profile name + avatar populate live during cold start, just slightly slower (500 ms intervals instead of 200 ms)

Closes #372 — at least the FriendPicker-jank slice of it.

## A/B with PR #386

Both PRs are open. Whichever performs better in re-measurement merges; the other gets closed.
