### PR TITLE
docs(release): TestFlight notes + chore polish for v1.0.2-rc1

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -146,7 +146,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     //   eas build:list --platform android --status finished --limit 1
     //
     // See docs/DEPLOYMENT.adoc → "Local production builds".
-    versionCode: 35,
+    versionCode: 52,
   },
   web: {
     favicon: './assets/favicon.png',

--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -12,4 +12,15 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ## What to test in the next release
 
--
+- New: pick a fiat currency from a searchable list of 38 (USD/EUR/GBP pinned at the top; DKK, KRW, CNY, INR and more supported). Account → Currency.
+- New: confirmation prompt before any Lightning send or wallet transfer at or above 10,000 sats. Threshold is configurable (Off / 1k / 10k / 100k / Custom) under Account → Security.
+- New: friends-profile sheet now shows the friend's npub QR code, a "Copy lud16" button, and a "Write to NFC tag" affordance directly on the bottom sheet.
+- Polish: amount-entry SATS↔fiat swap is now a bright pink pill with a white arrow instead of a small grey arrow — much easier to tap.
+- Fix: outgoing payments now record the counterparty correctly — sent zaps show the friend's avatar and name in the conversation thread.
+- Fix: Amber-signed NIP-17 group messages now send end-to-end (raw-JSON Intent encoding fix; was breaking kind-13 seals).
+- Fix: "Type message" composer in conversations no longer briefly jumps to the top of the screen on first open.
+- Fix: action row on the friends-profile sheet no longer overflows on narrower phone screens.
+- Perf: slow Lightning payments (e.g. via Boltz/RBTC swaps that take 30–90 s to settle) no longer mis-report as failed — wait extends to 90 s with an honest "still in flight" message; the conversation bubble only turns red on a definitive failure.
+- Perf: Lightning-zap sender avatars render instantly on cold start instead of waiting for a relay round-trip.
+- Perf: home wallet card clears the "Disconnected" indicator noticeably faster on cold app launch.
+- Perf: avatar grids no longer hit a decode-error storm when a contact has an unsupported image URL (`.svg` / `.heic`).

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -568,4 +568,43 @@ actually cancel the LN HTLC — once the payment is on a route the sender cannot
 stop it. Tapping "Cancel" only stops the UI from waiting; the HTLC continues,
 and the recipient may be paid minutes later. The button is being relabelled to
 "Continue in background".
+
+| Wireless ADB IP shown on the phone is unreachable (`adb connect` hangs / 100% packet loss)
+| The IP shown in Settings → Developer options → Wireless debugging is whatever
+the phone reports for its currently-active default network, which is the **VPN
+tunnel address** when a VPN is connected (e.g. `10.2.0.2` from a corporate /
+self-hosted VPN). That address only routes inside the VPN; from a peer machine
+on the home Wi-Fi (`192.168.1.x`) there's no path to it. +
+*Symptoms:* `adb connect 10.x.y.z:NNNNN` hangs ~30 s then fails silently, or
+`ping` returns 100% packet loss. The Pixel's developer options page keeps
+showing the VPN address even after toggling Wi-Fi off and on. +
+*Fix:* Toggle the VPN OFF on the phone, **then** re-open Wireless debugging —
+the page will refresh with the home-Wi-Fi address (`192.168.1.x`). The port
+also changes on every wireless-debugging restart, so always re-read both
+fields. Re-pair if the host hasn't paired before. +
+*Verify reachability before `adb connect`:* `ping -c 2 -W 2 <ip>` from the
+host. If that returns `100% packet loss`, the address isn't routable —
+fastest fallback is USB cable (`adb devices` shows the USB serial like
+`37111FDJH0067B`).
+
+| Pixel screen locks mid-deploy / mid-perf-suite, breaking install or Maestro
+| `adb install` after the build prompts in dev settings (the user has to
+re-tap "Allow" if the screen has slept), and `dumpsys gfxinfo` returns zeros
+when the surface isn't being painted. Maestro flows tap real UI so the screen
+must be unlocked + interactive. Default Android lockscreen kicks in at 30 s –
+2 min idle. +
+*Fix (per-session, not persisted across reboot):*
+[source,bash]
+----
+# Keep the screen on regardless of charging state for as long as adb is connected.
+# Reverts on next reboot, or call again with `false` when done.
+adb shell svc power stayon true
+----
+Or: Settings → System → Developer options → "Stay awake" — keeps the screen
+on while charging, persists across reboot. Pair with USB / charger so you can
+walk away. +
+*Combo for hands-off deploy + perf:* USB cable + `adb shell svc power stayon
+true` + Settings → "Don't lock when on this network" disabled (default), and
+the phone won't auto-lock for the duration of the build (~20 min) and the
+follow-on perf-suite (~3 min).
 |===

--- a/scripts/eas-deploy-pixel.sh
+++ b/scripts/eas-deploy-pixel.sh
@@ -35,6 +35,16 @@ DEVICE_VC=$(adb -s "$PIXEL" shell dumpsys package "$PACKAGE" 2>/dev/null | grep 
 echo "device $PIXEL has $PACKAGE versionCode=$DEVICE_VC"
 [ -z "$DEVICE_VC" ] && { echo "could not read device versionCode — is the device connected?"; exit 1; }
 
+# Keep the screen on while we deploy + run the perf suite. The phone
+# defaults to a 30 s – 2 min lock timeout; if it locks mid-flow, the
+# `adb install` reauth prompt is missed and Maestro / dumpsys gfxinfo
+# stop receiving events. `stayon true` is per-session (resets on
+# reboot); we restore it on EXIT below. See docs/TROUBLESHOOTING.adoc.
+PRIOR_STAYON=$(adb -s "$PIXEL" shell dumpsys power 2>/dev/null | grep -oP 'mStayOn=\K\w+' | head -1)
+echo "stayon: was=$PRIOR_STAYON; setting to true for the deploy + perf run"
+adb -s "$PIXEL" shell svc power stayon true 2>/dev/null || true
+trap 'echo "restoring stayon=${PRIOR_STAYON:-false}"; adb -s "$PIXEL" shell svc power stayon ${PRIOR_STAYON:-false} 2>/dev/null || true' EXIT
+
 echo "starting eas build --local in background (logs: $BUILD_LOG)"
 # `setsid` puts the build in its own process group so we can kill the whole
 # tree later (eas-cli spawns npm, npx, java/gradle — a plain kill on the


### PR DESCRIPTION
## Summary

Two commits landing together so the next GitHub Release can ship cleanly:

1. **`docs/RELEASE_NOTES_NEXT.md`** — populated with 12 tester-facing bullets covering the user-visible changes since `v1.0.1-rc1` (currency picker, security threshold, profile-sheet QR/lud16/NFC, swap-button polish, counterparty fixes, Amber NIP-17 fix, slow-LN-payment honest state, perf wins).
2. **Local-build polish** — bumps `app.config.ts` `versionCode` floor 35 → 52 (was lagging the cloud counter, breaking manual `eas build --local` sideloads), adds `adb shell svc power stayon true` to `eas-deploy-pixel.sh` so the Pixel won't auto-lock during the ~20 min build + install + perf-suite chain (with prior-state restore on EXIT), and documents both the wireless-ADB VPN-tunnel-IP gotcha and the screen-lock recipe in `docs/TROUBLESHOOTING.adoc`.

## Why now

Cutting `v1.0.2-rc1` immediately after this lands. The release workflow reads `RELEASE_NOTES_NEXT.md` and PATCHes them onto the TestFlight build's "What to Test" via the App Store Connect API.

## Test plan

- [x] `npx prettier --check src/` clean (no `src/` changes here)
- [ ] After merge, publish a GitHub Release tagged `v1.0.2-rc1` targeted at `main`. Workflow → EAS prod build → TestFlight upload → notes PATCH.
- [ ] Verify on TestFlight that the "What to Test" pane shows the bullets.