### PR TITLE
chore(ci): make Android-APK attach robust to eas-cli stdout noise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,14 +292,16 @@ jobs:
           OUT=$(mktemp)
           ERR=$(mktemp)
           if ! fetch "$OUT" "$ERR"; then
-            echo "::warning title=eas build:list transient failure — retrying in 8 s::"
+            echo "::warning title=eas build:list failed once — retrying in 8 s::Transient EAS API hiccup; see grouped logs below if the retry also fails."
             sleep 8
             if ! fetch "$OUT" "$ERR"; then
-              echo "::error title=eas build:list failed twice::"
-              echo "--- stderr ---"
+              echo "::error title=eas build:list failed twice::See grouped logs below for stderr and stdout."
+              echo "::group::eas build:list stderr"
               cat "$ERR"
-              echo "--- stdout ---"
+              echo "::endgroup::"
+              echo "::group::eas build:list stdout"
               cat "$OUT"
+              echo "::endgroup::"
               exit 1
             fi
           fi
@@ -313,18 +315,21 @@ jobs:
           if ! url=$(jq -r --arg sha "${{ github.sha }}" \
                        '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty' \
                        "$CLEAN" 2>/dev/null); then
-            echo "::error title=jq parse failed on eas build:list output::"
-            echo "--- raw stdout ---"
+            echo "::error title=jq parse failed on eas build:list output::See grouped logs below for raw stdout and the stripped JSON we tried to parse."
+            echo "::group::raw stdout"
             cat "$OUT"
-            echo "--- stripped JSON ---"
+            echo "::endgroup::"
+            echo "::group::stripped JSON (post sed)"
             cat "$CLEAN"
+            echo "::endgroup::"
             exit 1
           fi
 
           if [ -z "$url" ] || [ "$url" = "null" ]; then
-            echo "::error title=No Android build artifact::Could not find a finished Android build for commit ${{ github.sha }}. The EAS build may still be running, or failed."
-            echo "--- recent builds (cleaned) ---"
+            echo "::error title=No Android build artifact for commit ${{ github.sha }}::EAS build may still be running, or failed. Recent builds dumped in the grouped log below."
+            echo "::group::recent builds (cleaned)"
             cat "$CLEAN"
+            echo "::endgroup::"
             exit 1
           fi
           echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,22 +266,65 @@ jobs:
       - name: Resolve latest finished Android APK URL
         id: find
         env:
-          # Suppress Node `(node:NNN) [DEPxxxx] DeprecationWarning: ...`
-          # lines that eas-cli emits to stdout, which would otherwise
-          # poison the JSON pipe to jq with `Invalid numeric literal`.
-          # See #207 for the v1.0.0-rc2 release where this manifested.
+          # Suppress Node deprecation warnings on stdout. NODE_NO_WARNINGS
+          # only handles Node-level deprecations though — eas-cli itself
+          # can also print error / progress noise to stdout (`Error:
+          # build:list command failed.` on transient API hiccups,
+          # update-notifier banners), which is what v1.0.2-rc1 tripped on.
+          # The script below captures stderr separately, retries once on
+          # failure, and strips any pre-JSON prefix before jq sees it.
           NODE_NO_WARNINGS: '1'
         run: |
+          set -uo pipefail
+
           # Pick the most recent FINISHED Android production build (the one we just submitted).
           # Filter by the git commit of the Release tag so we don't accidentally grab an
           # unrelated older build.
