### PR TITLE
perf(nostr): carry knownWrapIds across live-sub re-opens + eager add

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -31,7 +31,11 @@ import {
   reconcileSyntheticGroup,
 } from '../services/groupRoutingRegistry';
 import { isSyntheticGroupId, syntheticGroupIdForParticipants } from '../utils/syntheticGroupId';
-import { appendGroupMessage, type GroupMessage } from '../services/groupMessagesStorageService';
+import {
+  appendGroupMessage,
+  listPersistedGroupWrapIds,
+  type GroupMessage,
+} from '../services/groupMessagesStorageService';
 import { perAccountKey } from '../services/perAccountStorage';
 import {
   loadIdentities,
@@ -3513,9 +3517,17 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           const seedRaw = await AsyncStorage.getItem(wrapCacheKey);
           const seedCache = safeParseRecord<Nip17CacheEntry>(seedRaw);
           for (const id of Object.keys(seedCache)) knownWrapIds.add(id);
+          // Also seed from persisted group messages — group-routed wraps
+          // never land in the 1:1 wrapCache (the tryRouteGroupRumor
+          // branch returns before the cache write). Without this union
+          // every cold start re-decrypts + re-routes the same group
+          // wraps the relay re-streams since the last `since` cursor.
+          const dmCount = knownWrapIds.size;
+          const groupWrapIds = await listPersistedGroupWrapIds();
+          for (const id of groupWrapIds) knownWrapIds.add(id);
           if (__DEV__) {
             console.log(
-              `[Nostr] live DM sub: seeded knownWrapIds with ${knownWrapIds.size} cached wraps`,
+              `[Nostr] live DM sub: seeded knownWrapIds with ${dmCount} dm + ${knownWrapIds.size - dmCount} group wraps`,
             );
           }
         } catch (e) {

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -3074,6 +3074,21 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     followPubkeysRef.current = followPubkeys;
   }, [followPubkeys]);
 
+  // In-memory dedup Set that survives live-DM-sub re-opens. The sub
+  // useEffect below re-runs when getReadRelays changes — e.g. when the
+  // relay-list refresh adds a new relay 9 s into cold start. Without
+  // this ref, the new effect instance creates a fresh Set and re-seeds
+  // it from AsyncStorage's wrap cache. That snapshot is stale by the
+  // deferred-write window, so all wraps the prior sub already
+  // decrypted re-stream from the relays (same `since` cursor) and get
+  // re-routed/re-decrypted. Carrying the Set forward keeps the
+  // early-return in handleInboxEvent honest across the re-open.
+  // Reset only when the viewer changes (sign out / account switch).
+  const knownWrapIdsRef = useRef<{ pubkey: string | null; set: Set<string> }>({
+    pubkey: null,
+    set: new Set(),
+  });
+
   // Long-lived kind-1059 (NIP-17 gift wrap) subscription for the
   // current viewer (#349). Without this, new incoming wraps only
   // surface via pull-to-refresh or the 30 s-TTL useFocusEffect on
@@ -3119,19 +3134,20 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const readRelays = getReadRelays();
     const seen = new Set<string>();
     const SEEN_CAP = 4096;
-    // In-memory mirror of the persisted NIP-17 wrap-id cache. Seeded
-    // eagerly up-front below (one async AsyncStorage.getItem + one
-    // JSON.parse, before `subscribeInboxDmsForViewer` opens the sub)
-    // so the live sub's onevent path can early-return on cache hits
-    // as the VERY FIRST check, without paying the per-event
-    // console.log + seen-set + dispatch + cacheKey-build cost that
-    // was eating 12 s of the cold-start JS thread on Big Piggy's
-    // fixture. Per issue #505 — the relay re-streams the backlog
-    // since the last `since` cursor, and on a busy account that's
-    // 100+ wraps in ~12 s, almost all of which are already known.
-    // Pre-#505 the dedup-cache hit check was lazy-populated and
-    // downstream of several per-event operations.
-    let knownWrapIds: Set<string> = new Set();
+    // In-memory mirror of the persisted NIP-17 wrap-id cache. Backed
+    // by `knownWrapIdsRef` so the Set survives this effect's re-runs
+    // (relay-list change → fresh effect instance). Seeded by union
+    // below from AsyncStorage's wrap cache, but does NOT replace any
+    // entries the prior sub instance added in-memory but the deferred
+    // writeChain hasn't persisted yet. Per issue #505 — the relay
+    // re-streams the backlog since the last `since` cursor, and on a
+    // busy account that's 100+ wraps in ~12 s, almost all of which are
+    // already known; pre-#505 the dedup-cache hit check was
+    // lazy-populated and downstream of several per-event operations.
+    if (knownWrapIdsRef.current.pubkey !== viewerPubkey) {
+      knownWrapIdsRef.current = { pubkey: viewerPubkey, set: new Set() };
+    }
+    const knownWrapIds: Set<string> = knownWrapIdsRef.current.set;
     let cancelled = false;
     let writeChain: Promise<void> = Promise.resolve();
 
@@ -3170,6 +3186,15 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       // cold-start JS-thread occupation window from ~12 s to <1 s.
       // Per issue #505.
       if (ev.kind === 1059 && knownWrapIds.has(ev.id)) return;
