### PR TITLE
chore(scripts): eas-deploy-pixel.sh — fail-fast versionCode check

### DIFF
--- a/scripts/eas-deploy-pixel.sh
+++ b/scripts/eas-deploy-pixel.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # eas-deploy-pixel.sh — kick off `eas build --local --profile production`,
-# fail fast if the determined versionCode won't install on the Pixel,
+# fail fast if the determined versionCode won't install on the device,
 # install + run perf-suite if it will.
 #
 # Why fail-fast: eas-cli prints "Incrementing versionCode from N to M"
@@ -9,42 +9,59 @@
 # the install at the end of the build will fail with
 # INSTALL_FAILED_VERSION_DOWNGRADE — so detect at line ~20 of the log
 # and abort, saving ~19 min.
+#
+# Env overrides:
+#   PIXEL_SERIAL — adb device serial (default: Ben's Pixel)
+#   PACKAGE      — Android package id (default: com.lightningpiggy.app)
 set -uo pipefail
 
+# Locate the repo root from the script's location instead of hardcoding —
+# scripts/eas-deploy-pixel.sh ⇒ repo root is one dir up.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
 PIXEL=${PIXEL_SERIAL:-37111FDJH0067B}
-PACKAGE=com.lightningpiggy.app
+PACKAGE=${PACKAGE:-com.lightningpiggy.app}
 LOG_DIR=/tmp
 BUILD_LOG="$LOG_DIR/eas-deploy-pixel-build.log"
-CHAIN_LOG="$LOG_DIR/eas-deploy-pixel-chain.log"
+EAS_TMPDIR="$HOME/eas-tmp"
+
+# Make sure the disk-backed TMPDIR exists. Required because /tmp is tmpfs (12 GB
+# cap on stock Ubuntu) and the EAS local builder writes ~9 GB of native-lib
+# intermediates per build. See docs/TROUBLESHOOTING.adoc.
+mkdir -p "$EAS_TMPDIR"
 
 DEVICE_VC=$(adb -s "$PIXEL" shell dumpsys package "$PACKAGE" 2>/dev/null | grep -oP 'versionCode=\K\d+' | head -1)
 echo "device $PIXEL has $PACKAGE versionCode=$DEVICE_VC"
-[ -z "$DEVICE_VC" ] && { echo "could not read device versionCode — is Pixel connected?"; exit 1; }
+[ -z "$DEVICE_VC" ] && { echo "could not read device versionCode — is the device connected?"; exit 1; }
 
 echo "starting eas build --local in background (logs: $BUILD_LOG)"
 # `setsid` puts the build in its own process group so we can kill the whole
-# tree later (eas-cli spawns npm, npx, java/gradle, kotlin daemons — a plain
-# kill on the parent leaves them as cpu-burning orphans).
-setsid bash -c "TMPDIR=\"$HOME/eas-tmp\" eas build --local --profile production --platform android --non-interactive" >"$BUILD_LOG" 2>&1 &
+# tree later (eas-cli spawns npm, npx, java/gradle — a plain kill on the
+# parent leaves them as cpu-burning orphans).
+setsid bash -c "TMPDIR=\"$EAS_TMPDIR\" eas build --local --profile production --platform android --non-interactive" >"$BUILD_LOG" 2>&1 &
 BUILD_PID=$!
 echo "build PID=$BUILD_PID (process group $BUILD_PID)"
 
-# Helper: kill the entire build process group + any stray gradle/kotlin daemons
+# Helper: kill the build's process group cleanly. Detached gradle / kotlin
+# daemons may survive (they're in their own pgroups, with idle-shutdown
+# timers); we deliberately do NOT pkill them globally because that would
+# also nuke any unrelated Android-Studio / VSCode-Java sessions on the
+# same machine.
 kill_build_tree() {
   kill -TERM -- -"$BUILD_PID" 2>/dev/null
   sleep 2
   kill -KILL -- -"$BUILD_PID" 2>/dev/null
-  # Gradle + Kotlin daemons detach into their own pgroups; pattern-kill them
-  pkill -KILL -f "GradleDaemon" 2>/dev/null
-  pkill -KILL -f "kotlin.daemon.KotlinCompileDaemon" 2>/dev/null
-  pkill -KILL -f "eas-cli-local-build-plugin" 2>/dev/null
   true
 }
 
+# If the user Ctrl-Cs / SIGTERMs the wrapper, take the build down with us.
+# Without this trap a Ctrl-C would leave the detached EAS pipeline + gradle
+# burning CPU + filling disk for the rest of the build.
+trap 'echo "[$(date +%T)] interrupted — killing build tree"; kill_build_tree; exit 130' INT TERM HUP
+
 # Phase 1: watch for the versionCode determination, fail fast if too low.
 # eas-cli emits "Version code: NN" within the first ~1% of the build (~60s).
-# Give it 5 min to reach that line — far longer than needed, but generous if
-# the box is loaded.
 echo "phase 1: waiting up to 5 min for versionCode determination"
 TIMEOUT=$((SECONDS + 300))
 NEW_VC=
