### PR TITLE
fix(nostr): remove "Enable NIP-17 on Amber" toggle, default ON (#404)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -2462,14 +2462,12 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               nip17CacheSize = Object.keys(cache).length;
             }
           } else if (refreshForSigner === 'amber' && kind1059.length > 0) {
-            const amberEnabled = (await AsyncStorage.getItem(AMBER_NIP17_ENABLED_KEY)) === 'true';
-            if (!amberEnabled) {
-              if (__DEV__) {
-                console.log(
-                  `[Nostr] Skipping ${kind1059.length} NIP-17 wrap(s) — Account toggle is off`,
-                );
-              }
-            } else {
+            // Always run the unwrap loop — Amber's silent content-resolver
+            // path returns PERMISSION_NOT_GRANTED on the first wrap if the
+            // user hasn't granted nip44_decrypt yet, which we surface via
+            // setAmberNip44Permission('denied') so NostrScreen can show
+            // the one-shot "Grant permission in Amber" button. Closes #404.
+            {
               // Persistent cache keyed by wrap id. Only ever contains rumors
               // from *followed* senders — see the filter gate below.
               const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -77,7 +77,8 @@ function clearMemoisedSecretKey(): void {
 const AMBER_NIP17_CACHE_KEY = 'amber_nip17_cache_v1';
 const NSEC_NIP17_CACHE_KEY = 'nsec_nip17_cache_v1';
 const NIP17_CACHE_CAP = 5000;
-const AMBER_NIP17_ENABLED_KEY = 'amber_nip17_enabled';
+// Legacy AsyncStorage key from the now-removed "Enable NIP-17 on Amber" toggle (#404). Cleared on logout so old installs don't leave dead bytes around.
+const AMBER_NIP17_ENABLED_KEY_LEGACY = 'amber_nip17_enabled';
 
 /** Persistent wrap-id → DmInboxEntry cache. Only ever contains rumors
  * from followed senders — see refreshDmInbox's filter gate. */
@@ -1191,7 +1192,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       // Amber NIP-17 permission intent belong to the logged-in user,
       // not globally.
       AMBER_NIP17_CACHE_KEY,
-      AMBER_NIP17_ENABLED_KEY,
+      AMBER_NIP17_ENABLED_KEY_LEGACY,
       NSEC_NIP17_CACHE_KEY,
     ];
     // PR B caches are per-user-keyed — only clear the ones for the
@@ -2075,59 +2076,49 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             }
           }
         } else if (signerType === 'amber') {
-          const amberEnabled = (await AsyncStorage.getItem(AMBER_NIP17_ENABLED_KEY)) === 'true';
-          if (amberEnabled) {
-            const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);
-            const cache = safeParseRecord<Nip17CacheEntry>(raw);
-            let threadTouched = 0;
-            for (const wrap of kind1059) {
-              const cached = cache[wrap.id];
-              if (cached) {
-                nip17CacheHits++;
-                if (cached.partnerPubkey !== normalized) continue;
-                // LRU touch (#193) — see fast-path above for rationale.
-                touchNip17CacheEntry(cache, wrap.id);
-                threadTouched++;
-                decrypted.push({
-                  id: wrap.id,
-                  fromMe: cached.fromMe,
-                  text: cached.text,
-                  createdAt: cached.createdAt,
-                });
-                continue;
-              }
-              nip17FreshDecrypts++;
-              // Not cached. For thread view we DO fall back to the Intent
-              // dialog if the silent path rejects — the user has actively
-              // opened this thread, one approval prompt per wrap is fine.
-              // The inbox refresh uses the silent-only path to avoid the
-              // flood, so cached entries cover the hot path.
-              try {
-                const rumor = await unwrapWrapViaNip44(
-                  wrap,
-                  (ct, cp) => amberService.requestNip44Decrypt(ct, cp, pubkey),
-                  onSkip,
-                );
-                if (!rumor) continue;
-                // Multi-recipient (group) rumors: route to group storage
-                // and skip the 1:1 thread.
-                const routeResult = await tryRouteGroupRumor(rumor, pubkey, wrap.id);
-                if (routeResult.kind !== 'not-group') continue;
-                const partnership = partnerFromRumor(rumor, pubkey);
-                if (!partnership || partnership.partnerPubkey !== normalized) continue;
-                decrypted.push({
-                  id: wrap.id,
-                  fromMe: partnership.fromMe,
-                  text: rumor.content,
-                  createdAt: rumor.created_at,
-                });
-              } catch (error) {
-                if (__DEV__) console.warn('[Nostr] Amber NIP-17 thread unwrap failed:', error);
-              }
+          const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);
+          const cache = safeParseRecord<Nip17CacheEntry>(raw);
+          let threadTouched = 0;
+          for (const wrap of kind1059) {
+            const cached = cache[wrap.id];
+            if (cached) {
+              nip17CacheHits++;
+              if (cached.partnerPubkey !== normalized) continue;
+              touchNip17CacheEntry(cache, wrap.id);
+              threadTouched++;
+              decrypted.push({
+                id: wrap.id,
+                fromMe: cached.fromMe,
+                text: cached.text,
+                createdAt: cached.createdAt,
+              });
+              continue;
             }
-            if (threadTouched > 0) {
-              await writeNip17Cache(AMBER_NIP17_CACHE_KEY, cache);
+            nip17FreshDecrypts++;
+            // Thread view falls back to the Intent dialog if the silent path rejects — the user has actively opened this thread, one approval prompt per wrap is fine. Inbox refresh uses the silent-only path to avoid the flood; cached entries cover the hot path.
+            try {
+              const rumor = await unwrapWrapViaNip44(
+                wrap,
+                (ct, cp) => amberService.requestNip44Decrypt(ct, cp, pubkey),
+                onSkip,
+              );
+              if (!rumor) continue;
+              const routeResult = await tryRouteGroupRumor(rumor, pubkey, wrap.id);
+              if (routeResult.kind !== 'not-group') continue;
+              const partnership = partnerFromRumor(rumor, pubkey);
+              if (!partnership || partnership.partnerPubkey !== normalized) continue;
+              decrypted.push({
+                id: wrap.id,
+                fromMe: partnership.fromMe,
+                text: rumor.content,
+                createdAt: rumor.created_at,
+              });
+            } catch (error) {
+              if (__DEV__) console.warn('[Nostr] Amber NIP-17 thread unwrap failed:', error);
             }
+          }
+          if (threadTouched > 0) {
+            await writeNip17Cache(AMBER_NIP17_CACHE_KEY, cache);
           }
         }
       }