-          url=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
-            --platform android --status finished --limit 5 --json \
-            --non-interactive \
-            | jq -r --arg sha "${{ github.sha }}" \
-                '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty')
+
+          fetch() {
+            local out_file="$1" err_file="$2"
+            npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
+              --platform android --status finished --limit 5 --json \
+              --non-interactive \
+              > "$out_file" 2> "$err_file"
+          }
+
+          OUT=$(mktemp)
+          ERR=$(mktemp)
+          if ! fetch "$OUT" "$ERR"; then
+            echo "::warning title=eas build:list transient failure — retrying in 8 s::"
+            sleep 8
+            if ! fetch "$OUT" "$ERR"; then
+              echo "::error title=eas build:list failed twice::"
+              echo "--- stderr ---"
+              cat "$ERR"
+              echo "--- stdout ---"
+              cat "$OUT"
+              exit 1
+            fi
+          fi
+
+          # Strip any non-JSON prefix lines (deprecation banners, error noise
+          # written to stdout) — find the first `[` line and keep everything
+          # from there.
+          CLEAN=$(mktemp)
+          sed -n '/^\[/,$p' "$OUT" > "$CLEAN"
+
+          if ! url=$(jq -r --arg sha "${{ github.sha }}" \
+                       '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty' \
+                       "$CLEAN" 2>/dev/null); then
+            echo "::error title=jq parse failed on eas build:list output::"
+            echo "--- raw stdout ---"
+            cat "$OUT"
+            echo "--- stripped JSON ---"
+            cat "$CLEAN"
+            exit 1
+          fi
+
           if [ -z "$url" ] || [ "$url" = "null" ]; then
             echo "::error title=No Android build artifact::Could not find a finished Android build for commit ${{ github.sha }}. The EAS build may still be running, or failed."
+            echo "--- recent builds (cleaned) ---"
+            cat "$CLEAN"
             exit 1
           fi
           echo "url=$url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

The \`Attach Android APK to Release\` job failed on **v1.0.2-rc1** (run [25543840926](https://github.com/BenGWeeks/lightning-piggy-mobile/actions/runs/25543840926)):

\`\`\`
jq: parse error: Invalid numeric literal at line 1, column 7
Error: build:list command failed.
\`\`\`

\`eas-cli\` printed \`Error: build:list command failed.\` (a transient API hiccup) to **stdout**, ahead of the JSON. The pipe to \`jq\` then choked on the non-numeric prefix. \`NODE_NO_WARNINGS=1\` is already set in the env block, but that only suppresses **Node-level** deprecation warnings — it doesn't catch eas-cli's own error / progress output.

The user impact: every release that hits this surface goes out without the Android APK attached unless someone notices and uploads it manually. I had to do exactly that for v1.0.2-rc1 (\`gh release upload v1.0.2-rc1 lightning-piggy-v1.0.2-rc1.apk\`).

## What changes

\`.github/workflows/release.yml\` → \`Attach Android APK to Release\` → \`Resolve latest finished Android APK URL\` step:

1. **Capture stdout + stderr to separate temp files** so the JSON parse target is never contaminated by stderr noise (and vice versa).
2. **Single retry with 8 s backoff** to absorb transient EAS API failures — most \`build:list\` errors on EAS are flakey one-shots, not deterministic.
3. **Strip pre-JSON prefix** with \`sed -n '/^\\[/,\$p'\` before jq sees it — defence-in-depth in case eas-cli prepends a banner or update-notifier line to stdout.
4. **Surface the real error on failure** with grouped \`::error\` annotations (raw stdout + cleaned JSON) so the next failure is debuggable in one click instead of \"command failed exit 5\".

Functional behaviour for the happy path is identical. Failure modes now produce diagnosable output.

## Test plan

- [x] YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`).
- [x] Workflow file shape unchanged outside the single step (61 lines changed in one place).
- [ ] Confirmed by the next release tag (v1.0.2-rc2 / v1.0.3-rc1) running \`Attach Android APK to Release\` to completion. If a transient eas-cli failure does occur, expect a single retry visible in logs followed by success — and if it fails twice, the actual stderr is now in the annotation instead of \`exit code 5\`.

## Caveats

- This is a workflow-only change; can't be exercised by CI on this PR (release.yml only fires on \`release: published\`). Verification has to wait for the next release.
- Doesn't fix the **upstream** flakiness on EAS's \`build:list\` endpoint — just makes our consumer robust to it.

Closes nothing — recovery PR for the v1.0.2-rc1 release-workflow blip.