### PR TITLE
chore(release): bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.1-rc1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.0.1-rc1",
+      "version": "1.0.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.0",
+  "version": "1.0.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.0.0",
+      "version": "1.0.1-rc1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.1-rc1",
+  "version": "1.0.1",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.0",
+  "version": "1.0.1-rc1",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Why

`package.json` was still at `1.0.0` even though the most recent GitHub release was tagged **`v1.0.1-rc1`** on 2026-05-04. As a result, every EAS iOS build since the tag stamped `CFBundleShortVersionString` as `1.0.0`, and TestFlight kept showing the build labelled `1.0.0` while the GitHub release said `1.0.1-rc1` — confusing for anyone cross-referencing.

## What

One-line bump via \`npm version 1.0.1-rc1 --no-git-tag-version\`. Flows through:

- \`app.config.ts:41\` reads \`pkg.version\` → iOS \`CFBundleShortVersionString\` + Android \`android.versionName\`
- next EAS build picks it up automatically

## Scope

Marketing version only. Does **not** touch:
- iOS \`buildNumber\` (managed by EAS remote counter)
- Android \`versionCode\` (managed by EAS remote counter; was bumped to 5078 separately to clear a local-install \`INSTALL_FAILED_VERSION_DOWNGRADE\` block)

## Test plan

- [ ] CI green (TS / lint / coverage)
- [ ] Verify next EAS build shows \`appVersion: 1.0.1-rc1\` in \`eas build:list\`