### PR TITLE
chore(release): prepare v1.0.3 release — notes + version bump

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -12,23 +12,9 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ## What to test in the next release
 
-- New: pick a fiat currency from a searchable list of 38 (USD/EUR/GBP pinned at the top; DKK, KRW, CNY, INR and more supported). Account → Currency.
-- New: confirmation prompt before any Lightning send or wallet transfer at or above 10,000 sats. Threshold is configurable (Off / 1k / 10k / 100k / Custom) under Account → Security.
-- New: friends-profile sheet now shows the friend's npub QR code, a "Copy lud16" button, and a "Write to NFC tag" affordance directly on the bottom sheet.
-- Polish: amount-entry SATS↔fiat swap is now a bright pink pill with a white arrow instead of a small grey arrow — much easier to tap.
-- Fix: outgoing payments now record the counterparty correctly — sent zaps show the friend's avatar and name in the conversation thread.
-- Fix: Amber-signed NIP-17 group messages now send end-to-end (raw-JSON Intent encoding fix; was breaking kind-13 seals).
-- Fix: "Type message" composer in conversations no longer briefly jumps to the top of the screen on first open.
-- Fix: action row on the friends-profile sheet no longer overflows on narrower phone screens.
-- Perf: slow Lightning payments (e.g. via Boltz/RBTC swaps that take 30–90 s to settle) no longer mis-report as failed — wait extends to 90 s with an honest "still in flight" message; the conversation bubble only turns red on a definitive failure.
-- Perf: Lightning-zap sender avatars render instantly on cold start instead of waiting for a relay round-trip.
-- Perf: home wallet card clears the "Disconnected" indicator noticeably faster on cold app launch.
-- Perf: avatar grids no longer hit a decode-error storm when a contact has an unsupported image URL (`.svg` / `.heic`).
-- New: Transfer can now send to a wallet in a different signed-in profile — pick the destination profile from a new "Profile" dropdown under "To". Display names show up when cached. Default behaviour unchanged for single-profile users.
-- New: Send to a Bitcoin address from a Lightning wallet now persists the swap — a force-stop or network hiccup mid-flight can be recovered via "Retry now" or on next app launch. Previously a failed claim could leave funds stuck.
-- New: group conversation header now reads "3 members" not "2 members" — you're now counted, with a "· you" tag on your own row in the members sheet. Mirrors Signal / WhatsApp.
-- Polish: Revolut and Xapo wallet card wordmarks no longer overlap the balance text — the brand sits flush in the lower-right of the card.
-- Polish: Send button on Home is now greyed out when the active wallet is receive-only (Xapo deposit address, watch-only xpub) — taps no longer open a Send sheet that can't sign.
-- Polish: the `⋯` (open Account Switcher / add another nsec) button in the side drawer is right-aligned again — was collapsing left next to the avatar for single-profile users.
-- Perf: several improvements to reduce cold-start JS-thread contention — more frequent yielding while draining the inbox, deduped NIP-04 deprecation log spam, a brief grace window before the bulk relay/profile refresh fires, an event-loop yield between each live-sub wrap decrypt, and cached gift-wraps no longer re-fire listeners. `console.log` calls are stripped from production bundles too. Heavy phones may still see a brief unresponsive window on first launch — more work to come in 1.0.3.
-
+- Fix: cold-start "Send button feels frozen for ~12 s" is gone — tap Send the moment Home appears and the bottom sheet opens within ~1 s on real hardware. Same for Receive and Transfer.
+- Fix: sending a GIF (or text, image, location, contact, invoice) in a 1:1 conversation no longer disappears when you tap back and reopen the chat — the bubble persists immediately, and dedups cleanly when the relay echo lands.
+- Perf: fiat balance (GBP / USD / etc.) renders on cold start from cache instead of being blank for 1-3 s while the BTC price fetch round-trips.
+- Perf: Nostr profile + relay list hydrate from cache on first paint, so own avatar + name appear in the drawer immediately instead of waiting on a relay round-trip.
+- Perf: messages tab populates faster on cold start — wrap-ID dedup carries across the live-DM sub re-open so the relay re-stream doesn't re-decrypt + re-route everything it already saw.
+- Perf: outgoing zap counterparty names + avatars resolve in a single batched relay round-trip instead of one query per transaction — fixes the multi-second JS-thread freeze when the transaction list has many unresolved senders.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Summary

Bumps `package.json` 1.0.2 → 1.0.3 and resets `docs/RELEASE_NOTES_NEXT.md` to the user-visible changes in this release so the release workflow publishes them as TestFlight "What to Test" notes after the tag.

## What's in v1.0.3

Merged PRs (since v1.0.2):

- **#503** — eager-hydrate profile + relays from cache on bootstrap
- **#508** — carry knownWrapIds across live-sub re-opens + seed from group msgs + logout reset
- **#509** — persist optimistic local-DM messages so a back-then-reopen doesn't drop them
- **#510** — cut cold-start tap latency 12 s → ~1 s on real Pixel (cached BTC price, no eager BDK, gated live NIP-17 sub on DM-surface focus, batched outgoing zap fetch)
- #507 — seed-piggy-dms test corpus script (dev helper, not user-visible)
- #512 — TROUBLESHOOTING.adoc cold-start playbook (dev docs)

## Release plan

1. Merge this PR.
2. Tag the resulting `main` commit as `v1.0.3`: `git tag v1.0.3 <merge-commit> && git push --tags`.
3. Draft + publish a GitHub Release for `v1.0.3` — the Release workflow then auto-builds production for iOS + Android, submits iOS to TestFlight, attaches the Android APK to the release page.

## Test plan

- [x] Notes content double-checked: tester-facing, one-line bullets, only user-visible changes.
- [x] `package.json` + `package-lock.json` versions match.
- [ ] After tag publish: confirm Actions → Release run, iOS build lands in TestFlight, Android APK attached to release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)