+      // Eagerly claim this wrap.id in the in-memory dedup Set before
+      // doing any async work. The deferred writeChain at the bottom of
+      // this handler also does this, but only after AsyncStorage I/O
+      // completes — leaving a window where a re-opened sub (relay-list
+      // change mid cold start) re-streams the same wrap and gets past
+      // the early-return because the Set hasn't been updated yet.
+      // Set.add is idempotent so the trailing writeChain add becomes
+      // a no-op. kind 4 has its own `seen` Set below.
+      if (ev.kind === 1059) knownWrapIds.add(ev.id);
       if (__DEV__) console.log(`[Nostr] live evt kind=${ev.kind} recv ${ev.id.slice(0, 8)}`);
       if (cancelled) return;
       if (seen.has(ev.id)) {
@@ -3487,7 +3512,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         try {
           const seedRaw = await AsyncStorage.getItem(wrapCacheKey);
           const seedCache = safeParseRecord<Nip17CacheEntry>(seedRaw);
-          knownWrapIds = new Set(Object.keys(seedCache));
+          for (const id of Object.keys(seedCache)) knownWrapIds.add(id);
           if (__DEV__) {
             console.log(
               `[Nostr] live DM sub: seeded knownWrapIds with ${knownWrapIds.size} cached wraps`,

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -1487,6 +1487,14 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     clearMemoisedSecretKey();
     setAmberNip44Permission('unknown');
     nip04PlaintextCache.clear();
+    // Drop the in-memory NIP-17 wrap-id dedup Set — without this, a
+    // sign-out then sign-back-in to the SAME pubkey would keep wrap
+    // ids from the prior session alive in memory, and any wrap whose
+    // on-disk cache entry got wiped by `wipeAccountCaches` below
+    // would be permanently skipped by the live-sub early-return
+    // (since the in-memory Set would still claim "seen"). Per Copilot
+    // review on #508.
+    knownWrapIdsRef.current = { pubkey: null, set: new Set() };
     const loggedOutPubkey = pubkey;
     await SecureStore.deleteItemAsync(NSEC_KEY);
     await SecureStore.deleteItemAsync(PUBKEY_KEY);

--- a/src/services/groupMessagesStorageService.ts
+++ b/src/services/groupMessagesStorageService.ts
@@ -92,3 +92,35 @@ export async function appendGroupMessage(
 export async function clearGroupMessages(groupId: string): Promise<void> {
   await AsyncStorage.removeItem(KEY(groupId));
 }
+
+// Scan AsyncStorage for every `group_messages_*` blob and return the
+// set of message ids that look like NIP-17 wrap ids (64-char hex —
+// `local_*` optimistic rows are excluded). Used by NostrContext to
+// pre-seed `knownWrapIds` on cold start so the live DM sub doesn't
+// redundantly decrypt + re-route group wraps it already processed in
+// a previous session. Single AsyncStorage round-trip per stored group.
+const WRAP_ID_PATTERN = /^[0-9a-f]{64}$/;
+export async function listPersistedGroupWrapIds(): Promise<string[]> {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const groupKeys = keys.filter((k) => k.startsWith('group_messages_'));
+    if (groupKeys.length === 0) return [];
+    const pairs = await AsyncStorage.multiGet(groupKeys);
+    const ids: string[] = [];
+    for (const [, raw] of pairs) {
+      if (!raw) continue;
+      try {
+        const parsed = JSON.parse(raw) as GroupMessage[];
+        if (!Array.isArray(parsed)) continue;
+        for (const m of parsed) {
+          if (typeof m.id === 'string' && WRAP_ID_PATTERN.test(m.id)) ids.push(m.id);
+        }
+      } catch {
+        // Skip malformed blob — better than aborting the whole scan.
+      }
+    }
+    return ids;
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a NIP-17 redundancy bug not caught by #506: when the live DM-sub useEffect re-runs (relay-list refresh adds a relay 9 s into cold start), the new instance previously created a fresh in-memory dedup Set and re-seeded from disk. Disk lagged the live work by the deferred `writeChain` window, so re-streamed wraps got fully decrypted + group-routed all over again.

## Repro

On the AVD (`emulator-5554`) signed in as Big Piggy with 230 seeded NIP-17 wraps in the inbox (`scripts/seed-piggy-dms.mjs 200` then 30 from earlier):

```
$ adb logcat ReactNativeJS:V | grep "live DM sub.*seeded\|live wrap.*routed"
[Nostr] live DM sub: seeded knownWrapIds with 113 cached wraps   ← sub #1 (4 relays)
[Nostr] live DM sub: seeded knownWrapIds with 113 cached wraps   ← sub #2 (5 relays) — SAME 113
... 38 wraps group-routed ...
```

Sub #2 seeds with the same 113 because the 22 wraps sub #1 just processed haven't been persisted yet. Both subs route those wraps → 2× work.

## Fix

1. Lift `knownWrapIds` into a `useRef` keyed by `viewerPubkey` so the Set survives effect re-runs. AsyncStorage seed now `union`s into the existing Set rather than replacing it.
2. In `handleInboxEvent`, add `ev.id` to `knownWrapIds` **immediately** after the kind-1059 early-return check passes — before any async work. The trailing `writeChain` add calls stay but become idempotent no-ops.

## After

| metric | before | after |
|---|---:|---:|
| live `kind=1059` arrivals logged | 46 | 24 |
| group-routed wraps | 38 | 19 |
| sub #2 seeded count | 113 | 135 |

**Wall-clock cold-start → SendSheet "Scan" visible: ~30 s, essentially unchanged.** That path is dominated by other work (BDK hot-wallet init runs 4×, NWC handshake, bundle load on dev). This PR is correctness for the NIP-17 path. The remaining 30 s wall-clock budget is the v1.0.3 perf focus once we instrument the other hot paths.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [x] `npx eslint` clean for the changed file (one pre-existing warning at L1373 unchanged)
- [x] Verified on AVD with 230 seeded wraps — counts halve, sub #2 seed grows from 113 → 135 to reflect carry-over
- [ ] Validate no regression in 1-on-1 DM live receive (Maestro `test-nip17-send-1on1.yaml`)
- [ ] Validate dmMessageListeners still fire for new wraps in an open conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #490