### PR TITLE
fix(send): disable Send button for receive-only on-chain wallets (#493)

### DIFF
--- a/src/components/AccountDrawerContent.tsx
+++ b/src/components/AccountDrawerContent.tsx
@@ -451,11 +451,15 @@ const createStyles = (colors: Palette) =>
       borderColor: colors.divider,
       alignItems: 'center',
       justifyContent: 'center',
-      // No marginLeft: 'auto' here — switcherAvatars already absorbs
-      // the available row space via its own auto-margin, pushing both
-      // it and this button to the right as one tight group. A second
-      // auto-margin would split the space evenly, leaving the
-      // switcher avatars marooned mid-row (#442 layout review).
+      // marginLeft: 'auto' here is a single-identity safety net. When
+      // `switcherAvatars` renders, its own `marginLeft: 'auto'` fires
+      // FIRST (consumes the available row space) and this one is a
+      // no-op — both elements end up flush-right adjacent to each
+      // other, as the original design intended. When `switcherAvatars`
+      // does NOT render (no other identities signed in), this auto-
+      // margin keeps the ⋯ button right-aligned. Without it, the
+      // button collapsed left next to the avatar (#492).
+      marginLeft: 'auto',
     },
     avatarPlaceholder: {
       backgroundColor: colors.background,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -225,7 +225,14 @@ const HomeScreen: React.FC = () => {
   // `hasActiveConnection` left taps un-feedback-able for the 1-3 s
   // cold-start window while NWC handshakes complete (#474).
   const isReceiveDisabled = walletsHydrated && wallets.length === 0;
-  const isSendDisabled = walletsHydrated && wallets.length === 0;
+  // Send is also disabled when the active wallet itself can't sign —
+  // watch-only on-chain (xpub) and bare-receive-address imports
+  // (Xapo deposit addresses, etc.) have no signing material so the
+  // Send sheet can't complete from them. Per #493. The "no wallets
+  // at all" case still kicks in first.
+  const isSendDisabled =
+    (walletsHydrated && wallets.length === 0) ||
+    (activeWallet !== null && !isSendableWallet(activeWallet));
   // Transfer needs at least two wallets (a source + destination).
   const isTransferDisabled = walletsHydrated && wallets.length < 2;
 


### PR DESCRIPTION
## Summary

Two small UI polish fixes from real-device inspection on the Pixel.

### 1. Send button disabled for receive-only wallets — #493

`isSendDisabled` now also returns true when the active wallet can't sign. Watch-only / xpub / bare-receive-address imports (Xapo `bc1...` deposit addresses, etc.) no longer leave the Home Send button enabled.

Reuses the existing `isSendableWallet` helper from `utils/walletCapabilities.ts` — same predicate the Transfer source filter uses, exhaustive-switch over `WalletType`. New wallet types or import methods stay compile-checked. Receive button stays enabled — the whole point of a deposit-only address is to receive.

### 2. Account drawer kebab `⋯` right-alignment — #492

The `⋯` (open account switcher / add another nsec) button in the drawer header was collapsing left next to the avatar when only one profile was signed in. The `switcherAvatars` block carries the `marginLeft: 'auto'` that pushes the right cluster, but that block doesn't render when `otherIdentities.length === 0`.

Adds `marginLeft: 'auto'` to `moreButton` as a single-identity safety net. Multi-identity case unaffected: `switcherAvatars`'s own auto-margin fires first, consumes the row space, and `moreButton`'s auto-margin becomes a no-op — both end up flush-right adjacent as before. Verified on the AVD with the Big / Middle / Little Piggy fixture — switcher avatars still sit immediately left of the `⋯`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check src/screens/HomeScreen.tsx src/types/wallet.ts src/components/AccountDrawerContent.tsx` — clean
- [x] `npx jest --no-coverage` — 24 suites / 243 tests pass
- [x] AVD multi-identity drawer: `[avatar] [switcher x N] [⋯]` flush-right, layout unchanged
- [ ] Pixel single-identity drawer: `⋯` flush-right alone (was the bug)
- [ ] Pixel: switch carousel to Xapo deposit-address wallet, confirm Send greyed out, Receive still works

Closes #492
Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