@@ -2462,112 +2453,103 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               nip17CacheSize = Object.keys(cache).length;
             }
           } else if (refreshForSigner === 'amber' && kind1059.length > 0) {
-            // Always run the unwrap loop — Amber's silent content-resolver
-            // path returns PERMISSION_NOT_GRANTED on the first wrap if the
-            // user hasn't granted nip44_decrypt yet, which we surface via
-            // setAmberNip44Permission('denied') so NostrScreen can show
-            // the one-shot "Grant permission in Amber" button. Closes #404.
-            {
-              // Persistent cache keyed by wrap id. Only ever contains rumors
-              // from *followed* senders — see the filter gate below.
-              const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);
-              const cache = safeParseRecord<Nip17CacheEntry>(raw);
-              const newlyCached: Nip17CacheEntry[] = [];
-              let permissionDenied = false;
-              let nip17Iterated = 0;
-              let touched = 0;
-              let unfollowedPurged = 0;
+            // Always run the unwrap loop — Amber's silent content-resolver path returns PERMISSION_NOT_GRANTED on the first wrap if the user hasn't granted nip44_decrypt yet, which we surface via setAmberNip44Permission('denied') so NostrScreen can show the one-shot "Grant permission in Amber" button. Closes #404.
+            // Persistent cache keyed by wrap id. Only ever contains rumors from *followed* senders — see the filter gate below.
+            const raw = await AsyncStorage.getItem(AMBER_NIP17_CACHE_KEY);
+            const cache = safeParseRecord<Nip17CacheEntry>(raw);
+            const newlyCached: Nip17CacheEntry[] = [];
+            let permissionDenied = false;
+            let nip17Iterated = 0;
+            let touched = 0;
+            let unfollowedPurged = 0;
 
-              for (const wrap of kind1059) {
-                // Periodic yield + abort check (#286) — see the nsec
-                // branch above for rationale.
-                if (++nip17Iterated % NIP17_LOOP_YIELD_EVERY === 0) {
-                  if (signal?.aborted) return;
-                  await yieldToEventLoop();
-                }
-                const cached = cache[wrap.id];
-                if (cached) {
-                  nip17Hits++;
-                  // Cache entry exists → it was from a followed sender when first stored. Re-check against the *current* follow set; if the partner is no longer followed, purge the entry so we don't keep dragging it through every refresh until the 5000-cap LRU finally evicts it (mirrors the nsec branch).
-                  if (!passesFollowGate(cached.partnerPubkey)) {
-                    delete cache[wrap.id];
-                    unfollowedPurged++;
-                    continue;
-                  }
-                  // LRU touch (#193) — see nsec branch for rationale.
-                  touchNip17CacheEntry(cache, wrap.id);
-                  touched++;
-                  entries.push({
-                    id: cached.wrapId,
-                    partnerPubkey: cached.partnerPubkey,
-                    fromMe: cached.fromMe,
-                    createdAt: cached.createdAt,
-                    text: cached.text,
-                    wireKind: cached.wireKind,
-                  });
+            for (const wrap of kind1059) {
+              // Periodic yield + abort check (#286) — see the nsec branch above for rationale.
+              if (++nip17Iterated % NIP17_LOOP_YIELD_EVERY === 0) {
+                if (signal?.aborted) return;
+                await yieldToEventLoop();
+              }
+              const cached = cache[wrap.id];
+              if (cached) {
+                nip17Hits++;
+                // Re-check against current follow set; purge if no longer followed so we don't drag stale entries through every refresh.
+                if (!passesFollowGate(cached.partnerPubkey)) {
+                  delete cache[wrap.id];
+                  unfollowedPurged++;
                   continue;
                 }
-                nip17Misses++;
-                // Uncached — unwrap via Amber's silent content-resolver path.
-                // If Amber hasn't granted blanket nip44_decrypt permission,
-                // this throws PERMISSION_NOT_GRANTED and we stop iterating.
-                try {
-                  const rumor = await unwrapWrapViaNip44(wrap, amberNip44DecryptSilent, onSkip);
-                  if (!rumor) continue;
-                  // Multi-recipient (group) rumors: route to group storage
-                  // and short-circuit the DM-inbox path.
-                  const routeResult = await tryRouteGroupRumor(rumor, refreshForPubkey, wrap.id);
-                  if (routeResult.kind !== 'not-group') continue;
-                  const partnership = partnerFromRumor(rumor, refreshForPubkey);
-                  if (!partnership) continue;
-                  // B1 — never cache rumors from non-followed senders. The
-                  // cost is re-decrypting them on the next refresh, but the
-                  // silent path is ~1 ms per call and keeps plaintext off
-                  // AsyncStorage.
-                  if (!passesFollowGate(partnership.partnerPubkey)) continue;
-                  const entry: Nip17CacheEntry = {
-                    id: wrap.id,
-                    wrapId: wrap.id,
-                    partnerPubkey: partnership.partnerPubkey,
-                    fromMe: partnership.fromMe,
-                    createdAt: rumor.created_at,
-                    text: rumor.content,
-                    wireKind: rumor.kind,
-                  };
-                  cache[wrap.id] = entry;
-                  newlyCached.push(entry);
-                  entries.push({
-                    id: entry.id,
-                    partnerPubkey: entry.partnerPubkey,
-                    fromMe: entry.fromMe,
-                    createdAt: entry.createdAt,
-                    text: entry.text,
-                    wireKind: entry.wireKind,
-                  });
-                } catch (error) {
-                  const code = (error as { code?: string })?.code;
-                  const message = (error as Error)?.message ?? '';
-                  if (code === 'PERMISSION_NOT_GRANTED' || /PERMISSION_NOT_GRANTED/.test(message)) {
-                    permissionDenied = true;
-                    if (__DEV__) {
-                      console.log(
-                        `[Nostr] Amber NIP-44 permission not granted — stopping NIP-17 unwrap for this refresh`,
-                      );
-                    }
-                    break;
+                touchNip17CacheEntry(cache, wrap.id);
+                touched++;
+                entries.push({
+                  id: cached.wrapId,
+                  partnerPubkey: cached.partnerPubkey,
+                  fromMe: cached.fromMe,
+                  createdAt: cached.createdAt,
+                  text: cached.text,
+                  wireKind: cached.wireKind,
+                });
+                continue;
+              }
+              nip17Misses++;
+              // Uncached — unwrap via Amber's silent content-resolver path.
+              // If Amber hasn't granted blanket nip44_decrypt permission,
+              // this throws PERMISSION_NOT_GRANTED and we stop iterating.
+              try {
+                const rumor = await unwrapWrapViaNip44(wrap, amberNip44DecryptSilent, onSkip);
+                if (!rumor) continue;
+                // Multi-recipient (group) rumors: route to group storage
+                // and short-circuit the DM-inbox path.
+                const routeResult = await tryRouteGroupRumor(rumor, refreshForPubkey, wrap.id);
+                if (routeResult.kind !== 'not-group') continue;
+                const partnership = partnerFromRumor(rumor, refreshForPubkey);
+                if (!partnership) continue;
+                // B1 — never cache rumors from non-followed senders. The
+                // cost is re-decrypting them on the next refresh, but the
+                // silent path is ~1 ms per call and keeps plaintext off
+                // AsyncStorage.
+                if (!passesFollowGate(partnership.partnerPubkey)) continue;
+                const entry: Nip17CacheEntry = {
+                  id: wrap.id,
+                  wrapId: wrap.id,
+                  partnerPubkey: partnership.partnerPubkey,
+                  fromMe: partnership.fromMe,
+                  createdAt: rumor.created_at,
+                  text: rumor.content,
+                  wireKind: rumor.kind,
+                };
+                cache[wrap.id] = entry;
+                newlyCached.push(entry);
+                entries.push({
+                  id: entry.id,
+                  partnerPubkey: entry.partnerPubkey,
+                  fromMe: entry.fromMe,
+                  createdAt: entry.createdAt,
+                  text: entry.text,
+                  wireKind: entry.wireKind,
+                });
+              } catch (error) {
+                const code = (error as { code?: string })?.code;
+                const message = (error as Error)?.message ?? '';
+                if (code === 'PERMISSION_NOT_GRANTED' || /PERMISSION_NOT_GRANTED/.test(message)) {
+                  permissionDenied = true;
+                  if (__DEV__) {
+                    console.log(
+                      `[Nostr] Amber NIP-44 permission not granted — stopping NIP-17 unwrap for this refresh`,
+                    );
                   }
-                  if (__DEV__) console.warn('[Nostr] Amber NIP-17 unwrap failed:', error);
+                  break;
                 }
+                if (__DEV__) console.warn('[Nostr] Amber NIP-17 unwrap failed:', error);
               }
-
-              setAmberNip44Permission(permissionDenied ? 'denied' : 'granted');
-
-              // Persist on new entries, LRU touches (#193 — touches reorder insertion order which we need on disk), or unfollowed-partner purges (so the purge survives the next launch).
-              if (newlyCached.length > 0 || touched > 0 || unfollowedPurged > 0) {
-                nip17Evictions += await writeNip17Cache(AMBER_NIP17_CACHE_KEY, cache);
-              }
-              nip17CacheSize = Object.keys(cache).length;
             }
+
+            setAmberNip44Permission(permissionDenied ? 'denied' : 'granted');
+
+            // Persist on new entries, LRU touches (#193 — touches reorder insertion order which we need on disk), or unfollowed-partner purges (so the purge survives the next launch).
+            if (newlyCached.length > 0 || touched > 0 || unfollowedPurged > 0) {
+              nip17Evictions += await writeNip17Cache(AMBER_NIP17_CACHE_KEY, cache);
+            }
+            nip17CacheSize = Object.keys(cache).length;
           }
 
           // Identity-change guard: if the user logged out or switched signer
@@ -2719,8 +2701,6 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     // Lazy-populated in-memory mirror of the persisted NIP-17 wrap-id cache. Loaded
     // on first wrap so we don't JSON.parse the full cache (up to 5000 entries) on every event.
     let knownWrapIds: Set<string> | null = null;
-    // Lazy mirror of the AMBER_NIP17_ENABLED toggle. Loaded once on the first amber wrap so we don't AsyncStorage.getItem on every event. Tradeoff: if the user toggles the setting *after* the sub starts, the change takes effect on next sub re-establishment (logout/login or signer-type change). Acceptable since the toggle isn't expected to flip mid-session in normal use.
-    let amberNip17EnabledCached: boolean | null = null;
     let cancelled = false;
     let writeChain: Promise<void> = Promise.resolve();
 
@@ -2881,11 +2861,6 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         if (!secretKey) return;
         rumor = unwrapWrapNsec(wrap, secretKey, onSkip);
       } else if (activeSigner === 'amber') {
-        if (amberNip17EnabledCached === null) {
-          amberNip17EnabledCached =
-            (await AsyncStorage.getItem(AMBER_NIP17_ENABLED_KEY)) === 'true';
-        }
-        if (!amberNip17EnabledCached) return;
         try {
           rumor = await unwrapWrapViaNip44(
             wrap,

--- a/src/screens/account/NostrScreen.tsx
+++ b/src/screens/account/NostrScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import { Alert } from '../../components/BrandedAlert';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
 import AccountScreenLayout from './AccountScreenLayout';
 import { createSharedAccountStyles } from './sharedStyles';
@@ -58,11 +57,9 @@ const NostrScreen: React.FC = () => {
     });
   }, [relays, connStatus]);
   const [blossomServer, setBlossomServerInput] = useState(DEFAULT_BLOSSOM_SERVER);
-  const [amberNip17Enabled, setAmberNip17Enabled] = useState(false);
 
   useEffect(() => {
     getBlossomServer().then(setBlossomServerInput);
-    AsyncStorage.getItem('amber_nip17_enabled').then((v) => setAmberNip17Enabled(v === 'true'));
   }, []);
 
   const handleBlossomSave = async () => {
@@ -70,14 +67,6 @@ const NostrScreen: React.FC = () => {
     setBlossomServerInput(normalized);
     await setBlossomServer(normalized);
   };
-
-  const toggleAmberNip17 = useCallback(() => {
-    setAmberNip17Enabled((prev) => {
-      const next = !prev;
-      AsyncStorage.setItem('amber_nip17_enabled', next ? 'true' : 'false').catch(() => {});
-      return next;
-    });
-  }, []);
 
   const grantAmberNip44Permission = useCallback(async () => {
     if (!profile?.pubkey) throw new Error('No profile pubkey — log in first.');
@@ -152,65 +141,33 @@ const NostrScreen: React.FC = () => {
         server works — e.g. blossom.primal.net or nostr.build.
       </Text>
 
-      {signerType === 'amber' && (
+      {signerType === 'amber' && amberNip44Permission === 'denied' && (
         <>
           <Text style={[sharedAccountStyles.sectionLabel, { marginTop: 24 }]}>
             Encrypted Messages (NIP-17)
           </Text>
-          <View style={sharedAccountStyles.sslRow}>
-            <Text style={sharedAccountStyles.sslLabel}>Enable NIP-17 on Amber</Text>
-            <TouchableOpacity
-              style={[
-                sharedAccountStyles.sslToggle,
-                amberNip17Enabled && sharedAccountStyles.sslToggleActive,
-              ]}
-              onPress={toggleAmberNip17}
-              testID="amber-nip17-toggle"
-              accessibilityLabel="Enable NIP-17 messages on Amber"
-              accessibilityRole="switch"
-              accessibilityState={{ checked: amberNip17Enabled }}
-            >
-              <View
-                style={[
-                  sharedAccountStyles.sslToggleThumb,
-                  amberNip17Enabled && sharedAccountStyles.sslToggleThumbActive,
-                ]}
-              />
-            </TouchableOpacity>
-          </View>
-          <Text style={sharedAccountStyles.fieldHint}>
-            NIP-17 gift-wrapped messages hide sender metadata from relays, but each one requires a
-            NIP-44 decrypt via Amber. When you first enable this, Amber will ask to approve — tap
-            &quot;Remember my choice&quot; so subsequent messages load silently. Messages from
-            people you don&apos;t follow stay hidden.
+          <Text style={[sharedAccountStyles.fieldHint, { color: colors.brandPink }]}>
+            Amber hasn&apos;t granted NIP-44 decrypt permission to this app yet — tap below to grant
+            it. One dialog, then subsequent encrypted messages decrypt silently. Messages from
+            people you don&apos;t follow stay hidden either way.
           </Text>
-          {amberNip17Enabled && amberNip44Permission === 'denied' && (
-            <>
-              <Text
-                style={[sharedAccountStyles.fieldHint, { color: colors.brandPink, marginTop: 8 }]}
-              >
-                Amber hasn&apos;t granted NIP-44 decrypt permission to this app yet — tap the button
-                below to grant it. One dialog, then subsequent messages decrypt silently.
-              </Text>
-              <TouchableOpacity
-                style={[sharedAccountStyles.saveButton, { marginTop: 8 }]}
-                onPress={async () => {
-                  try {
-                    await grantAmberNip44Permission();
-                  } catch (e) {
-                    Alert.alert(
-                      'Amber permission',
-                      e instanceof Error ? e.message : 'Could not grant NIP-44 permission.',
-                    );
-                  }
-                }}
-                accessibilityLabel="Grant Amber NIP-44 permission"
-                testID="amber-nip17-grant"
-              >
-                <Text style={sharedAccountStyles.saveButtonText}>Grant permission in Amber</Text>
-              </TouchableOpacity>
-            </>
-          )}
+          <TouchableOpacity
+            style={[sharedAccountStyles.saveButton, { marginTop: 8 }]}
+            onPress={async () => {
+              try {
+                await grantAmberNip44Permission();
+              } catch (e) {
+                Alert.alert(
+                  'Amber permission',
+                  e instanceof Error ? e.message : 'Could not grant NIP-44 permission.',
+                );
+              }
+            }}
+            accessibilityLabel="Grant Amber NIP-44 permission"
+            testID="amber-nip17-grant"
+          >
+            <Text style={sharedAccountStyles.saveButtonText}>Grant permission in Amber</Text>
+          </TouchableOpacity>
         </>
       )}
     </AccountScreenLayout>


### PR DESCRIPTION
Closes #404

## Summary

The "Enable NIP-17 on Amber" toggle in Account → Nostr defaulted OFF on every fresh install, silently dropping all incoming kind-1059 wraps. Net effect: Amber users with active NIP-17 conversations opened the app, saw empty group threads, and had no idea why. Buried-three-taps-deep settings aren't a place to hide load-bearing functionality.

## What changed

- **`NostrContext.tsx`** — drop the \`amber_nip17_enabled === 'true'\` gate around the unwrap loop. NIP-17 unwrap now runs whenever \`refreshForSigner === 'amber' && kind1059.length > 0\`.
- **`NostrScreen.tsx`** — remove the toggle UI + its surrounding state/handlers. Keep the existing "Grant permission in Amber" button, but show it whenever \`amberNip44Permission === 'denied'\` (independent of any toggle state).

## Why this is safe

The "approval avalanche" the toggle was protecting against is already handled by the unwrap loop's existing error path:

\`\`\`ts
catch (error) {
  if (code === 'PERMISSION_NOT_GRANTED' || /PERMISSION_NOT_GRANTED/.test(message)) {
    permissionDenied = true;
    break;  // ← stops on the FIRST permission failure
  }
}
\`\`\`

The first wrap that hits \`PERMISSION_NOT_GRANTED\` from Amber:
1. Stops the loop immediately (no avalanche)
2. Sets \`amberNip44Permission = 'denied'\` on the context
3. Surfaces the existing "Grant permission in Amber" affordance on the Nostr screen

Once the user grants the one-shot \`nip44_decrypt: Always\` permission, the next refresh runs through cleanly and silently.

## Test plan

- [ ] **Fresh install on Amber, permission already granted (e.g. user has used another LP install with the same Amber identity):** unwrap proceeds silently, group threads populate
- [ ] **Fresh install on Amber, permission NOT yet granted:** Account → Nostr shows "Grant permission in Amber" with the warning copy → tap → Amber prompt → grant → next refresh unwraps wraps
- [ ] **Existing user who had toggle ON:** continues to work unchanged
- [ ] **Existing user who had toggle OFF and prior permission denied:** sees the new always-visible "Grant permission in Amber" button (no longer requires flipping a hidden toggle first)
- [ ] **nsec users:** unaffected — different code path, no Amber round-trip

## Out of scope

- Removing the leftover \`AMBER_NIP17_ENABLED_KEY\` AsyncStorage key + its logout-cleanup reference. Leaving for a follow-up since dropping the constant is mechanical and the cleanup remains valid (it idempotently clears any stale 'true'/'false' values from upgrades).

🤖 Generated with [Claude Code](https://claude.com/claude-code)