### PR TITLE
test(e2e): regression guard for Receive → Friend invoice flow (#457)

### DIFF
--- a/tests/e2e/_subflow-login-as-piggy.yaml
+++ b/tests/e2e/_subflow-login-as-piggy.yaml
@@ -1,0 +1,89 @@
+appId: com.lightningpiggy.app.dev
+name: Internal — login as the nsec passed via PIGGY_NSEC env var
+---
+# Parametrised version of _subflow-login-as.yaml. The original is
+# hard-coded to MAESTRO_NSEC_BIG (used by the 3-way group-chat suite
+# which always logs in the same fixture). This variant takes the
+# nsec as a parameter so multi-account roundtrip tests can chain
+# Big → Little → Big logins from a single wrapper.
+#
+# Caller passes:
+#   PIGGY_NSEC — the nsec to log in as (e.g. ${MAESTRO_NSEC_BIG})
+
+- launchApp:
+    appId: com.lightningpiggy.app.dev
+    stopApp: true
+- waitForAnimationToEnd:
+    timeout: 10000
+
+- tapOn:
+    id: 'tab-home'
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn:
+    id: 'profile-icon'
+- waitForAnimationToEnd:
+    timeout: 5000
+
+- tapOn:
+    id: 'drawer-sign-out'
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn:
+    id: 'branded-alert-button-1'
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: 'profile-icon'
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn:
+    id: 'drawer-row-profile'
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: 'connect-nostr'
+- waitForAnimationToEnd:
+    timeout: 5000
+
+- tapOn:
+    id: 'nsec-input'
+- inputText: ${PIGGY_NSEC}
+- waitForAnimationToEnd:
+    timeout: 1500
+
+- tapOn:
+    id: 'login-button'
+- waitForAnimationToEnd:
+    timeout: 10000
+
+- tapOn:
+    text: 'UPDATE'
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- extendedWaitUntil:
+    visible:
+      text: 'Edit Profile'
+    timeout: 15000
+
+- tapOn:
+    text: 'Allow'
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn: 'Back'
+- waitForAnimationToEnd:
+    timeout: 1500
+- extendedWaitUntil:
+    visible:
+      id: 'tab-home'
+    timeout: 8000

--- a/tests/e2e/test-receive-amount-send-to-friend.yaml
+++ b/tests/e2e/test-receive-amount-send-to-friend.yaml
@@ -56,16 +56,28 @@ name: Receive → Amount → Friend regression guard for #457
 - waitForAnimationToEnd:
     timeout: 3000
 
-# Drill into custom-amount step. Wallets that have a lud16 land on
-# the address QR view by default; the "Custom amount" entry surface
-# (receive-enter-custom-amount) is always visible regardless of
-# whether the wallet has a lud16, so we tap it directly.
-- tapOn:
-    id: 'receive-enter-custom-amount'
+# Drill into custom-amount step. Two render paths:
+#   - Wallets with a lud16 → ReceiveSheet lands on the main step
+#     (lud16 QR + buttons), need to tap receive-enter-custom-amount
+#     to reach the keypad.
+#   - Wallets without a lud16 → ReceiveSheet skips main and goes
+#     straight to AmountEntryScreen (the keypad is already visible).
+# Tap the main-step "Custom amount" button when present. Use
+# `when: visible:` (not `notVisible:`) so we don't hit a timing race
+# where the receive sheet hasn't fully rendered yet — `notVisible`
+# returns true during the brief window before either screen has
+# painted, causing a false-positive into the inner block.
+- runFlow:
+    when:
+      visible:
+        id: 'receive-enter-custom-amount'
+    commands:
+      - tapOn:
+          id: 'receive-enter-custom-amount'
 - extendedWaitUntil:
     visible:
       id: 'amount-entry-screen'
-    timeout: 5000
+    timeout: 8000
 
 # 21 sats — matches the existing _subflow-send-21sat-bolt11 convention
 # so a wrapper that chains the two ends up with a consistent amount
@@ -95,29 +107,37 @@ name: Receive → Amount → Friend regression guard for #457
     timeout: 3000
 
 # FriendPicker should be open. Use the accessibilityLabel `Send to
-# Little Piggy` (FriendPickerSheet.tsx:247) — the testID form
-# requires the recipient's pubkey-prefix which is environment-
-# specific; the accessibilityLabel is stable.
+# {name}` (FriendPickerSheet.tsx:247) — the testID form requires
+# the recipient's pubkey-prefix which is environment-specific; the
+# accessibilityLabel is stable. Recipient name is parametrised via
+# RECIPIENT_NAME so this test runs whether the AVD is signed in as
+# Big Piggy (default → Little Piggy as recipient) or Little Piggy
+# (override → RECIPIENT_NAME='Big Piggy').
 - tapOn:
-    text: 'Send to Little Piggy'
-- waitForAnimationToEnd:
-    timeout: 4000
+    text: 'Send to ${RECIPIENT_NAME}'
 
 # === Regression assertions for #457 ===
 
 # (a) The success Toast must fire. Reporter confirmed this is the
 # observable that's currently missing. Toast text comes from
 # ReceiveSheet.tsx:369-376: "Invoice sent to {friend.name}".
+# IMPORTANT: assert this immediately — react-native-toast-message
+# default visibilityTime is 2500ms. If we waitForAnimationToEnd
+# before checking, the Toast can fade out before the assertion runs.
 - extendedWaitUntil:
-    visible: 'Invoice sent to Little Piggy'
+    visible: 'Invoice sent to ${RECIPIENT_NAME}'
     timeout: 5000
 
-# (b) The user lands inside the Little Piggy 1:1 thread. The chat
+# Now wait for the navigate animation to settle.
+- waitForAnimationToEnd:
+    timeout: 4000
+
+# (b) The user lands inside the recipient's 1:1 thread. The chat
 # header avatar/name is rendered as part of ConversationScreen.
 - assertVisible:
     id: 'chat-header-open-profile'
 - assertVisible:
-    text: 'Little Piggy'
+    text: ${RECIPIENT_NAME}
 
 # (c) The just-sent bolt11 bubble must appear in the thread. Bolt11
 # bubbles render with their decoded amount — substring match on

--- a/tests/e2e/test-receive-amount-send-to-friend.yaml
+++ b/tests/e2e/test-receive-amount-send-to-friend.yaml
@@ -1,0 +1,128 @@
+appId: com.lightningpiggy.app.dev
+name: Receive → Amount → Friend regression guard for #457
+---
+# Regression guard for issue #457 — when sending a generated bolt11
+# invoice from Home > Receive > Custom amount > Friend, the success
+# Toast doesn't fire AND the bolt11 bubble doesn't land in the
+# recipient thread, even though the user gets navigated into the
+# conversation.
+#
+# This test is **expected to FAIL on main today** until #457 is
+# resolved. Its purpose is to:
+#   1. Provide a deterministic repro the fix can be validated against.
+#   2. Guard against regression once the fix lands.
+#
+# Flow (from a fresh tab-home, AVD signed in as the sender — Big Piggy
+# in the fixture set):
+#
+#   1. Tap btn-receive → ReceiveSheet opens
+#   2. Tap receive-enter-custom-amount → AmountEntryScreen
+#   3. 2 + 1 → 21 sats, tap "Generate invoice" (amount-entry-confirm)
+#   4. Wait for the bolt11 to render, tap receive-send-to-friend
+#   5. FriendPicker opens — tap "Send to Little Piggy"
+#   6. Assert: success Toast "Invoice sent to Little Piggy" appears
+#      (this is the bit that currently doesn't fire — see the
+#      reporter's confirmation in the issue)
+#   7. Assert: app navigates into Little Piggy 1:1 conversation
+#   8. Assert: a "21 sats" bolt11 bubble is visible in the thread
+#      (current bug: the bubble is missing; the wrap doesn't
+#      round-trip back through the live subscription)
+#
+# Preconditions:
+#   - AVD signed in as the sender. By default this test uses whatever
+#     account is currently active — pair with _subflow-login-as.yaml
+#     in a wrapper if you want deterministic Big Piggy login.
+#   - Sender has Little Piggy as a Nostr friend (kind-3 contact list).
+#     If they're not, the FriendPicker won't surface them and the
+#     "Send to Little Piggy" tap below fails with element-not-found.
+#   - Active wallet is Lightning (NWC) and has invoice-issuance
+#     methods. On-chain wallets would route through receive-friend-
+#     share-onchain instead — covered by a separate test.
+
+- launchApp:
+    clearState: false
+- extendedWaitUntil:
+    visible:
+      id: 'tab-home'
+    timeout: 30000
+
+- tapOn:
+    id: 'tab-home'
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: 'btn-receive'
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# Drill into custom-amount step. Wallets that have a lud16 land on
+# the address QR view by default; the "Custom amount" entry surface
+# (receive-enter-custom-amount) is always visible regardless of
+# whether the wallet has a lud16, so we tap it directly.
+- tapOn:
+    id: 'receive-enter-custom-amount'
+- extendedWaitUntil:
+    visible:
+      id: 'amount-entry-screen'
+    timeout: 5000
+
+# 21 sats — matches the existing _subflow-send-21sat-bolt11 convention
+# so a wrapper that chains the two ends up with a consistent amount
+# in both the send-from-thread and send-from-home flows.
+- tapOn: { id: 'amount-entry-key-2' }
+- tapOn: { id: 'amount-entry-key-1' }
+- assertVisible: '21'
+
+# "Generate invoice" — confirm goes back to the receive sheet's main
+# step and kicks off invoice generation in parallel.
+- tapOn:
+    id: 'amount-entry-confirm'
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Wait for the bolt11 to materialise — receive-send-to-friend stays
+# disabled (and likely hidden) until friendShareValue is non-empty.
+# 15s ceiling matches what _subflow-send-21sat-bolt11.yaml already uses.
+- extendedWaitUntil:
+    visible:
+      id: 'receive-send-to-friend'
+    timeout: 15000
+
+- tapOn:
+    id: 'receive-send-to-friend'
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# FriendPicker should be open. Use the accessibilityLabel `Send to
+# Little Piggy` (FriendPickerSheet.tsx:247) — the testID form
+# requires the recipient's pubkey-prefix which is environment-
+# specific; the accessibilityLabel is stable.
+- tapOn:
+    text: 'Send to Little Piggy'
+- waitForAnimationToEnd:
+    timeout: 4000
+
+# === Regression assertions for #457 ===
+
+# (a) The success Toast must fire. Reporter confirmed this is the
+# observable that's currently missing. Toast text comes from
+# ReceiveSheet.tsx:369-376: "Invoice sent to {friend.name}".
+- extendedWaitUntil:
+    visible: 'Invoice sent to Little Piggy'
+    timeout: 5000
+
+# (b) The user lands inside the Little Piggy 1:1 thread. The chat
+# header avatar/name is rendered as part of ConversationScreen.
+- assertVisible:
+    id: 'chat-header-open-profile'
+- assertVisible:
+    text: 'Little Piggy'
+
+# (c) The just-sent bolt11 bubble must appear in the thread. Bolt11
+# bubbles render with their decoded amount — substring match on
+# "21 sats" because the bubble layout adds prefix copy.
+- extendedWaitUntil:
+    visible:
+      text: '.*21 sats.*'
+    timeout: 8000


### PR DESCRIPTION
## Summary

Adds a single Maestro flow `tests/e2e/test-receive-amount-send-to-friend.yaml` that drives the buggy path end-to-end: **Home → Receive → Custom amount → 21 sats → Friend → Little Piggy**.

After picking the friend, the test asserts the three observables that the reporter confirmed are currently missing:

1. The green **"Invoice sent to Little Piggy"** Toast fires (`ReceiveSheet.tsx:369-376`)
2. The user lands inside the Little Piggy 1:1 thread (`chat-header-open-profile` visible + name rendered)
3. A bolt11 bubble carrying `21 sats` renders in the conversation history

## Why this is opening as failing

This test is **expected to FAIL on main today**. That's the point — it exists to:

- Provide a deterministic repro the fix can be validated against
- Lock down the assertion once #457 is resolved so the bug can't silently regress

Maestro flows aren't part of the GitHub Actions CI matrix in this repo (only TypeScript / ESLint / Prettier / Jest coverage / PR-Lint run on PRs), so a failing test here doesn't break the ratchet — it has to be run manually on the AVD with `maestro test tests/e2e/test-receive-amount-send-to-friend.yaml`.

## Diagnostic value

Reporter confirmed in #457 that no Toast appeared. Combined with the navigation still firing, that narrows the root cause:

- Either `sendDirectMessage` returned `success: true` but the Toast call itself was swallowed (Toast queue empty / provider missing / BrandedToast wrap misbehaving)
- Or `success: false` came back AND the early-return at `ReceiveSheet.tsx:367` was somehow bypassed by an exception path

Running this test once with `adb logcat *:S ReactNativeJS:V` open should make the answer obvious.

## Test plan

- [ ] Run `maestro test tests/e2e/test-receive-amount-send-to-friend.yaml` against AVD signed in as Big Piggy with Little Piggy as a friend — currently fails at the "Invoice sent to Little Piggy" assertion (the regression we're guarding)
- [ ] Once #457 is fixed, the test passes through all three assertions

## Preconditions

- AVD signed in as the sender (Big Piggy in the fixture set)
- Sender has Little Piggy as a Nostr kind-3 contact (so the FriendPicker surfaces them)
- Active wallet is a connected Lightning (NWC) wallet capable of issuing invoices

Closes nothing — issue stays open until the underlying bug is fixed and this test goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)