### PR TITLE
fix(dm): persist optimistic local- messages so a back-then-reopen doesn't drop them

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -444,6 +444,12 @@ function mergeInboxEntries(
   return all.slice(0, cap);
 }
 
+// Window in seconds to match a fresh real-id message against a pending
+// optimistic local- echo (same fromMe + same text). Mirrors
+// appendGroupMessage's LOCAL_ECHO_MATCH_WINDOW_SECS so the same UX
+// invariant — one bubble per send, not two — holds across 1:1 + group.
+const LOCAL_DM_ECHO_WINDOW_SECS = 30;
+
 function mergeConversationMessages(
   cached: ConversationMessage[],
   fresh: ConversationMessage[],
@@ -451,7 +457,30 @@ function mergeConversationMessages(
 ): ConversationMessage[] {
   const map = new Map<string, ConversationMessage>();
   for (const m of cached) map.set(m.id, m);
-  for (const m of fresh) map.set(m.id, m);
+  for (const m of fresh) {
+    // When a real (non-local-) entry arrives, drop any pending local-
+    // echo with matching fromMe + text within the echo window. Without
+    // this the user would see two bubbles for the same GIF/text: the
+    // optimistic local- row persisted by ConversationScreen on send,
+    // plus the NIP-17 self-wrap echo from the relay.
+    if (!m.id.startsWith('local-')) {
+      let bestKey: string | null = null;
+      let bestDelta = Infinity;
+      for (const [k, prev] of map) {
+        if (!k.startsWith('local-')) continue;
+        if (prev.fromMe !== m.fromMe) continue;
+        if (prev.text !== m.text) continue;
+        const delta = Math.abs(prev.createdAt - m.createdAt);
+        if (delta > LOCAL_DM_ECHO_WINDOW_SECS) continue;
+        if (delta < bestDelta) {
+          bestDelta = delta;
+          bestKey = k;
+        }
+      }
+      if (bestKey !== null) map.delete(bestKey);
+    }
+    map.set(m.id, m);
+  }
   const all = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
   if (all.length <= cap) return all;
   // Keep the newest DM_CONV_CAP messages; drop oldest.
@@ -587,6 +616,15 @@ interface NostrContextType {
     recipientPubkey: string,
     plaintext: string,
   ) => Promise<{ success: boolean; error?: string }>;
+  /**
+   * Persist an optimistic local- DM message to the per-conversation
+   * cache so it survives navigating away + back before the NIP-17
+   * self-wrap echo arrives. The matching merge dedup against the real
+   * relay echo lives in `mergeConversationMessages`. Without this,
+   * leaving the thread after sending a GIF (or any message) would
+   * drop the optimistic bubble until the relay round-trip completes.
+   */
+  appendLocalDmMessage: (otherPubkey: string, msg: ConversationMessage) => Promise<void>;
   /**
    * Send a NIP-17 group chat message to multiple recipients. Builds one
    * kind-14 rumor with `subject` + `p` tags for every member, then NIP-59
@@ -2178,6 +2216,43 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     [pubkey],
   );
 
+  const appendLocalDmMessage = useCallback(
+    async (otherPubkey: string, msg: ConversationMessage): Promise<void> => {
+      if (!pubkey) return;
+      const normalized = otherPubkey.trim().toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(normalized)) return;
+      try {
+        const key = convCacheKey(pubkey, normalized);
+        const raw = await AsyncStorage.getItem(key);
+        const existing: ConversationMessage[] = raw
+          ? (() => {
+              try {
+                const parsed = JSON.parse(raw);
+                return Array.isArray(parsed) ? parsed : [];
+              } catch {
+                return [];
+              }
+            })()
+          : [];
+        // Dedup on id (same key would arise from a double-tap retry).
+        const map = new Map<string, ConversationMessage>();
+        for (const m of existing) map.set(m.id, m);
+        map.set(msg.id, msg);
+        const merged = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
+        const capped =
+          merged.length <= DM_CONV_CAP ? merged : merged.slice(merged.length - DM_CONV_CAP);
+        await AsyncStorage.setItem(key, JSON.stringify(capped));
+      } catch {
+        // Swallow — the in-memory setMessages above already painted the
+        // bubble. The remount-after-back regression is precisely what
+        // this method exists to fix, so a write failure is unfortunate
+        // but not destructive (next relay echo will repopulate the
+        // cache).
+      }
+    },
+    [pubkey],
+  );
+
   const fetchConversation = useCallback(
     async (otherPubkey: string): Promise<ConversationMessage[]> => {
       if (!pubkey || !isLoggedIn) return [];
@@ -3543,6 +3618,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       publishGroupState,
       fetchConversation,
       getCachedConversation,
+      appendLocalDmMessage,
       dmInbox,
       dmInboxLoading,
       refreshDmInbox,
@@ -3575,6 +3651,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       publishGroupState,
       fetchConversation,
       getCachedConversation,
+      appendLocalDmMessage,
       dmInbox,
       dmInboxLoading,
       refreshDmInbox,

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -60,6 +60,13 @@ import {
  * path free and avoid serialising full-bundle JSON on every decrypt.
  */
 const nip04PlaintextCache = new LRUCache<string, string>({ max: 1000 });
+
+// Per-(viewer,partner) serialization chain for the optimistic local-
+// message disk-cache writes. Without this, two rapid sends (e.g.
+// double-tap retry, or two sequential tap-share-from-attach) could
+// each read-modify-write the conversation blob concurrently — last
+// write wins, losing the prior optimistic row. Per Copilot review #509.
+const appendLocalDmChains = new Map<string, Promise<void>>();
 export function __clearNip04PlaintextCacheForTests() {
   nip04PlaintextCache.clear();
 }
@@ -2221,34 +2228,49 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       if (!pubkey) return;
       const normalized = otherPubkey.trim().toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(normalized)) return;
-      try {
-        const key = convCacheKey(pubkey, normalized);
-        const raw = await AsyncStorage.getItem(key);
-        const existing: ConversationMessage[] = raw
-          ? (() => {
-              try {
-                const parsed = JSON.parse(raw);
-                return Array.isArray(parsed) ? parsed : [];
-              } catch {
-                return [];
-              }
-            })()
-          : [];
-        // Dedup on id (same key would arise from a double-tap retry).
-        const map = new Map<string, ConversationMessage>();
-        for (const m of existing) map.set(m.id, m);
-        map.set(msg.id, msg);
-        const merged = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
-        const capped =
-          merged.length <= DM_CONV_CAP ? merged : merged.slice(merged.length - DM_CONV_CAP);
-        await AsyncStorage.setItem(key, JSON.stringify(capped));
-      } catch {
-        // Swallow — the in-memory setMessages above already painted the
-        // bubble. The remount-after-back regression is precisely what
-        // this method exists to fix, so a write failure is unfortunate
-        // but not destructive (next relay echo will repopulate the
-        // cache).
-      }
+      // Serialize concurrent appends to the same conversation. Without
+      // this, two rapid sends could both read the same `existing` array,
+      // each merge their msg, both write back — last write wins, the
+      // earlier optimistic row is silently lost. Per Copilot review #509.
+      const chainKey = `${pubkey}:${normalized}`;
+      const prev = appendLocalDmChains.get(chainKey) ?? Promise.resolve();
+      const next = prev.then(async () => {
+        try {
+          const key = convCacheKey(pubkey, normalized);
+          const raw = await AsyncStorage.getItem(key);
+          const existing: ConversationMessage[] = raw
+            ? (() => {
+                try {
+                  const parsed = JSON.parse(raw);
+                  return Array.isArray(parsed) ? parsed : [];
+                } catch {
+                  return [];
+                }
+              })()
+            : [];
+          // Dedup on id (same key would arise from a double-tap retry).
+          const map = new Map<string, ConversationMessage>();
+          for (const m of existing) map.set(m.id, m);
+          map.set(msg.id, msg);
+          const merged = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
+          const capped =
+            merged.length <= DM_CONV_CAP ? merged : merged.slice(merged.length - DM_CONV_CAP);
+          await AsyncStorage.setItem(key, JSON.stringify(capped));
+        } catch {
+          // Swallow — the in-memory setMessages above already painted
+          // the bubble. The remount-after-back regression is precisely
+          // what this method exists to fix, so a write failure is
+          // unfortunate but not destructive (next relay echo will
+          // repopulate the cache).
+        }
+      });
+      // `.catch` on the chain entry so a single failure doesn't poison
+      // every subsequent append on this conversation.
+      appendLocalDmChains.set(
+        chainKey,
+        next.catch(() => {}),
+      );
+      await next;
     },
     [pubkey],
   );

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -156,6 +156,7 @@ const ConversationScreen: React.FC = () => {
     fetchConversation,
     getCachedConversation,
     sendDirectMessage,
+    appendLocalDmMessage,
     signEvent,
     contacts,
     relays,
@@ -488,6 +489,25 @@ const ConversationScreen: React.FC = () => {
     }
   }, [load]);
 
