### PR TITLE
chore(android): bump versionCode 64 -> 65

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -146,7 +146,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     //   eas build:list --platform android --status finished --limit 1
     //
     // See docs/DEPLOYMENT.adoc → "Local production builds".
-    versionCode: 64,
+    versionCode: 65,
   },
   web: {
     favicon: './assets/favicon.png',


### PR DESCRIPTION
## Summary

Bump the local-build versionCode floor in `app.config.ts` so subsequent local APK builds can install over the current dev/perf-test installs (Pixel currently at 63, previous v62 / v64 builds landed in between).

EAS *cloud* production builds use the remote counter from `eas.json` and ignore this — affects only local builds.

## Test plan

- [x] Local build matches new floor