### PR TITLE
feat(preview): purple adaptive-icon background for preview variant (#529)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -118,16 +118,16 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ],
   android: {
     adaptiveIcon: {
-      // Dev variant uses a flat blue backgroundColor so it's visibly
-      // distinct in the launcher next to a production install. The
-      // backgroundImage takes precedence in Expo's adaptive-icon
-      // template, so we deliberately drop it for dev — that lets the
-      // backgroundColor line up against the foreground piggy and you
-      // can see at a glance which icon is which when both are
-      // installed alongside each other.
-      backgroundColor: IS_DEV ? '#4A90D9' : '#E6F4FE',
+      // Dev variant uses a flat blue backgroundColor and preview uses
+      // a flat purple — both drop the backgroundImage so the flat color
+      // dominates and the icon is recognisable in the launcher next to
+      // a production install. backgroundImage takes precedence in Expo's
+      // adaptive-icon template, so we deliberately omit it for the two
+      // non-prod variants. Production keeps the layered pink/blue
+      // background image.
+      backgroundColor: IS_DEV ? '#4A90D9' : IS_PREVIEW ? '#8B5CF6' : '#E6F4FE',
       foregroundImage: './assets/android-icon-foreground.png',
-      ...(IS_DEV ? {} : { backgroundImage: './assets/android-icon-background.png' }),
+      ...(IS_DEV || IS_PREVIEW ? {} : { backgroundImage: './assets/android-icon-background.png' }),
       monochromeImage: './assets/android-icon-monochrome.png',
     },
     predictiveBackGestureEnabled: false,


### PR DESCRIPTION
## Summary

Adds a third visually-distinct adaptive icon for the **preview** Android variant, mirroring the dev variant's flat-blue treatment with a flat purple (`#8B5CF6`, Tailwind violet-500). Production keeps its layered pink/blue background image.

Why: the three variants (`com.lightningpiggy.app` / `.dev` / `.preview`) coexist on the same device during release validation. Telling them apart at a glance in the launcher matters — particularly when sideloading a preview build for perf testing while the user's real prod install is sitting next to it.

Mechanism: same as dev — drop `backgroundImage` so the flat `backgroundColor` dominates. One file changed (`app.config.ts`), nine lines.

Stacked on top of #488 (Explore tab) since it touches the same `IS_PREVIEW` branch in `app.config.ts`; rebase will be clean once #488 lands.

Closes #529

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `eas build --local --profile preview --platform android` produces an APK whose adaptive icon shows a purple square in the Pixel launcher
- [ ] Sideloaded preview APK installs alongside the existing `com.lightningpiggy.app` (different package, no conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)