### PR TITLE
docs(troubleshooting): cold-start freeze investigation toolkit

### DIFF
--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -42,6 +42,15 @@ adb shell ime set com.google.android.inputmethod.latin/com.android.inputmethod.l
 | App unresponsive after Nostr login (20s lockup)
 | Wrap `setContacts` calls in `startTransition()`, use `InteractionManager.runAfterInteractions` to defer network I/O, add `freezeOnBlur: true` to tab navigator, and yield to event loop between profile fetch batches with `setTimeout(r, 50)`.
 
+| Cold-start "tap Send button feels frozen for ~12 s" but the Maestro perf script reports ~1 s
+| Maestro taps immediately after `HomeScreen first render` (fast ~1 s on Pixel). The real freeze starts 3-7 s LATER when zap-counterparty / profile resolvers run N sequential relay round-trips on the JS thread. A user-driven tap lands INSIDE that window and waits up to 12 s for the queue to drain. +
+*Diagnostic tools (all gated by `EXPO_PUBLIC_KEEP_PERF_LOGS=1` at build time):* +
+1. **JS-thread heartbeat** — `perfHeartbeatStart()` in `src/utils/perfLog.ts` self-schedules every 100 ms and logs the gap between scheduled-fire and actual-fire. Gap > 200 ms is a stutter; > 1 s is a freeze. Captures freezes without needing a tap. +
+2. **Multi-window tap-latency script** — `scripts/perf-cold-tap-windows.sh` cold-starts once per offset and taps Send at +0/+500/+1.5k/+3k/+5k/+7k/+10k/+13k ms after Home renders. Plots tap-to-onPress latency as a curve so the freeze window is visible. +
+3. **`perfLog(tag)`** sprinkled at every cold-start boundary (`WalletProvider first render`, `HomeScreen first render`, `WalletCarousel first render (N wallets)`, `TransactionList first render (N txs)`, `resolveZapSenders[id]: start/done`, etc.). A single `adb logcat \| grep "\[Perf\]"` gives the full attribution. +
+*Common cause + fix:* sequential `await fetchProfile(pk, relays)` in a `for...of` loop over N transactions. Each iteration is one relay round-trip (~500-2000 ms). Replace with two-phase batch: collect all pubkeys → one `zapSenderProfileStorage.getMany([...pks])` from disk → one `nostrService.fetchProfiles(missing, relays)` for the remainder. The incoming branch of `resolveZapSendersForWallet` already used this pattern; the outgoing branch did not until PR #510. +
+*Build a perf-instrumented APK to investigate on a real device:* `EXPO_PUBLIC_KEEP_PERF_LOGS=1 eas build --local --profile production --platform android --non-interactive --output /tmp/lp-perf.apk`. `babel.config.js` skips `transform-remove-console` and `perfLog.ts` honours the same env flag, so `[Perf]` lines survive in the release APK. **Never ship a real release build with the flag set.**
+
 | `npx expo start` fails but `npm start` works
 | The `start` script includes `--dev-client` which is required for custom native modules. Always use `npm start`.
 


### PR DESCRIPTION
## Summary

Captures the diagnostic playbook we built while chasing the ~12 s "Send button feels frozen" symptom on a real Pixel (closed via #510):

- JS-thread **heartbeat** in `perfLog.ts` — `setTimeout(cb, 100)` self-recurring loop; logs the gap between scheduled-fire and actual-fire. Gap > 200 ms = stutter, > 1 s = freeze. **Captures freezes without needing a user tap.**
- **`scripts/perf-cold-tap-windows.sh`** — cold-starts once per offset, taps Send at +0/+0.5/+1.5/+3/+5/+7/+10/+13 s after Home renders. Plots tap-to-onPress latency as a curve so freezes that start AFTER a single tap show up.
- **`[Perf]` markers** at every cold-start boundary (`WalletProvider first render`, `HomeScreen first render`, `WalletCarousel first render (N wallets)`, `TransactionList first render (N txs)`, `resolveZapSenders[id]: start/done`, etc.). Single `adb logcat \| grep '[Perf]'` gives full attribution.
- The **"sequential `await fetchProfile` in a loop" anti-pattern** + the two-phase batch fix.
- **Build recipe** for a perf-instrumented APK via `EXPO_PUBLIC_KEEP_PERF_LOGS=1`.

So the next dev or AI chasing a similar freeze starts from a checklist instead of from scratch.

## Test plan

- [x] docs-only change; tsc / eslint / prettier unaffected
- [x] Renders cleanly in GitHub's AsciiDoc preview