@@ -75,18 +92,26 @@ wait "$BUILD_PID"
 BUILD_RC=$?
 [ $BUILD_RC -ne 0 ] && { echo "build failed rc=$BUILD_RC"; tail -30 "$BUILD_LOG"; exit $BUILD_RC; }
 
-cd /home/benw/GitHub/lightning-piggy-mobile
 APK=$(ls -1t build-*.apk 2>/dev/null | head -1)
 [ -z "$APK" ] && { echo "no APK produced"; exit 1; }
 echo "APK = $APK"
 
 echo "installing on $PIXEL"
+# adb install can return 0 on transport errors (e.g. "device offline") and
+# its app-level failures show up only in stdout as "Failure …" or
+# "INSTALL_FAILED_…". Check both rc and stdout.
 INSTALL_OUT=$(adb -s "$PIXEL" install -r "$APK" 2>&1)
+INSTALL_RC=$?
 echo "$INSTALL_OUT"
-echo "$INSTALL_OUT" | grep -q "Failure\|INSTALL_FAILED" && exit 3
+if [ $INSTALL_RC -ne 0 ] || echo "$INSTALL_OUT" | grep -qiE "Failure|INSTALL_FAILED|^error:|adb: device .* not found|device offline"; then
+  echo "install failed (rc=$INSTALL_RC) — not running perf-suite"
+  exit 3
+fi
 
 NEW_DEVICE_VC=$(adb -s "$PIXEL" shell dumpsys package "$PACKAGE" | grep -oP 'versionCode=\K\d+' | head -1)
 echo "device now reports versionCode=$NEW_DEVICE_VC"
 
 echo "perf-suite"
-SERIAL="$PIXEL" PACKAGE="$PACKAGE" bash scripts/perf-suite.sh
+# perf-suite.sh reads DEVICE + PKG from env (per scripts/perf-suite.sh:39-41).
+# Don't pass SERIAL / PACKAGE — those are this wrapper's names, not its.
+DEVICE="$PIXEL" PKG="$PACKAGE" bash scripts/perf-suite.sh

--- a/scripts/eas-deploy-pixel.sh
+++ b/scripts/eas-deploy-pixel.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# eas-deploy-pixel.sh — kick off `eas build --local --profile production`,
+# fail fast if the determined versionCode won't install on the Pixel,
+# install + run perf-suite if it will.
+#
+# Why fail-fast: eas-cli prints "Incrementing versionCode from N to M"
+# in the [CONFIGURE_ANDROID_VERSION] phase, which runs ~60 seconds into
+# a 20-minute build. If M is less than the device's current versionCode,
+# the install at the end of the build will fail with
+# INSTALL_FAILED_VERSION_DOWNGRADE — so detect at line ~20 of the log
+# and abort, saving ~19 min.
+set -uo pipefail
+
+PIXEL=${PIXEL_SERIAL:-37111FDJH0067B}
+PACKAGE=com.lightningpiggy.app
+LOG_DIR=/tmp
+BUILD_LOG="$LOG_DIR/eas-deploy-pixel-build.log"
+CHAIN_LOG="$LOG_DIR/eas-deploy-pixel-chain.log"
+
+DEVICE_VC=$(adb -s "$PIXEL" shell dumpsys package "$PACKAGE" 2>/dev/null | grep -oP 'versionCode=\K\d+' | head -1)
+echo "device $PIXEL has $PACKAGE versionCode=$DEVICE_VC"
+[ -z "$DEVICE_VC" ] && { echo "could not read device versionCode — is Pixel connected?"; exit 1; }
+
+echo "starting eas build --local in background (logs: $BUILD_LOG)"
+# `setsid` puts the build in its own process group so we can kill the whole
+# tree later (eas-cli spawns npm, npx, java/gradle, kotlin daemons — a plain
+# kill on the parent leaves them as cpu-burning orphans).
+setsid bash -c "TMPDIR=\"$HOME/eas-tmp\" eas build --local --profile production --platform android --non-interactive" >"$BUILD_LOG" 2>&1 &
+BUILD_PID=$!
+echo "build PID=$BUILD_PID (process group $BUILD_PID)"
+
+# Helper: kill the entire build process group + any stray gradle/kotlin daemons
+kill_build_tree() {
+  kill -TERM -- -"$BUILD_PID" 2>/dev/null
+  sleep 2
+  kill -KILL -- -"$BUILD_PID" 2>/dev/null
+  # Gradle + Kotlin daemons detach into their own pgroups; pattern-kill them
+  pkill -KILL -f "GradleDaemon" 2>/dev/null
+  pkill -KILL -f "kotlin.daemon.KotlinCompileDaemon" 2>/dev/null
+  pkill -KILL -f "eas-cli-local-build-plugin" 2>/dev/null
+  true
+}
+
+# Phase 1: watch for the versionCode determination, fail fast if too low.
+# eas-cli emits "Version code: NN" within the first ~1% of the build (~60s).
+# Give it 5 min to reach that line — far longer than needed, but generous if
+# the box is loaded.
+echo "phase 1: waiting up to 5 min for versionCode determination"
+TIMEOUT=$((SECONDS + 300))
+NEW_VC=
+while [ $SECONDS -lt $TIMEOUT ]; do
+  NEW_VC=$(grep -oP 'Version code: \K\d+' "$BUILD_LOG" 2>/dev/null | head -1)
+  [ -n "$NEW_VC" ] && break
+  kill -0 "$BUILD_PID" 2>/dev/null || { echo "build exited before versionCode line"; tail -20 "$BUILD_LOG"; exit 1; }
+  sleep 10
+done
+
+if [ -z "$NEW_VC" ]; then
+  echo "TIMEOUT — no versionCode line in 5 min. killing build."
+  kill_build_tree
+  exit 1
+fi
+
+echo "build will produce versionCode=$NEW_VC (device has $DEVICE_VC)"
+if [ "$NEW_VC" -le "$DEVICE_VC" ]; then
+  echo "ABORT — $NEW_VC <= $DEVICE_VC, install would fail with VERSION_DOWNGRADE"
+  echo "killing build to save ~19 min"
+  kill_build_tree
+  exit 2
+fi
+
+# Phase 2: build is going to produce an installable APK. Wait for it.
+echo "versionCode OK — letting build complete"
+wait "$BUILD_PID"
+BUILD_RC=$?
+[ $BUILD_RC -ne 0 ] && { echo "build failed rc=$BUILD_RC"; tail -30 "$BUILD_LOG"; exit $BUILD_RC; }
+
+cd /home/benw/GitHub/lightning-piggy-mobile
+APK=$(ls -1t build-*.apk 2>/dev/null | head -1)
+[ -z "$APK" ] && { echo "no APK produced"; exit 1; }
+echo "APK = $APK"
+
+echo "installing on $PIXEL"
+INSTALL_OUT=$(adb -s "$PIXEL" install -r "$APK" 2>&1)
+echo "$INSTALL_OUT"
+echo "$INSTALL_OUT" | grep -q "Failure\|INSTALL_FAILED" && exit 3
+
+NEW_DEVICE_VC=$(adb -s "$PIXEL" shell dumpsys package "$PACKAGE" | grep -oP 'versionCode=\K\d+' | head -1)
+echo "device now reports versionCode=$NEW_DEVICE_VC"
+
+echo "perf-suite"
+SERIAL="$PIXEL" PACKAGE="$PACKAGE" bash scripts/perf-suite.sh


