### PR TITLE
fix(eas): set APP_VARIANT=production in eas.json production profile (#401)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -24,6 +24,9 @@
     },
     "production": {
       "autoIncrement": true,
+      "env": {
+        "APP_VARIANT": "production"
+      },
       "android": {
         "buildType": "apk"
       }


### PR DESCRIPTION
## Summary

Adds `env: { APP_VARIANT: "production" }` to the `production` build profile in `eas.json`, mirroring what `development` and `preview` already do.

Closes #401

See #401 for the full silent-wrong-bundle-id diagnosis.

## Test plan

- [ ] Re-run `eas build --platform ios --profile production --auto-submit` interactively
- [ ] Confirm `Bundle identifier registered com.lightningpiggy.app` (no `.dev` suffix)
- [ ] Confirm build appears in TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)