### PR TITLE
chore(nwc): flip isConnected: true after provider.enable() resolves (refs #410)

### DIFF
--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -355,9 +355,18 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
               const nwcUrl = await walletStorage.getNwcUrl(wallet.id);
               if (!nwcUrl) return;
 
-              const result = await nwcService.connect(wallet.id, nwcUrl);
+              const result = await nwcService.connect(wallet.id, nwcUrl, () => {
+                setWallets((prev) =>
+                  prev.map((w) => (w.id === wallet.id ? { ...w, isConnected: true } : w)),
+                );
+                if (!firstWalletConnectLogged) {
+                  firstWalletConnectLogged = true;
+                  console.log(
+                    `[Perf] wallet connected: ${wallet.id.slice(0, 8)} in ${Date.now() - WALLET_MODULE_LOAD_T0}ms from JS bundle load`,
+                  );
+                }
+              });
               if (result.success) {
-                // Try getInfo but don't let a failure prevent the wallet from being marked Connected — the relay handshake is what determines functional connectivity, not whether getInfo round-tripped successfully.
                 let info: Awaited<ReturnType<typeof nwcService.getInfo>> | null = null;
                 try {
                   info = await nwcService.getInfo(wallet.id);
@@ -372,25 +381,13 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
                       ? {
                           ...w,
                           isConnected: true,
-                          balance: result.balance ?? null,
-                          walletAlias: info?.alias || null,
-                          // Prefer any user-set / previously-persisted
-                          // address — a manual override in Wallet
-                          // Settings must survive every startup, even
-                          // when the NWC URL still carries a `lud16=`
-                          // that resolves to the provider's default.
+                          balance: result.balance ?? w.balance ?? null,
+                          walletAlias: info?.alias || w.walletAlias || null,
                           lightningAddress: w.lightningAddress || lud16 || info?.lud16 || null,
                         }
                       : w,
                   ),
                 );
-                // Log AFTER setWallets so the marker matches the moment the UI actually flips to Connected (not just the moment connect() resolved). Gated by firstWalletConnectLogged so a second wallet's connect doesn't double-log this run.
-                if (!firstWalletConnectLogged) {
-                  firstWalletConnectLogged = true;
-                  console.log(
-                    `[Perf] wallet connected: ${wallet.id.slice(0, 8)} in ${Date.now() - WALLET_MODULE_LOAD_T0}ms from JS bundle load`,
-                  );
-                }
               }
             } catch (error) {
               console.warn(`Failed to connect wallet ${wallet.alias} (${wallet.id}):`, error);

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -127,6 +127,7 @@ export function validateNwcUrl(url: string): { valid: boolean; error?: string } 
 export async function connect(
   walletId: string,
   nwcUrl: string,
+  onEnabled?: () => void,
 ): Promise<{ success: boolean; balance?: number; error?: string }> {
   const validation = validateNwcUrl(nwcUrl);
   if (!validation.valid) {
@@ -155,8 +156,7 @@ export async function connect(
     providers.set(walletId, provider);
     nwcUrls.set(walletId, nwcUrl.trim());
 
-    // Allow relay connection to stabilize before first request
-    await new Promise((r) => setTimeout(r, 500));
+    onEnabled?.();
 
     // Try to get initial balance, but don't fail the connection if it times out
     let balance: number | undefined;

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -156,7 +156,13 @@ export async function connect(
     providers.set(walletId, provider);
     nwcUrls.set(walletId, nwcUrl.trim());
 
-    onEnabled?.();
+    // Guard the consumer callback so a UI-side throw can't unwind into our
+    // catch block and falsely tear down a healthy provider.
+    try {
+      onEnabled?.();
+    } catch (cbErr) {
+      if (__DEV__) console.warn('[NWC] onEnabled callback threw — connection unaffected', cbErr);
+    }
 
     // Try to get initial balance, but don't fail the connection if it times out
     let balance: number | undefined;


### PR DESCRIPTION
## Summary

Cold-start used to leave the NWC wallet tile showing "Disconnected" for ~16 s on a fresh launch even though the relay handshake (`provider.enable()`) usually completes in ~5–7 s. The tail came from two sources downstream of `enable()`:

1. A 500 ms sleep "to let the relay stabilise" (the handshake **is** the stabilise step).
2. The `getBalance` retry loop blocking the post-`enable()` `setWallets({ isConnected: true })` flip.

This PR adds an `onEnabled?: () => void` callback to `nwcService.connect()`. The cold-start caller in `WalletContext` uses it to flip `isConnected: true` and emit the `[Perf] wallet connected` marker the instant `enable()` resolves; the existing `getInfo` / balance follow-up still runs and patches `walletAlias` / `lightningAddress` / `balance` into state when it lands.

The 500 ms stabilise sleep is removed.

`addNwcWallet` and the 30 s reconnect-watchdog path keep their old behaviour (no `onEnabled` passed) so user-explicit "Connect wallet" UX is unchanged.

## Expected impact

Median time-to-Connected on cold start: **~16 s → ~10–12 s**. (`enable()` p50 sets the floor; we now stop adding ~5 s of post-handshake retries on top.)

This is the partial fix from the plan parked in #410. The remaining work — render last-known-good wallet state optimistically before reconnect completes, so the tile never shows "Disconnected" at all on warm starts — is a separate issue and not in this PR.

Refs #410.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] `npx jest src/services/nwcService.test.ts` passes (verified locally — 5/5)
- [ ] Cold-start the app on a Pixel with one NWC wallet; observe the tile flips to "Connected" before getBalance round-trips
- [ ] `[Perf] wallet connected: … in <ms>ms` log fires once, at the new earlier moment
- [ ] Add a second NWC wallet via the wallet sheet — flow still works (no `onEnabled` on that path)