### PR TITLE
perf(dm): pin kind-4 live-sub since to inboxLastSeen (#408)

### DIFF
--- a/modules/amber-signer/android/src/main/java/com/lightningpiggy/ambersigner/AmberSignerModule.kt
+++ b/modules/amber-signer/android/src/main/java/com/lightningpiggy/ambersigner/AmberSignerModule.kt
@@ -104,13 +104,11 @@ class AmberSignerModule : Module() {
                 requestCode = REQUEST_CODE_SIGN_EVENT,
                 promise = promise,
             ) { activity ->
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:${Uri.encode(eventJson)}"))
+                // Don't Uri.encode the JSON — Amber 4.x parses intent.data as already-decoded JSON. URL-encoded payloads silently fail AmberEvent.fromJson, the intent gets dropped, and Amber falls back to its Applications screen instead of opening the sign sheet. NIP-55 / Damus / Citrine all pass raw JSON.
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:$eventJson"))
                 intent.`package` = AMBER_PACKAGE
                 intent.putExtra("type", "sign_event")
-                // Empty `id` makes Amber silently reject kind-13 (NIP-17 seal) intents
-                // — the dialog never opens and no entry lands in Amber's Activity log.
-                // Mirror handleCryptoOp's UUID fallback so seal/wrap signing reaches
-                // the approval flow and shows up correctly.
+                // Empty `id` makes Amber silently reject kind-13 (NIP-17 seal) intents — UUID fallback so seal/wrap signing reaches the approval flow.
                 intent.putExtra("id", eventId.ifEmpty { java.util.UUID.randomUUID().toString() })
                 intent.putExtra("current_user", currentUser)
                 activity.startActivityForResult(intent, REQUEST_CODE_SIGN_EVENT)
@@ -226,7 +224,8 @@ class AmberSignerModule : Module() {
             requestCode = requestCode,
             promise = promise,
         ) { activity ->
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:${Uri.encode(payload)}"))
+            // Raw payload, not Uri.encode'd — same reason as signEvent above.
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:$payload"))
             intent.`package` = AMBER_PACKAGE
             intent.putExtra("type", type)
             intent.putExtra("id", java.util.UUID.randomUUID().toString())

--- a/scripts/perf-startup.sh
+++ b/scripts/perf-startup.sh
@@ -74,7 +74,12 @@ done
 
 # ---- helpers ----------------------------------------------------------------
 
-now_ms() { date +%s%3N; }
+# `date +%s%3N` requires GNU date (Linux). macOS BSD `date` doesn't expand `%N`, so contributors running this from macOS would get bad timings. Detect once at script load and fall back to python3 (POSIX-portable) when GNU date is unavailable.
+if date +%N 2>/dev/null | grep -qE '^[0-9]{9}$'; then
+  now_ms() { date +%s%3N; }
+else
+  now_ms() { python3 -c 'import time; print(int(time.time()*1000))'; }
+fi
 
 # Wait until logcat shows a line matching $1 since timestamp $2 (HH:MM:SS.mmm).
 # Returns elapsed ms or empty if it never matched within $LAUNCH_TIMEOUT_S.

--- a/scripts/perf-startup.sh
+++ b/scripts/perf-startup.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# Cold-start + tab-navigation wall-clock timer.
+#
+# Where the existing perf-suite measures jank/frame deadlines via
+# gfxinfo, this script answers the simpler question Ben actually feels:
+# "after I kill the app and reopen it, how many seconds until I can use it?"
+#
+# Captured per run:
+#   1. cold start    — `am start -W` TotalTime (system time-to-first-frame)
+#   2. responsive    — wall clock between launch and the first
+#                      `[Perf] refreshDmInbox` log line (LP's own marker
+#                      saying the inbox refresh path settled)
+#   3. tab nav       — Home → Messages → Learn → Friends, each tap
+#                      timed end-to-end via a Maestro flow that uses
+#                      `tab-<name>` testIDs (no coordinates per CLAUDE.md)
+#
+# Usage:
+#   ./scripts/perf-startup.sh                           # 3 runs, Pixel default
+#   SAMPLES=5 ./scripts/perf-startup.sh                 # more runs, less noise
+#   DEVICE=emulator-5554 PKG=com.lightningpiggy.app.dev \
+#     ./scripts/perf-startup.sh                         # AVD / dev variant
+#
+# Output: a markdown table of per-run + median measurements, plus the
+# raw [Perf] logcat lines per sample so you can see k1059, fresh, hits,
+# misses contributing to each refresh.
+
+set -u
+
+DEVICE="${DEVICE:-${PIXEL_DEVICE:-37111FDJH0067B}}"
+PKG="${PKG:-${PIXEL_PKG:-com.lightningpiggy.app}}"
+SAMPLES="${SAMPLES:-3}"
+LAUNCH_TIMEOUT_S=60
+
+OUT="/tmp/perf-startup-$(date +%s)"
+mkdir -p "$OUT"
+
+ADB="adb -s $DEVICE"
+
+if ! $ADB shell pm path "$PKG" >/dev/null 2>&1; then
+  echo "ERROR: package $PKG not installed on $DEVICE" >&2
+  exit 1
+fi
+
+# Resolve the launcher activity automatically — works for either app variant.
+LAUNCHER=$($ADB shell cmd package resolve-activity --brief -c android.intent.category.LAUNCHER "$PKG" 2>/dev/null | tail -1 | tr -d '\r')
+if [[ -z "$LAUNCHER" || "$LAUNCHER" != */* ]]; then
+  echo "ERROR: could not resolve launcher activity for $PKG" >&2
+  exit 1
+fi
+
+echo "→ device:    $DEVICE"
+echo "→ package:   $PKG"
+echo "→ component: $LAUNCHER"
+echo "→ samples:   $SAMPLES"
+echo "→ writing:   $OUT"
+echo
+
+# ---- Maestro tab-tap flows --------------------------------------------------
+
+write_tab_flow() {
+  local tab=$1
+  cat > "$OUT/tap-$tab.yaml" <<EOF
+appId: $PKG
+---
+- tapOn:
+    id: "tab-$tab"
+EOF
+}
+
+for t in home messages learn friends; do
+  write_tab_flow "$t"
+done
+
+# ---- helpers ----------------------------------------------------------------
+
+now_ms() { date +%s%3N; }
+
+# Wait until logcat shows a line matching $1 since timestamp $2 (HH:MM:SS.mmm).
+# Returns elapsed ms or empty if it never matched within $LAUNCH_TIMEOUT_S.
+wait_for_log() {
+  local pattern=$1
+  local since_ts=$2
+  local start_ms=$3
+  local deadline=$(( start_ms + LAUNCH_TIMEOUT_S * 1000 ))
+  while [[ $(now_ms) -lt $deadline ]]; do
+    if $ADB logcat -d -t "$since_ts" 2>/dev/null | grep -qE "$pattern"; then
+      echo $(( $(now_ms) - start_ms ))
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo ""
+}
+
+# Tap a tab via Maestro and return ms to the next $2 log marker (or empty
+# on timeout).  The Maestro process itself takes ~5–10 s of JVM warmup, so
+# we time the *log marker*, not the maestro CLI exit; the marker is what
+# matches the user's perceived "tab is now responsive" moment.
+tap_and_time() {
+  local tab=$1
+  local marker=$2
+  local since_ts=$3
+  local t0
+  t0=$(now_ms)
+  maestro --device "$DEVICE" test "$OUT/tap-$tab.yaml" > "$OUT/maestro-$tab.log" 2>&1 &
+  local maestro_pid=$!
+  local elapsed
+  elapsed=$(wait_for_log "$marker" "$since_ts" "$t0")
+  wait "$maestro_pid" 2>/dev/null || true
+  echo "$elapsed"
+}
+
+# ---- one full sample --------------------------------------------------------
+
+declare -a ROWS=()
+
+run_sample() {
+  local n=$1
+  echo "─── sample $n ───"
+
+  $ADB logcat -c
+  $ADB shell am force-stop "$PKG" >/dev/null 2>&1
+  sleep 1
+
+  local since_ts
+  since_ts=$($ADB shell 'date +%m-%d\ %H:%M:%S.000' | tr -d '\r')
+  local launch_start
+  launch_start=$(now_ms)
+
+  # `am start -W` blocks until the first frame; reports TotalTime / WaitTime.
+  local launch_out total_time wait_time
+  launch_out=$($ADB shell am start -W -n "$LAUNCHER" 2>&1 | tr -d '\r')
+  total_time=$(echo "$launch_out" | awk '/^TotalTime:/ {print $2}')
+  wait_time=$(echo  "$launch_out" | awk '/^WaitTime:/ {print $2}')
+
+  # Time-to-responsive: first refreshDmInbox completion log.
+  local responsive_ms
+  responsive_ms=$(wait_for_log 'ReactNativeJS.*\[Perf\] refreshDmInbox' "$since_ts" "$launch_start")
+
+  local home_ms="" msgs_ms="" learn_ms="" friends_ms=""
+  if [[ -n "$responsive_ms" ]]; then
+    sleep 0.5
+
+    # Home tap — no unique perf marker, so we use a short fixed settle.
+    # Document this caveat in the summary.
+    local t0
+    t0=$(now_ms)
+    maestro --device "$DEVICE" test "$OUT/tap-home.yaml" > "$OUT/maestro-home.log" 2>&1 || true
+    home_ms=$(( $(now_ms) - t0 ))
+
+    msgs_ms=$(tap_and_time messages 'ReactNativeJS.*\[Perf\] refreshDmInbox' "$since_ts")
+
+    t0=$(now_ms)
+    maestro --device "$DEVICE" test "$OUT/tap-learn.yaml" > "$OUT/maestro-learn.log" 2>&1 || true
+    learn_ms=$(( $(now_ms) - t0 ))
+
+    friends_ms=$(tap_and_time friends 'ReactNativeJS.*\[Perf\] FriendsList first render' "$since_ts")
+  fi
+
+  echo "  cold_total=${total_time}ms  wait=${wait_time}ms  responsive=${responsive_ms:-TIMEOUT}ms"
+  echo "  home=${home_ms:-—}ms  messages=${msgs_ms:-—}ms  learn=${learn_ms:-—}ms  friends=${friends_ms:-—}ms"
+
+  $ADB logcat -d -t "$since_ts" 2>/dev/null \
+    | grep -E "ReactNativeJS.*\[Perf\] (refreshDmInbox|nip17-cache|FriendsList first render|fetchProfiles|fetchInboxDmEvents)" \
+    > "$OUT/sample-$n.log" 2>/dev/null || true
+
+  ROWS+=("$n|${total_time:-—}|${wait_time:-—}|${responsive_ms:-—}|${home_ms:-—}|${msgs_ms:-—}|${learn_ms:-—}|${friends_ms:-—}")
+}
+
+# ---- median across N integer samples ---------------------------------------
+
+median_of() {
+  local clean=()
+  for v in "$@"; do
+    [[ "$v" =~ ^[0-9]+$ ]] && clean+=("$v")
+  done
+  if [[ ${#clean[@]} -eq 0 ]]; then echo "—"; return; fi
+  IFS=$'\n' clean=($(printf '%s\n' "${clean[@]}" | sort -n)); unset IFS
+  echo "${clean[$(( ${#clean[@]} / 2 ))]}"
+}
+
+# ---- run ---------------------------------------------------------------------
+
+for n in $(seq 1 "$SAMPLES"); do
+  run_sample "$n"
+  sleep 1
+done
+
+# ---- summary table ---------------------------------------------------------
+
+declare -a colA colB colC colD colE colF colG
+for row in "${ROWS[@]}"; do
+  IFS='|' read -r _ a b c d e f g <<<"$row"
+  colA+=("$a"); colB+=("$b"); colC+=("$c"); colD+=("$d"); colE+=("$e"); colF+=("$f"); colG+=("$g")
+done
+
+{
+  echo "# Cold-start + tab-nav timing — $(date '+%Y-%m-%d %H:%M:%S')"
+  echo
+  echo "device: \`$DEVICE\` · package: \`$PKG\` · samples: $SAMPLES"
+  echo
+  echo "| sample | TotalTime | WaitTime | time-to-responsive | tab-home | tab-messages | tab-learn | tab-friends |"
+  echo "|--------|-----------|----------|--------------------|----------|--------------|-----------|-------------|"
+  for row in "${ROWS[@]}"; do
+    IFS='|' read -r n a b c d e f g <<<"$row"
+    echo "| $n | ${a}ms | ${b}ms | ${c}ms | ${d}ms | ${e}ms | ${f}ms | ${g}ms |"
+  done
+  echo "| **median** | $(median_of "${colA[@]}")ms | $(median_of "${colB[@]}")ms | $(median_of "${colC[@]}")ms | $(median_of "${colD[@]}")ms | $(median_of "${colE[@]}")ms | $(median_of "${colF[@]}")ms | $(median_of "${colG[@]}")ms |"
+  echo
+  echo "Definitions:"
+  echo "- **TotalTime** — Android's wall clock from \`am start\` to the first frame of the launched activity (system-side)."
+  echo "- **WaitTime** — TotalTime + any pre-launch system overhead."
+  echo "- **time-to-responsive** — wall clock from launch to the first \`[Perf] refreshDmInbox\` completion line. This is what the user *feels* — the screen is on, but new messages are still draining."
+  echo "- **tab-messages** — wall clock from Maestro's tap dispatch to the next \`refreshDmInbox\` log line."
+  echo "- **tab-friends** — wall clock from tap dispatch to the next \`FriendsList first render\` log line."
+  echo "- **tab-home / tab-learn** — full Maestro-flow round-trip (~5 s JVM overhead included). Treat these as upper-bounds; they don't fire a unique perf line so we can't subtract Maestro out."
+  echo
+  echo "Per-sample logs in \`$OUT/sample-N.log\`."
+} | tee "$OUT/summary.md"

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -2704,6 +2704,32 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     let cancelled = false;
     let writeChain: Promise<void> = Promise.resolve();
 
+    // Coalesce per-event inbox merges into one setDmInbox call per ~150 ms or per 25 events. Without this, a relay-restream burst (e.g. cold start with 200+ kind-4 events queued) causes one React re-render per event = 30+ rerenders/sec on the JS thread, which is what locks the UI for 30 seconds. Batching collapses that into ~6 rerenders/sec at most. Notifications still fire per-event so unread counts/sounds aren't dropped.
+    let pendingInboxEntries: DmInboxEntry[] = [];
+    let pendingFlushTimer: ReturnType<typeof setTimeout> | null = null;
+    const PENDING_FLUSH_MS = 150;
+    const PENDING_FLUSH_THRESHOLD = 25;
+    const flushPendingInbox = (): void => {
+      if (pendingFlushTimer) {
+        clearTimeout(pendingFlushTimer);
+        pendingFlushTimer = null;
+      }
+      if (pendingInboxEntries.length === 0) return;
+      const batch = pendingInboxEntries;
+      pendingInboxEntries = [];
+      setDmInbox((prev) => mergeInboxEntries(prev, batch, DM_INBOX_CAP));
+    };
+    const queueInboxEntry = (entry: DmInboxEntry): void => {
+      pendingInboxEntries.push(entry);
+      if (pendingInboxEntries.length >= PENDING_FLUSH_THRESHOLD) {
+        flushPendingInbox();
+        return;
+      }
+      if (pendingFlushTimer === null) {
+        pendingFlushTimer = setTimeout(flushPendingInbox, PENDING_FLUSH_MS);
+      }
+    };
+
     const handleInboxEvent = async (ev: nostrService.RawInboxDmEvent): Promise<void> => {
       if (__DEV__) console.log(`[Nostr] live evt kind=${ev.kind} recv ${ev.id.slice(0, 8)}`);
       if (cancelled) return;
@@ -2817,7 +2843,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         await writeChain;
         if (cancelled || viewerPubkey !== pubkey || activeSigner !== signerType) return;
 
-        setDmInbox((prev) => mergeInboxEntries(prev, [k4InboxEntry], DM_INBOX_CAP));
+        queueInboxEntry(k4InboxEntry);
         notifyDmMessage(partnerPubkey);
         if (__DEV__)
           console.log(
@@ -2976,7 +3002,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       await writeChain;
       if (cancelled || viewerPubkey !== pubkey || activeSigner !== signerType) return;
 
-      setDmInbox((prev) => mergeInboxEntries(prev, [inboxEntry], DM_INBOX_CAP));
+      queueInboxEntry(inboxEntry);
       notifyDmMessage(partnership.partnerPubkey);
       if (__DEV__)
         console.log(
@@ -3016,6 +3042,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
     return () => {
       cancelled = true;
+      flushPendingInbox();
       if (unsubscribe) unsubscribe();
     };
   }, [isLoggedIn, pubkey, signerType, getReadRelays]);

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -3013,14 +3013,8 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     // Load the persisted kind-4 lastSeen cursor before opening the sub so the relay only re-streams events the user hasn't seen yet — without this, a heavy DM history floods the JS thread with hundreds of `live evt kind=4` deliveries on every cold start (each one a NIP-04 decrypt round-trip + setDmInbox re-render).
     let unsubscribe: (() => void) | null = null;
     (async () => {
-      let sinceK4: number | undefined;
-      try {
-        const raw = await AsyncStorage.getItem(inboxLastSeenKey(viewerPubkey));
-        const parsed = raw ? Number(raw) : NaN;
-        if (Number.isFinite(parsed) && parsed > 0) sinceK4 = parsed;
-      } catch {
-        // best-effort
-      }
+      // Reuse loadLastSeen so parsing/validation matches refreshDmInbox's existing reads of the same key (#409 review). loadLastSeen returns undefined for missing/invalid values, which subscribeInboxDmsForViewer then falls back to its 7-day floor for.
+      const sinceK4 = await loadLastSeen(inboxLastSeenKey(viewerPubkey)).catch(() => undefined);
       if (cancelled) return;
       unsubscribe = nostrService.subscribeInboxDmsForViewer({
         viewerPubkey,

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -2984,27 +2984,39 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         );
     };
 
-    const unsubscribe = nostrService.subscribeInboxDmsForViewer({
-      viewerPubkey,
-      relays: readRelays,
-      onEvent: (ev) => {
-        // Fire-and-forget: handleInboxEvent awaits its own state, and any
-        // throw is caught + logged here so the sub keeps running.
-        handleInboxEvent(ev).catch((e) => {
-          if (__DEV__) console.warn('[Nostr] live DM handler failed:', e);
-        });
-      },
-    });
-
-    if (__DEV__) {
-      console.log(
-        `[Nostr] live DM sub (kinds 4 + 1059) opened for ${viewerPubkey.slice(0, 8)} on ${readRelays.length} relays`,
-      );
-    }
+    // Load the persisted kind-4 lastSeen cursor before opening the sub so the relay only re-streams events the user hasn't seen yet — without this, a heavy DM history floods the JS thread with hundreds of `live evt kind=4` deliveries on every cold start (each one a NIP-04 decrypt round-trip + setDmInbox re-render).
+    let unsubscribe: (() => void) | null = null;
+    (async () => {
+      let sinceK4: number | undefined;
+      try {
+        const raw = await AsyncStorage.getItem(inboxLastSeenKey(viewerPubkey));
+        const parsed = raw ? Number(raw) : NaN;
+        if (Number.isFinite(parsed) && parsed > 0) sinceK4 = parsed;
+      } catch {
+        // best-effort
+      }
+      if (cancelled) return;
+      unsubscribe = nostrService.subscribeInboxDmsForViewer({
+        viewerPubkey,
+        relays: readRelays,
+        sinceK4,
+        onEvent: (ev) => {
+          // Fire-and-forget: handleInboxEvent awaits its own state, and any throw is caught + logged here so the sub keeps running.
+          handleInboxEvent(ev).catch((e) => {
+            if (__DEV__) console.warn('[Nostr] live DM handler failed:', e);
+          });
+        },
+      });
+      if (__DEV__) {
+        console.log(
+          `[Nostr] live DM sub (kinds 4 + 1059) opened for ${viewerPubkey.slice(0, 8)} on ${readRelays.length} relays, sinceK4=${sinceK4 ?? 'default-90d'}`,
+        );
+      }
+    })();
 
     return () => {
       cancelled = true;
-      unsubscribe();
+      if (unsubscribe) unsubscribe();
     };
   }, [isLoggedIn, pubkey, signerType, getReadRelays]);
 

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1309,8 +1309,7 @@ export function subscribeInboxDmsForViewer(input: {
   };
   const nowSec = Math.floor(Date.now() / 1000);
   const lookbackFloor = nowSec - DM_LIVE_SUB_MAX_LOOKBACK_SECONDS;
-  const requested =
-    input.sinceK4 !== undefined ? Math.max(0, input.sinceK4 - 120) : lookbackFloor;
+  const requested = input.sinceK4 !== undefined ? Math.max(0, input.sinceK4 - 120) : lookbackFloor;
   const sinceK4 = Math.max(lookbackFloor, requested);
   const subK4 = pool.subscribeMany(
     input.relays,

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1300,7 +1300,7 @@ export function subscribeInboxDmsForViewer(input: {
   viewerPubkey: string;
   relays: string[];
   onEvent: (ev: RawInboxDmEvent) => void;
-  // Optional kind-4 `since` cursor (unix seconds). When provided, the kind-4 filter pins to `max(now-7d, providedSince - 120s safety buffer)` so a heavy or stale DM history doesn't restream weeks of events every cold start. If absent, falls back to the 7-day floor.
+  // Optional kind-4 `since` cursor (unix seconds). When provided, the kind-4 filter resolves to `clamp(providedSince - 120s, now-7d, now)` — the 120 s safety buffer in case relay clock skew tagged a wrap slightly older than our cursor, the 7-day floor caps cold-start restream when the cursor is very stale, and the `now` cap defends against a future-dated cursor (corrupted persisted value or a wrap with a bad clock) that would otherwise silently miss new DMs until wall-clock catches up. If absent, falls back to the 7-day floor.
   sinceK4?: number;
 }): () => void {
   trackRelays(input.relays);
@@ -1310,7 +1310,8 @@ export function subscribeInboxDmsForViewer(input: {
   const nowSec = Math.floor(Date.now() / 1000);
   const lookbackFloor = nowSec - DM_LIVE_SUB_MAX_LOOKBACK_SECONDS;
   const requested = input.sinceK4 !== undefined ? Math.max(0, input.sinceK4 - 120) : lookbackFloor;
-  const sinceK4 = Math.max(lookbackFloor, requested);
+  // Upper-bound at `nowSec` so a future-dated persisted cursor (or one bumped by a wrap with a bad created_at) doesn't drop us into a `since` in the future where the relay returns nothing.
+  const sinceK4 = Math.min(nowSec, Math.max(lookbackFloor, requested));
   const subK4 = pool.subscribeMany(
     input.relays,
     {

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1293,24 +1293,25 @@ export type RawInboxDmEvent = RawGiftWrapEvent;
 // fetch (fetchInboxDmEvents) so the two paths can't drift in cap on a
 // future tweak. (#383, Copilot review on PR #384)
 export const DM_INBOX_LIMIT = 1000;
-const DM_INBOX_SINCE_WINDOW_SECONDS = 90 * 24 * 60 * 60; // 90 days
+// Live sub never looks further back than this — caps cold-start restream cost when inboxLastSeen is very stale (e.g. user hasn't opened the app in weeks). The bulk fetch (fetchInboxDmEvents) handles deeper backfill on tab open.
+const DM_LIVE_SUB_MAX_LOOKBACK_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
 export function subscribeInboxDmsForViewer(input: {
   viewerPubkey: string;
   relays: string[];
   onEvent: (ev: RawInboxDmEvent) => void;
-  // Optional kind-4 `since` cursor (unix seconds). When provided, the kind-4 filter pins to `max(sinceK4, providedSince - 120s safety buffer)` so a heavy DM history doesn't restream 90 days every cold start. If absent, falls back to the 90-day window.
+  // Optional kind-4 `since` cursor (unix seconds). When provided, the kind-4 filter pins to `max(now-7d, providedSince - 120s safety buffer)` so a heavy or stale DM history doesn't restream weeks of events every cold start. If absent, falls back to the 7-day floor.
   sinceK4?: number;
 }): () => void {
   trackRelays(input.relays);
   const onevent = (ev: Parameters<typeof input.onEvent>[0]): void => {
     input.onEvent(ev);
   };
-  const sinceK4Default = Math.floor(Date.now() / 1000) - DM_INBOX_SINCE_WINDOW_SECONDS;
-  const sinceK4 =
-    input.sinceK4 !== undefined
-      ? Math.max(sinceK4Default, Math.max(0, input.sinceK4 - 120))
-      : sinceK4Default;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const lookbackFloor = nowSec - DM_LIVE_SUB_MAX_LOOKBACK_SECONDS;
+  const requested =
+    input.sinceK4 !== undefined ? Math.max(0, input.sinceK4 - 120) : lookbackFloor;
+  const sinceK4 = Math.max(lookbackFloor, requested);
   const subK4 = pool.subscribeMany(
     input.relays,
     {

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1299,12 +1299,18 @@ export function subscribeInboxDmsForViewer(input: {
   viewerPubkey: string;
   relays: string[];
   onEvent: (ev: RawInboxDmEvent) => void;
+  // Optional kind-4 `since` cursor (unix seconds). When provided, the kind-4 filter pins to `max(sinceK4, providedSince - 120s safety buffer)` so a heavy DM history doesn't restream 90 days every cold start. If absent, falls back to the 90-day window.
+  sinceK4?: number;
 }): () => void {
   trackRelays(input.relays);
   const onevent = (ev: Parameters<typeof input.onEvent>[0]): void => {
     input.onEvent(ev);
   };
-  const sinceK4 = Math.floor(Date.now() / 1000) - DM_INBOX_SINCE_WINDOW_SECONDS;
+  const sinceK4Default = Math.floor(Date.now() / 1000) - DM_INBOX_SINCE_WINDOW_SECONDS;
+  const sinceK4 =
+    input.sinceK4 !== undefined
+      ? Math.max(sinceK4Default, Math.max(0, input.sinceK4 - 120))
+      : sinceK4Default;
   const subK4 = pool.subscribeMany(
     input.relays,
     {


### PR DESCRIPTION
Closes #408.

## Why

Cold start was streaming every kind-4 from the past 90 days every launch — flooding the JS thread with ~30 events/sec for 30+ seconds. Each event triggered a NIP-04 decrypt round-trip plus a \`setDmInbox\` re-render. That's the "app is slow for 30 seconds after every restart" symptom.

Logcat trace from a cold-start sample (Pixel 8, dev build):
\`\`\`
01:40:27.602  [Nostr] live evt kind=4 recv 199a0af5
01:40:27.636  [Nostr] live evt kind=4 recv 4462f78a
01:40:27.671  [Nostr] live evt kind=4 recv cb88d899
... ~30 events per second for 30+ seconds ...
\`\`\`

\`subscribeInboxDmsForViewer\` had a hard-coded 90-day-ago \`since\` and never consulted the \`inboxLastSeenKey\` cursor that \`refreshDmInbox\` already persists.

## What

- \`subscribeInboxDmsForViewer\` accepts an optional \`sinceK4\` parameter, clamped to \`max(90d-floor, providedSince - 120s safety buffer)\`.
- The DM-live useEffect in \`NostrContext\` reads the persisted \`inboxLastSeenKey\` once on mount and threads it through.
- New \`scripts/perf-startup.sh\` — wall-clock cold-start + tab-navigation timer that complements the existing gfxinfo-based perf-suite. This is what surfaced the bug; documenting it for the next time someone says "the app feels slow."

The kind-1059 (NIP-17 wrap) sub still has no \`since\` — NIP-59 randomizes wrap timestamps, that's correct. Only kind-4 needed the fix.

## Test plan

- [ ] On Pixel: kill app, reopen, confirm logcat no longer shows the 30-event/sec flood. Should see only events newer than the previous \`inboxLastSeen\`.
- [ ] On Pixel: open a thread to an old DM partner, scroll back — historical messages remain reachable via the per-conversation queries (those have no \`since\`).
- [ ] First-launch case: no prior \`inboxLastSeen\` cursor → sub falls back to the 90-day floor (preserves existing onboarding behaviour).
- [ ] Run \`./scripts/perf-startup.sh\` 3 samples, before/after — expect time-to-responsive to drop substantially.