### PR TITLE
docs(deploy): note that preview bundle ID needs NFC capability ticked

### DIFF
--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -567,9 +567,9 @@ Ad-hoc distribution installs a signed IPA onto a specific iPhone without going t
 * **Identifier type:** App IDs → App
 * **Description:** `Lightning Piggy Preview`
 * **Bundle ID (Explicit):** `com.lightningpiggy.app.preview`
-* Leave capabilities at defaults.
+* **Capabilities:** match the production bundle ID's capability set. Today the only iOS-side capability the app declares (per `ios/.../*.entitlements`) is **NFC Tag Reading** — tick that box. Other permissions (camera, contacts, microphone, photos) are handled via Info.plist usage strings, not capabilities, so they don't need toggling here.
 +
-(The production bundle ID gets auto-registered by EAS on the first iOS build, but the preview variant needs manual registration because the ad-hoc build path doesn't auto-create it.)
+(The production bundle ID gets auto-registered by EAS on the first iOS build, but the preview variant needs manual registration because the ad-hoc build path doesn't auto-create it. Missing the NFC capability surfaces as a confusing fastlane failure mid-build: `Provisioning profile ... doesn't include the NFC Tag Reading capability` / `... doesn't include the com.apple.developer.nfc.readersession.formats entitlement`. Fix is to enable it on the identifier and re-run the build — EAS auto-regenerates the provisioning profile.)
 
 . Register each tester's device UDID once via `eas device:create`:
 +


### PR DESCRIPTION
## Summary

Empirical: today's `eas build --platform ios --profile preview` failed mid-fastlane with:

```
Provisioning profile "*[expo] com.lightningpiggy.app.preview AdHoc..."
  doesn't include the NFC Tag Reading capability.
  doesn't include the com.apple.developer.nfc.readersession.formats entitlement.
```

Root cause: the preview bundle ID was registered per the documented "leave capabilities at defaults" instruction, but production has NFC enabled (PR #231 wired NFC tag read/write for Lightning + Nostr URLs) and the app's `ios/.../*.entitlements` file requests `com.apple.developer.nfc.readersession.formats: NDEF`. Mismatch → fastlane refuses to sign.

## Change

Updates the *One-time Apple Developer Portal setup* section in `docs/DEPLOYMENT.adoc` to:

- Say "match the production bundle ID's capability set" instead of "Leave capabilities at defaults"
- Call out NFC Tag Reading as the only capability the app declares today
- Quote the verbatim fastlane error so future readers find this section via Ctrl-F

Two-line diff. No code change.

## Test plan

N/A — docs-only.

Closes the doc gap surfaced while attempting to build a preview IPA for an under-13 tester (no GitHub issue filed since this is a one-shot doc fix; the next person registering a preview bundle ID will follow the corrected instructions).
