### PR TITLE
fix(nfc): use TAG not NDEF in iOS readersession.formats entitlement

### DIFF
--- a/plugins/withNfc.js
+++ b/plugins/withNfc.js
@@ -102,10 +102,11 @@ function withNfcIos(config) {
   // rejects 'NDEF' here as "disallowed" and requires 'TAG' instead.
   // 'TAG' covers reading raw tag UIDs and writing NDEF — the NFCNDEFReaderSession
   // at runtime works without 'NDEF' being in this entitlement.
+  // Always overwrite (no `if (!...)` guard) — a stale `['NDEF']` from a prior
+  // plugin run or upstream config would silently survive otherwise and the
+  // App Store validator would re-reject the IPA with the same error.
   config = withEntitlementsPlist(config, (config) => {
-    if (!config.modResults['com.apple.developer.nfc.readersession.formats']) {
-      config.modResults['com.apple.developer.nfc.readersession.formats'] = ['TAG'];
-    }
+    config.modResults['com.apple.developer.nfc.readersession.formats'] = ['TAG'];
     return config;
   });
 

--- a/plugins/withNfc.js
+++ b/plugins/withNfc.js
@@ -98,9 +98,13 @@ function withNfcIos(config) {
   });
 
   // Add NFC entitlement (correct location for readersession.formats).
+  // Apple's App Store Connect validator (Xcode 16+ / SDK 26.x with min iOS 15.1)
+  // rejects 'NDEF' here as "disallowed" and requires 'TAG' instead.
+  // 'TAG' covers reading raw tag UIDs and writing NDEF — the NFCNDEFReaderSession
+  // at runtime works without 'NDEF' being in this entitlement.
   config = withEntitlementsPlist(config, (config) => {
     if (!config.modResults['com.apple.developer.nfc.readersession.formats']) {
-      config.modResults['com.apple.developer.nfc.readersession.formats'] = ['NDEF'];
+      config.modResults['com.apple.developer.nfc.readersession.formats'] = ['TAG'];
     }
     return config;
   });


### PR DESCRIPTION
## Why

App Store Connect rejected today's TestFlight build (\`1.0.0 (15)\`) at the validation step:

\`\`\`
Validation failed (409) Invalid entitlement for core nfc framework. The sdk
version '26.2' and min OS version '15.1' are not compatible for the entitlement
'com.apple.developer.nfc.readersession.formats' because:
  - 'TAG is missing in the entitlement'  (ID: b7554b94-…)
  - 'NDEF is disallowed'                 (ID: 60ab1ab0-…)
\`\`\`

The plugin currently sets the entitlement to \`['NDEF']\`, which triggers both errors on Xcode 16+ / SDK 26.x toolchains.

## Fix

\`\`\`diff
- config.modResults['com.apple.developer.nfc.readersession.formats'] = ['NDEF'];
+ config.modResults['com.apple.developer.nfc.readersession.formats'] = ['TAG'];
\`\`\`

NDEF reads still work at runtime via \`NFCNDEFReaderSession\` — that session has its own entitlement check independent of this key. The \`TAG\` value covers reading raw tag UIDs and writing NDEF (the only NFC features Lightning Piggy uses, per #231 and #48).

## Validation

- IPA upload was rejected pre-merge by App Store Connect — fix re-tested by re-running \`eas build --platform ios --profile production --auto-submit\` after merge
- Android NFC stack untouched (this PR only touches \`withNfcIos\`)

## References

- [Apple forum: Testflight Validate ERROR ITMS-90778 NDEF is disallowed](https://developer.apple.com/forums/thread/123483)
- [Apple forum: 'NDEF is disallowed' Xcode 16.2](https://developer.apple.com/forums/thread/772845)
- [The Mobile Entity blog: How to fix NDEF is disallowed](https://www.themobileentity.com/home/how-to-fix-ndef-is-disallowed-error-when-uploading-nfc-enabled-app-to-app-store-connect)

## Test plan

- [ ] CI green
- [ ] After merge: \`eas build --platform ios --profile production --auto-submit\` succeeds end-to-end (build → submission → TestFlight)

Closes #399