### PR TITLE
perf(nostr): byte-cap DM caches to stop the cold-start stall (#543)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -507,6 +507,13 @@ const DM_CONV_CACHE_PREFIX = 'nostr_dm_conv_v1_';
 const DM_CONV_LAST_SEEN_PREFIX = 'nostr_dm_conv_last_seen_v1_';
 const DM_INBOX_CAP = 1000;
 const DM_CONV_CAP = 500;
+// Hard byte ceiling for a single DM cache row. Android's SQLite
+// CursorWindow caps a row at ~2 MB — past it the *read* throws
+// SQLiteBlobTooBigException, the cache silently fails to hydrate, and
+// every cold start falls back to a full relay restream + NIP-17
+// re-decrypt (a ~70s JS-thread stall). The count caps above aren't
+// enough when messages are long, so the merge fns trim by size too.
+const DM_CACHE_MAX_BYTES = 1_500_000;
 
 function inboxCacheKey(user: string) {
   return DM_INBOX_CACHE_PREFIX + user;
@@ -569,7 +576,13 @@ function mergeInboxEntries(
   for (const e of cached) map.set(dedupKey(e), e);
   for (const e of fresh) map.set(dedupKey(e), e);
   const all = Array.from(map.values()).sort((a, b) => b.createdAt - a.createdAt);
-  return all.slice(0, cap);
+  let result = all.slice(0, cap);
+  // Byte guard (see DM_CACHE_MAX_BYTES). Sorted newest-first, so trim
+  // the tail to drop the oldest entries until the blob fits.
+  while (result.length > 1 && JSON.stringify(result).length > DM_CACHE_MAX_BYTES) {
+    result = result.slice(0, Math.ceil(result.length * 0.8));
+  }
+  return result;
 }
 
 // Window in seconds to match a fresh real-id message against a pending
@@ -610,9 +623,14 @@ function mergeConversationMessages(
     map.set(m.id, m);
   }
   const all = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
-  if (all.length <= cap) return all;
   // Keep the newest DM_CONV_CAP messages; drop oldest.
-  return all.slice(all.length - cap);
+  let result = all.length <= cap ? all : all.slice(all.length - cap);
+  // Byte guard (see DM_CACHE_MAX_BYTES). Sorted oldest-first, so trim
+  // the head to drop the oldest messages until the blob fits.
+  while (result.length > 1 && JSON.stringify(result).length > DM_CACHE_MAX_BYTES) {
+    result = result.slice(Math.floor(result.length * 0.2));
+  }
+  return result;
 }
 
 const NSEC_KEY = 'nostr_nsec';

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -12,7 +12,11 @@ import { InteractionManager } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { LRUCache } from '../utils/lru';
-import { evictNip17CacheOverflow, touchNip17CacheEntry } from '../utils/nip17Cache';
+import {
+  evictNip17CacheBytes,
+  evictNip17CacheOverflow,
+  touchNip17CacheEntry,
+} from '../utils/nip17Cache';
 import * as nip19 from 'nostr-tools/nip19';
 import * as nostrService from '../services/nostrService';
 import * as amberService from '../services/amberService';
@@ -319,12 +323,16 @@ async function writeNip17Cache(
   cache: Record<string, Nip17CacheEntry>,
 ): Promise<number> {
   const evicted = evictNip17CacheOverflow(cache, NIP17_CACHE_CAP);
+  // Byte cap on top of the count cap — a row past Android's ~2 MB
+  // SQLite CursorWindow throws on *read*, silently breaking this
+  // fast-path cache and forcing a full cold-start restream.
+  const evictedBytes = evictNip17CacheBytes(cache, DM_CACHE_MAX_BYTES);
   try {
     await AsyncStorage.setItem(storageKey, JSON.stringify(cache));
   } catch (err) {
     console.warn(`[Nostr] NIP-17 cache write failed (${storageKey}):`, err);
   }
-  return evicted;
+  return evicted + evictedBytes;
 }
 
 /** Yield to the JS event loop so UI interactions can tick between

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -17,6 +17,7 @@ import {
   evictNip17CacheOverflow,
   touchNip17CacheEntry,
 } from '../utils/nip17Cache';
+import { utf8ByteSize } from '../utils/byteSize';
 import * as nip19 from 'nostr-tools/nip19';
 import * as nostrService from '../services/nostrService';
 import * as amberService from '../services/amberService';
@@ -536,6 +537,25 @@ function convLastSeenKey(user: string, peer: string) {
   return DM_CONV_LAST_SEEN_PREFIX + user + '_' + peer;
 }
 
+/**
+ * Read a DM-cache row, treating an unreadable row as empty. Android's
+ * SQLite CursorWindow caps a row at ~2 MB; a row past that throws
+ * `SQLiteBlobTooBigException` on read. Without this guard the throw
+ * aborts the whole refresh/fetch before the write-side byte cap can
+ * rewrite a smaller row — so an already-oversized row would never
+ * self-heal. Catching it (and dropping the poisoned key) lets the next
+ * relay restream repopulate a byte-capped row.
+ */
+async function safeGetDmCacheItem(key: string): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(key);
+  } catch (err) {
+    console.warn(`[Nostr] DM cache row unreadable — dropping ${key}:`, err);
+    AsyncStorage.removeItem(key).catch(() => {});
+    return null;
+  }
+}
+
 /** Read the persisted DM inbox for a user. Used during session restore /
  * post-login so the Messages tab paints from cache on cold start instead
  * of waiting for the relay round-trip + NIP-17 decrypt loop (3-5 s). The
@@ -549,7 +569,7 @@ function convLastSeenKey(user: string, peer: string) {
  * more than the brief render window before that re-filter happens. */
 async function loadDmInboxFromCache(pubkey: string): Promise<DmInboxEntry[]> {
   try {
-    const raw = await AsyncStorage.getItem(inboxCacheKey(pubkey));
+    const raw = await safeGetDmCacheItem(inboxCacheKey(pubkey));
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed : [];
@@ -585,10 +605,14 @@ function mergeInboxEntries(
   for (const e of fresh) map.set(dedupKey(e), e);
   const all = Array.from(map.values()).sort((a, b) => b.createdAt - a.createdAt);
   let result = all.slice(0, cap);
-  // Byte guard (see DM_CACHE_MAX_BYTES). Sorted newest-first, so trim
-  // the tail to drop the oldest entries until the blob fits.
-  while (result.length > 1 && JSON.stringify(result).length > DM_CACHE_MAX_BYTES) {
-    result = result.slice(0, Math.ceil(result.length * 0.8));
+  // Byte guard (see DM_CACHE_MAX_BYTES) — sorted newest-first, so drop
+  // from the tail (oldest). `> 0` not `> 1` so a single over-budget
+  // entry still goes rather than persisting an unreadable row;
+  // `Math.max(1, …)` guarantees forward progress (a 0.1 factor rounds
+  // to 0 for tiny arrays, which would spin forever).
+  while (result.length > 0 && utf8ByteSize(JSON.stringify(result)) > DM_CACHE_MAX_BYTES) {
+    const drop = Math.max(1, Math.floor(result.length * 0.1));
+    result = result.slice(0, result.length - drop);
   }
   return result;
 }
@@ -633,10 +657,12 @@ function mergeConversationMessages(
   const all = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
   // Keep the newest DM_CONV_CAP messages; drop oldest.
   let result = all.length <= cap ? all : all.slice(all.length - cap);
-  // Byte guard (see DM_CACHE_MAX_BYTES). Sorted oldest-first, so trim
-  // the head to drop the oldest messages until the blob fits.
-  while (result.length > 1 && JSON.stringify(result).length > DM_CACHE_MAX_BYTES) {
-    result = result.slice(Math.floor(result.length * 0.2));
+  // Byte guard (see DM_CACHE_MAX_BYTES) — sorted oldest-first, so drop
+  // from the head (oldest). `> 0` not `> 1` so a single over-budget
+  // message still goes; `Math.max(1, …)` guarantees forward progress.
+  while (result.length > 0 && utf8ByteSize(JSON.stringify(result)) > DM_CACHE_MAX_BYTES) {
+    const drop = Math.max(1, Math.floor(result.length * 0.1));
+    result = result.slice(drop);
   }
   return result;
 }
@@ -2466,7 +2492,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       const normalized = otherPubkey.trim().toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(normalized)) return [];
       try {
-        const raw = await AsyncStorage.getItem(convCacheKey(pubkey, normalized));
+        const raw = await safeGetDmCacheItem(convCacheKey(pubkey, normalized));
         if (!raw) return [];
         const parsed = JSON.parse(raw);
         return Array.isArray(parsed) ? parsed : [];
@@ -2553,7 +2579,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       // open so we only ever re-decrypt the (typically 0-few) events
       // that arrived since last open.
       const [convRaw, convLastSeen] = await Promise.all([
-        AsyncStorage.getItem(convCacheKey(pubkey, normalized)),
+        safeGetDmCacheItem(convCacheKey(pubkey, normalized)),
         loadLastSeen(convLastSeenKey(pubkey, normalized)),
       ]);
       const cachedConv: ConversationMessage[] = convRaw
@@ -2673,9 +2699,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           : signerType === 'amber'
             ? perAccountKey(AMBER_NIP17_CACHE_KEY_BASE, pubkey)
             : null;
-      const wrapCacheRaw = signerWrapCacheKey
-        ? await AsyncStorage.getItem(signerWrapCacheKey)
-        : null;
+      const wrapCacheRaw = signerWrapCacheKey ? await safeGetDmCacheItem(signerWrapCacheKey) : null;
       const wrapCache = safeParseRecord<Nip17CacheEntry>(wrapCacheRaw);
       const cachedWrapEntries = Object.values(wrapCache);
       let skippedInboxFetch = false;
@@ -2725,7 +2749,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             // next thread open across ANY conversation can short-circuit
             // without waiting for the next inbox refresh.
             const nsecCacheKey = perAccountKey(NSEC_NIP17_CACHE_KEY_BASE, pubkey);
-            const raw = await AsyncStorage.getItem(nsecCacheKey);
+            const raw = await safeGetDmCacheItem(nsecCacheKey);
             const cache = safeParseRecord<Nip17CacheEntry>(raw);
             const newlyCached: Nip17CacheEntry[] = [];
             let nip17Decrypted = 0;
@@ -2788,7 +2812,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           }
         } else if (signerType === 'amber') {
           const amberCacheKey = perAccountKey(AMBER_NIP17_CACHE_KEY_BASE, pubkey);
-          const raw = await AsyncStorage.getItem(amberCacheKey);
+          const raw = await safeGetDmCacheItem(amberCacheKey);
           const cache = safeParseRecord<Nip17CacheEntry>(raw);
           let threadTouched = 0;
           for (const wrap of kind1059) {
@@ -2952,7 +2976,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           // cached entries before the relay round-trip finishes and
           // (b) only fetch events newer than the last one we saw.
           const [cachedInboxRaw, lastSeen] = await Promise.all([
-            AsyncStorage.getItem(inboxCacheKey(refreshForPubkey)),
+            safeGetDmCacheItem(inboxCacheKey(refreshForPubkey)),
             loadLastSeen(inboxLastSeenKey(refreshForPubkey)),
           ]);
           const cachedInbox: DmInboxEntry[] = cachedInboxRaw
@@ -3077,7 +3101,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               // filter gate below. This is the fix for #176. Per-account
               // namespaced (#288).
               const nsecCacheKey = perAccountKey(NSEC_NIP17_CACHE_KEY_BASE, refreshForPubkey);
-              const raw = await AsyncStorage.getItem(nsecCacheKey);
+              const raw = await safeGetDmCacheItem(nsecCacheKey);
               const cache = safeParseRecord<Nip17CacheEntry>(raw);
               const newlyCached: Nip17CacheEntry[] = [];
               let unfollowedPurged = 0;
@@ -3188,7 +3212,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             // Always run the unwrap loop — Amber's silent content-resolver path returns PERMISSION_NOT_GRANTED on the first wrap if the user hasn't granted nip44_decrypt yet, which we surface via setAmberNip44Permission('denied') so NostrScreen can show the one-shot "Grant permission in Amber" button. Closes #404.
             // Persistent cache keyed by wrap id. Only ever contains rumors from *followed* senders — see the filter gate below. Per-account namespaced (#288).
             const amberCacheKey = perAccountKey(AMBER_NIP17_CACHE_KEY_BASE, refreshForPubkey);
-            const raw = await AsyncStorage.getItem(amberCacheKey);
+            const raw = await safeGetDmCacheItem(amberCacheKey);
             const cache = safeParseRecord<Nip17CacheEntry>(raw);
             const newlyCached: Nip17CacheEntry[] = [];
             let permissionDenied = false;
@@ -3609,7 +3633,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         writeChain = writeChain
           .then(async () => {
             if (cancelled) return;
-            const inboxRaw = await AsyncStorage.getItem(inboxCacheKey(viewerPubkey));
+            const inboxRaw = await safeGetDmCacheItem(inboxCacheKey(viewerPubkey));
             const cachedInbox: DmInboxEntry[] = inboxRaw
               ? (() => {
                   try {
@@ -3794,7 +3818,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           await writeNip17Cache(cacheKey, wrapCache);
           knownWrapIds?.add(wrap.id);
 
-          const inboxRaw = await AsyncStorage.getItem(inboxCacheKey(viewerPubkey));
+          const inboxRaw = await safeGetDmCacheItem(inboxCacheKey(viewerPubkey));
           const cachedInbox: DmInboxEntry[] = inboxRaw
             ? (() => {
                 try {

--- a/src/utils/byteSize.test.ts
+++ b/src/utils/byteSize.test.ts
@@ -1,0 +1,31 @@
+import { utf8ByteSize } from './byteSize';
+
+describe('utf8ByteSize', () => {
+  it('counts ASCII as one byte per character', () => {
+    expect(utf8ByteSize('')).toBe(0);
+    expect(utf8ByteSize('hello')).toBe(5);
+  });
+
+  it('counts 2-byte code points (Latin-1 supplement, e.g. accented chars)', () => {
+    // 'é' is U+00E9 → 2 UTF-8 bytes, 1 UTF-16 unit.
+    expect(utf8ByteSize('é')).toBe(2);
+    expect('é'.length).toBe(1);
+  });
+
+  it('counts 3-byte code points (CJK)', () => {
+    // '中' is U+4E2D → 3 UTF-8 bytes, 1 UTF-16 unit.
+    expect(utf8ByteSize('中')).toBe(3);
+    expect('中'.length).toBe(1);
+  });
+
+  it('counts 4-byte code points (emoji / surrogate pairs)', () => {
+    // '🐷' is U+1F437 → 4 UTF-8 bytes, 2 UTF-16 units (surrogate pair).
+    expect(utf8ByteSize('🐷')).toBe(4);
+    expect('🐷'.length).toBe(2);
+  });
+
+  it('is larger than .length for non-ASCII — the bug the guard depends on', () => {
+    const emojiHeavy = '🐷🐷🐷 hello 中文';
+    expect(utf8ByteSize(emojiHeavy)).toBeGreaterThan(emojiHeavy.length);
+  });
+});

--- a/src/utils/byteSize.ts
+++ b/src/utils/byteSize.ts
@@ -1,0 +1,39 @@
+/**
+ * Exact UTF-8 byte length of a string — the unit Android's SQLite
+ * `CursorWindow` row limit (and AsyncStorage's on-disk JSON) actually
+ * measures.
+ *
+ * `String.prototype.length` counts UTF-16 code units, which undercounts
+ * non-ASCII text: a CJK character is 1 code unit but 3 bytes, an emoji
+ * is 2 code units (a surrogate pair) but 4 bytes. A size guard based on
+ * `.length` can therefore pass while the persisted row is over the
+ * limit and becomes unreadable — so cache byte-caps must use this.
+ *
+ * Allocation-free: walks the string once rather than encoding it into a
+ * Uint8Array (which would allocate a buffer the size of the payload).
+ */
+export function utf8ByteSize(str: string): number {
+  let bytes = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    const code = str.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < str.length) {
+      // High surrogate followed by a low surrogate → a 4-byte code
+      // point. Consume both. A lone surrogate (malformed, never
+      // produced by JSON.stringify of valid data) falls through to 3.
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}

--- a/src/utils/nip17Cache.test.ts
+++ b/src/utils/nip17Cache.test.ts
@@ -14,7 +14,7 @@
  * production.
  */
 
-import { evictNip17CacheOverflow, touchNip17CacheEntry } from './nip17Cache';
+import { evictNip17CacheBytes, evictNip17CacheOverflow, touchNip17CacheEntry } from './nip17Cache';
 
 describe('touchNip17CacheEntry', () => {
   it('returns false and leaves cache untouched when key is absent', () => {
@@ -68,6 +68,34 @@ describe('evictNip17CacheOverflow', () => {
     const evicted = evictNip17CacheOverflow(cache, 3);
     expect(evicted).toBe(2);
     expect(Object.keys(cache)).toEqual(['c', 'd', 'e']);
+  });
+});
+
+describe('evictNip17CacheBytes', () => {
+  it('returns 0 and leaves the cache untouched when under the byte limit', () => {
+    const cache: Record<string, string> = { a: 'x', b: 'y' };
+    expect(evictNip17CacheBytes(cache, 10_000)).toBe(0);
+    expect(Object.keys(cache)).toEqual(['a', 'b']);
+  });
+
+  it('drops oldest-inserted entries until the serialised blob fits', () => {
+    // Each value is ~1 KB; a 3 KB cap should keep only the newest few.
+    const cache: Record<string, string> = {};
+    for (let i = 0; i < 10; i += 1) cache[`k${i}`] = 'z'.repeat(1000);
+    const removed = evictNip17CacheBytes(cache, 3000);
+    expect(removed).toBeGreaterThan(0);
+    expect(JSON.stringify(cache).length).toBeLessThanOrEqual(3000);
+    // Whatever survives must be the newest-inserted keys (a contiguous
+    // tail of the original insertion order).
+    const survivors = Object.keys(cache);
+    const originalOrder = Array.from({ length: 10 }, (_, i) => `k${i}`);
+    expect(survivors).toEqual(originalOrder.slice(originalOrder.length - survivors.length));
+  });
+
+  it('never empties the cache below one entry even if that entry is over budget', () => {
+    const cache: Record<string, string> = { only: 'z'.repeat(5000) };
+    evictNip17CacheBytes(cache, 100);
+    expect(Object.keys(cache)).toEqual(['only']);
   });
 });
 

--- a/src/utils/nip17Cache.test.ts
+++ b/src/utils/nip17Cache.test.ts
@@ -92,10 +92,26 @@ describe('evictNip17CacheBytes', () => {
     expect(survivors).toEqual(originalOrder.slice(originalOrder.length - survivors.length));
   });
 
-  it('never empties the cache below one entry even if that entry is over budget', () => {
+  it('drops a single over-budget entry rather than persisting an unreadable row', () => {
+    // A lone wrap whose own JSON exceeds the budget must still go —
+    // keeping it would write a row that fails to read anyway. An empty
+    // cache is valid; the relay restream repopulates it.
     const cache: Record<string, string> = { only: 'z'.repeat(5000) };
-    evictNip17CacheBytes(cache, 100);
-    expect(Object.keys(cache)).toEqual(['only']);
+    const removed = evictNip17CacheBytes(cache, 100);
+    expect(removed).toBe(1);
+    expect(Object.keys(cache)).toEqual([]);
+  });
+
+  it('measures UTF-8 bytes, not UTF-16 length — emoji content counts double-plus', () => {
+    // 4 emoji = 4 chars of .length 8, but 16 UTF-8 bytes. A budget that
+    // sits between the two must still trim. Guards the CursorWindow bug:
+    // a .length check would have passed this and written an over-limit row.
+    const cache: Record<string, string> = {};
+    for (let i = 0; i < 6; i += 1) cache[`k${i}`] = '🐷🐷🐷🐷';
+    // Each value JSON is ~"🐷🐷🐷🐷" = 16 bytes content + 2 quotes; key+
+    // punctuation overhead too. 6 entries comfortably exceed 60 bytes.
+    const removed = evictNip17CacheBytes(cache, 60);
+    expect(removed).toBeGreaterThan(0);
   });
 });
 

--- a/src/utils/nip17Cache.ts
+++ b/src/utils/nip17Cache.ts
@@ -19,6 +19,8 @@
  * users with very active inboxes.
  */
 
+import { utf8ByteSize } from './byteSize';
+
 /**
  * Mark `key` as most-recently-used in `cache` by deleting and
  * re-inserting it. No-op (returns false) if the key isn't present.
@@ -56,20 +58,28 @@ export function evictNip17CacheOverflow<V>(cache: Record<string, V>, cap: number
 
 /**
  * Evict the oldest-inserted entries until the cache's serialised JSON is
- * at most `maxBytes`. Mutates in place; returns the number removed.
+ * at most `maxBytes` (measured in real UTF-8 bytes — see `utf8ByteSize`,
+ * since that's the unit SQLite's CursorWindow row limit applies to).
+ * Mutates in place; returns the number removed.
  *
  * The count cap in `evictNip17CacheOverflow` isn't enough on its own —
  * Android's SQLite CursorWindow caps a row at ~2 MB, and past that the
  * *read* throws `SQLiteBlobTooBigException`. The wrap cache then fails
  * to hydrate, so every cold start falls back to a full relay restream +
  * NIP-17 re-decrypt instead of the fast cache path. Trims in ~10%
- * chunks to keep the `JSON.stringify` re-checks bounded.
+ * chunks to keep the re-checks bounded.
+ *
+ * `keys.length > 0` (not `> 1`): a single wrap whose own JSON exceeds
+ * the budget must still be dropped — keeping it would persist an
+ * unreadable row anyway. An empty cache is valid; the relay restream
+ * repopulates it. `Math.max(1, …)` guarantees forward progress so a
+ * small-but-over-budget cache can't spin forever.
  */
 export function evictNip17CacheBytes<V>(cache: Record<string, V>, maxBytes: number): number {
-  if (JSON.stringify(cache).length <= maxBytes) return 0;
+  if (utf8ByteSize(JSON.stringify(cache)) <= maxBytes) return 0;
   let removed = 0;
   let keys = Object.keys(cache);
-  while (keys.length > 1 && JSON.stringify(cache).length > maxBytes) {
+  while (keys.length > 0 && utf8ByteSize(JSON.stringify(cache)) > maxBytes) {
     const chunk = Math.max(1, Math.ceil(keys.length * 0.1));
     for (let i = 0; i < chunk; i += 1) delete cache[keys[i]];
     removed += chunk;

--- a/src/utils/nip17Cache.ts
+++ b/src/utils/nip17Cache.ts
@@ -53,3 +53,27 @@ export function evictNip17CacheOverflow<V>(cache: Record<string, V>, cap: number
   for (let i = 0; i < overflow; i++) delete cache[keys[i]];
   return overflow;
 }
+
+/**
+ * Evict the oldest-inserted entries until the cache's serialised JSON is
+ * at most `maxBytes`. Mutates in place; returns the number removed.
+ *
+ * The count cap in `evictNip17CacheOverflow` isn't enough on its own —
+ * Android's SQLite CursorWindow caps a row at ~2 MB, and past that the
+ * *read* throws `SQLiteBlobTooBigException`. The wrap cache then fails
+ * to hydrate, so every cold start falls back to a full relay restream +
+ * NIP-17 re-decrypt instead of the fast cache path. Trims in ~10%
+ * chunks to keep the `JSON.stringify` re-checks bounded.
+ */
+export function evictNip17CacheBytes<V>(cache: Record<string, V>, maxBytes: number): number {
+  if (JSON.stringify(cache).length <= maxBytes) return 0;
+  let removed = 0;
+  let keys = Object.keys(cache);
+  while (keys.length > 1 && JSON.stringify(cache).length > maxBytes) {
+    const chunk = Math.max(1, Math.ceil(keys.length * 0.1));
+    for (let i = 0; i < chunk; i += 1) delete cache[keys[i]];
+    removed += chunk;
+    keys = Object.keys(cache);
+  }
+  return removed;
+}


### PR DESCRIPTION
## Summary

Fixes a severe cold-start stall — diagnosed on a Pixel 8 where the React Native JS thread was pegged at 100%+ CPU for **~70 seconds** on every launch, blocking all navigation and rendering.

## Root cause

The three DM caches (inbox, conversation, NIP-17 wrap) were capped by **entry count** but not by **byte size**. A device with a long DM history — especially long-text messages — could write a cache row past Android's ~2 MB SQLite `CursorWindow` limit. Once that happens:

1. The next `getItem` **read** fails (`SQLiteBlobTooBigException`).
2. The cache silently never hydrates.
3. Every cold start falls back to a full relay restream + NIP-17 re-decrypt on the JS thread — the 70s stall. The wrap cache normally short-circuits this to <1s, but only if it can be read.

## Changes

- `mergeInboxEntries` / `mergeConversationMessages` now trim by serialised size (`DM_CACHE_MAX_BYTES`, 1.5 MB) after the existing count cap — dropping oldest entries.
- New `evictNip17CacheBytes` util (oldest-first, ~10% chunks), run in `writeNip17Cache` after the count evict — so the wrap cache is byte-bounded too.
- All three DM caches are now byte-bounded; no row can grow unreadable.

The fix is **self-healing** — a device with an already-oversized row does one more restream, which rewrites a capped row, then cold start is fast again.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `npx jest src/utils/nip17Cache.test.ts` — 14/14 passing (3 new for `evictNip17CacheBytes`)
- [ ] On-device: deploy to the Pixel 8 with the long DM history, cold-start twice, confirm the second launch is fast and navigation is responsive

## Notes

Branched from `main` (not `feat/explore-tab`) — `NostrContext.tsx` is identical on both, and this is a messages-layer fix unrelated to the Explore tab work in #488.

## Closes

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)