+  // Append an optimistic local- message to BOTH React state (instant
+  // paint) AND the per-conversation cache on disk (survives back-then-
+  // reopen before the NIP-17 self-wrap echo arrives). The merge-side
+  // dedup in mergeConversationMessages drops this local- row when the
+  // real wrap echoes back from the relay.
+  const appendOptimisticLocal = useCallback(
+    (text: string) => {
+      const optimistic = {
+        id: `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        fromMe: true,
+        text,
+        createdAt: Math.floor(Date.now() / 1000),
+      };
+      setMessages((prev) => [...prev, optimistic]);
+      void appendLocalDmMessage(pubkey, optimistic);
+    },
+    [appendLocalDmMessage, pubkey],
+  );
+
   const handleSend = useCallback(async () => {
     const text = draft.trim();
     if (!text || sending) return;
@@ -499,17 +519,11 @@ const ConversationScreen: React.FC = () => {
         return;
       }
       setDraft('');
-      const optimistic = {
-        id: `local-${Date.now()}`,
-        fromMe: true,
-        text,
-        createdAt: Math.floor(Date.now() / 1000),
-      };
-      setMessages((prev) => [...prev, optimistic]);
+      appendOptimisticLocal(text);
     } finally {
       setSending(false);
     }
-  }, [draft, sending, sendDirectMessage, pubkey]);
+  }, [draft, sending, sendDirectMessage, pubkey, appendOptimisticLocal]);
 
   const handleShareLocation = useCallback(async () => {
     if (sharingLocation) return;
@@ -551,15 +565,7 @@ const ConversationScreen: React.FC = () => {
                 if (!sendResult.success) {
                   Alert.alert('Send failed', sendResult.error ?? 'Could not send location.');
                 } else {
-                  setMessages((prev) => [
-                    ...prev,
-                    {
-                      id: `local-${Date.now()}`,
-                      fromMe: true,
-                      text,
-                      createdAt: Math.floor(Date.now() / 1000),
-                    },
-                  ]);
+                  appendOptimisticLocal(text);
                 }
                 resolve();
               },
@@ -576,7 +582,7 @@ const ConversationScreen: React.FC = () => {
     } finally {
       setSharingLocation(false);
     }
-  }, [sharingLocation, name, pubkey, sendDirectMessage]);
+  }, [sharingLocation, name, pubkey, sendDirectMessage, appendOptimisticLocal]);
 
   // Shared send-image path for both gallery and camera entry points.
   // Strips EXIF from the picked image, uploads to the user's configured
@@ -593,22 +599,14 @@ const ConversationScreen: React.FC = () => {
           Alert.alert('Send failed', sendResult.error ?? 'Could not send image.');
           return;
         }
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `local-${Date.now()}`,
-            fromMe: true,
-            text: url,
-            createdAt: Math.floor(Date.now() / 1000),
-          },
-        ]);
+        appendOptimisticLocal(url);
       } catch (error) {
         Alert.alert('Upload failed', error instanceof Error ? error.message : 'Please try again.');
       } finally {
         setUploadingImage(false);
       }
     },
-    [signEvent, sendDirectMessage, pubkey],
+    [signEvent, sendDirectMessage, pubkey, appendOptimisticLocal],
   );
 
   const handlePickAndSendImage = useCallback(async () => {
@@ -670,17 +668,9 @@ const ConversationScreen: React.FC = () => {
         Alert.alert('Share failed', result.error ?? 'Could not share contact.');
         return;
       }
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `local-${Date.now()}`,
-          fromMe: true,
-          text: payload,
-          createdAt: Math.floor(Date.now() / 1000),
-        },
-      ]);
+      appendOptimisticLocal(payload);
     },
-    [pubkey, sendDirectMessage, contacts, relays],
+    [pubkey, sendDirectMessage, contacts, relays, appendOptimisticLocal],
   );
 
   const handleSendGif = useCallback(
@@ -693,21 +683,9 @@ const ConversationScreen: React.FC = () => {
         Alert.alert('Send failed', result.error ?? 'Could not send GIF.');
         return;
       }
-      // `local-<ms>` on its own collides if two sends land in the same
-      // millisecond (e.g. a double-tap on a slow network). Append a
-      // short random suffix so the FlatList keyExtractor stays unique.
-      const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: localId,
-          fromMe: true,
-          text: payload,
-          createdAt: Math.floor(Date.now() / 1000),
-        },
-      ]);
+      appendOptimisticLocal(payload);
     },
-    [pubkey, sendDirectMessage],
+    [pubkey, sendDirectMessage, appendOptimisticLocal],
   );
 
   const openLocation = useCallback((loc: SharedLocation) => {
@@ -1107,15 +1085,7 @@ const ConversationScreen: React.FC = () => {
           lightningAddress: lightningAddress ?? null,
         }}
         onSent={(payload) => {
-          setMessages((prev) => [
-            ...prev,
-            {
-              id: `local-${Date.now()}`,
-              fromMe: true,
-              text: payload,
-              createdAt: Math.floor(Date.now() / 1000),
-            },
-          ]);
+          appendOptimisticLocal(payload);
         }}
       />
       <SendSheet


### PR DESCRIPTION
## Summary

After sending a GIF (or any 1:1 DM message) and tapping back, re-entering the conversation showed an empty thread until the NIP-17 self-wrap echo arrived from the relays — could be seconds, minutes, or never on a flaky relay set.

Reported by @bengweeks on a real-device send to Ninimonk05: "I sent her a GIF. It appeared in the chat, but then when I exited (back) and opened the chat again it was gone."

## Root cause

The optimistic local- entry was only appended to React state via `setMessages`. The `convCacheKey(viewer, partner)` blob on AsyncStorage was only written by `fetchConversation` after a successful relay round-trip. So:

1. Send → optimistic in React state only.
2. Back → ConversationScreen unmounts, React state lost.
3. Re-enter → `getCachedConversation` reads disk → no GIF (echo hasn't come back yet).
4. (eventually) relay echo arrives → `fetchConversation` writes it to disk → it reappears later.

Groups didn't have this bug because `appendGroupMessage` writes the `local_*` row to `group_messages_<groupId>` synchronously on every append (see #402 / `LOCAL_ECHO_MATCH_WINDOW_SECS`).

## Fix

1. New `appendLocalDmMessage(otherPubkey, msg)` on `NostrContext` — writes the local- entry into `convCacheKey` and caps to `DM_CONV_CAP`.
2. `mergeConversationMessages` now drops a pending local- row when a fresh real-id row arrives with matching `fromMe` + matching `text` within 30 s (mirrors the group surface's `LOCAL_ECHO_MATCH_WINDOW_SECS` in `appendGroupMessage`). Prevents duplicate bubbles once the relay echo lands.
3. `ConversationScreen` now has a single `appendOptimisticLocal(text)` helper that fans out to BOTH `setMessages` (instant paint) AND `appendLocalDmMessage` (disk persist). All 6 optimistic-append sites — text, location, image, contact, GIF, invoice — now route through it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [x] `npx eslint` clean (only pre-existing warnings)
- [ ] Manual smoke: send a GIF in a 1:1 thread, back, re-enter — GIF is visible immediately.
- [ ] Manual smoke: send a text, wait for the NIP-17 echo to land (a few seconds), confirm only ONE bubble visible (echo-dedup worked).
- [ ] No regression in the group send path — groups use their own `appendGroupMessage` and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #511