### PR TITLE
perf: yield event loop before each live-sub NIP-17 wrap decrypt (#496)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -3225,6 +3225,16 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         if (__DEV__) console.warn(`[Nostr] live NIP-17 unwrap skip (${wrapId}): ${reason}`);
       };
 
+      // Yield to the event loop before each per-wrap decryption. The
+      // live sub fans out wraps from the relay one at a time, but
+      // when the sub catches up a backlog after cold start, multiple
+      // wraps land in the same JS task — each sync `unwrapWrapNsec`
+      // is ~1-3 ms and they pile up to tens-of-ms of unbroken
+      // blocking, dropping bottom-sheet animation frames. A single
+      // setTimeout(0) per wrap costs ~0 ms but lets RN re-flush
+      // pending UI events between decryptions. See issue #496.
+      await yieldToEventLoop();
+
       let rumor: DecodedRumor | null = null;
       if (activeSigner === 'nsec') {
         const secretKey = await getMemoisedSecretKey(viewerPubkey);


### PR DESCRIPTION
## Summary

Single \`await yieldToEventLoop()\` before each per-wrap decrypt in the kind-1059 live-sub onevent handler. Costs ~0 ms per wrap but lets RN re-flush pending UI events between decryptions so animations don't lose frames during backlog catch-up.

## Why

The live sub fans out wraps from the relay one at a time, but during cold-start backlog catch-up several land in the same JS task. Each \`unwrapWrapNsec\` is 1-3 ms of synchronous secp256k1 + AES; 8-12 of them back-to-back in one task = ~10-30 ms unbroken blocking, which is enough to drop a bottom-sheet animation frame.

PR #489 already lowered `NIP17_LOOP_YIELD_EVERY: 8 → 4` for the BATCH paths in \`refreshDmInbox\`. This PR addresses the live-sub onevent handler that wasn't covered there — the path that fires on every kind-1059 the relay pushes us in real time.

## Measurable result

On AVD with Big Piggy fixture (lots of group rumors), live-sub backlog drain after relaunch:

```
[Nostr] live wrap 14415b2f group-routed (routed)
[Nostr] live wrap 3e513bdb group-routed (routed)
[Nostr] live wrap b1e986ca group-routed (routed)
... (16 wraps continue in sequence)
```

All wraps process cleanly with the yield inserted. Crucially: **no out-of-order persistence** — the await is on the event-loop yield, not on the wrap itself, so each wrap's downstream chain (cache write, partnership lookup, group routing) still runs serially per-wrap. Only the synchronous decryption window between wraps becomes interruptible.

The user-visible win is in the cold-start interaction window: bottom-sheet open animations get scheduling slots between wraps instead of waiting for the entire backlog flood to drain. Pixel-side validation pending — AVD's slow x86 JS doesn't isolate this win cleanly from the existing per-burst yields.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check src/contexts/NostrContext.tsx` — clean
- [x] AVD live-sub catch-up after force-stop → relaunch processes 16+ wraps without error, no out-of-order log evidence
- [ ] Pixel sideload + bottom-sheet open during cold-start backlog drain (qualitative — should feel smoother)

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)