### PR DESCRIPTION
## Why

\`eas build --local --profile production\` decides the APK's versionCode in the **[CONFIGURE_ANDROID_VERSION]** phase, which runs ~60 seconds into a 20-minute build. If that versionCode is below what's already installed on the target device, the \`adb install\` at the end fails with **INSTALL_FAILED_VERSION_DOWNGRADE** — and the 19 minutes between "version known" and "install attempted" are wasted.

Today's session burned **~76 minutes across four doomed builds** for exactly this reason. This adds a guard.

## What

\`scripts/eas-deploy-pixel.sh\` does:

1. Reads the device's current versionCode via \`adb dumpsys package\`
2. Starts \`eas build --local --profile production --platform android\` in the background, **wrapped in \`setsid\`** so it has its own process group
3. Polls the build log every 10 s for the line \`[CONFIGURE_ANDROID_VERSION] Version code: NN\`
4. Compares **NN ≤ device** — if true, kills the entire build tree (eas-cli, npm-exec, gradle daemon, kotlin compiler daemon) and exits non-zero
5. Otherwise lets the build complete, installs the APK with \`adb install -r\`, runs \`scripts/perf-suite.sh\`

Exits:

| code | meaning |
|---|---|
| 0   | install + perf-suite succeeded |
| 1   | build crashed before versionCode line / no device / build failed |
| 2   | versionCode would have caused VERSION_DOWNGRADE — aborted |
| 3   | install failed for some other reason (signature mismatch, etc.) |

## Confirmed working

Against the real Pixel (\`37111FDJH0067B\`) + \`eas-cli@18.11.0\` on 2026-05-05:

\`\`\`
device 37111FDJH0067B has com.lightningpiggy.app versionCode=34
starting eas build --local in background
build PID=962212 (process group 962212)
phase 1: waiting up to 5 min for versionCode determination
build will produce versionCode=31 (device has 34)
ABORT — 31 <= 34, install would fail with VERSION_DOWNGRADE
killing build to save ~19 min
\`\`\`

Total elapsed: **~75 seconds**, no orphan gradle / kotlin daemons left running, \`/tmp\` and \`~/eas-tmp\` returned to pre-test sizes.

## Test plan

- [ ] CI green (script is bash + executable bit; no other surface)
- [ ] Local sanity: \`bash scripts/eas-deploy-pixel.sh\` (with Pixel attached)
- [ ] (next time we want to deploy) confirm phase-2 still works when versionCode is high enough — that path didn't run today because we never got past phase 1