### PR TITLE
feat(messages): three-tier WoT chip replaces Following-only toggle (#547)

### DIFF
--- a/src/contexts/GroupsContext.tsx
+++ b/src/contexts/GroupsContext.tsx
@@ -49,15 +49,19 @@ interface GroupsContextType {
    * default — see `followingOnly` / `setFollowingOnly`.
    */
   visibleGroups: Group[];
-  // @deprecated Since #547 the messages + groups filter is driven by the
-  // three-tier `wotTier` in TrustGraphContext, not this boolean. Kept
-  // exposed for the migration window so any external consumer doesn't
-  // crash — derived from `effectiveWotTier !== 'all'`. New code should
-  // read `effectiveWotTier` (or `useTrustGraph().wotTier`) directly.
+  /**
+   * @deprecated Since #547 the messages + groups filter is driven by the
+   * three-tier `wotTier` in TrustGraphContext, not this boolean. Kept
+   * exposed for the migration window so any external consumer doesn't
+   * crash — derived from `effectiveWotTier !== 'all'`. New code should
+   * read `effectiveWotTier` (or `useTrustGraph().wotTier`) directly.
+   */
   followingOnly: boolean;
-  // @deprecated See `followingOnly`. Setting this maps onto `setWotTier`:
-  // true → 'friends', false → 'all' (clamped to 'friends' when not in
-  // secret mode, matching the production hard-lock).
+  /**
+   * @deprecated See `followingOnly`. Setting this maps onto `setWotTier`:
+   * true → 'friends', false → 'all' (clamped to 'friends' when not in
+   * secret mode, matching the production hard-lock).
+   */
   setFollowingOnly: (next: boolean) => void;
   // Effective WoT tier after the production hard-lock has been applied.
   // Mirrors the persisted `wotTier` from TrustGraphContext except that
@@ -165,7 +169,12 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   // Tier source-of-truth lives in TrustGraphContext (#547). We read it here
   // so visibleGroups can apply the same trust filter the Map / Hunt / Events
   // surfaces use — keeping the three-tier model unified across the app.
-  const { wotTier, setWotTier, isTrusted } = useTrustGraph();
+  // `isTrustedAtTier` (not `isTrusted`) so the `visibleGroups` filter
+  // evaluates against `effectiveWotTier`. Otherwise a persisted 'all'
+  // would short-circuit `isTrusted` even when the hard-lock clamps to
+  // 'friends' (secretMode off), letting hidden groups leak past the
+  // parental-control gate (#547 follow-up).
+  const { wotTier, setWotTier, isTrustedAtTier } = useTrustGraph();
   // Per-group activity rollup (last message + recent senders). Populated
   // on mount from AsyncStorage and kept fresh by the inbound-message
   // listener below + a local hook from GroupConversationScreen sends.
@@ -237,6 +246,16 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   // Map-side preference isn't stomped). Mirrors the dev_mode → secret_mode
   // migration pattern just above.
   useEffect(() => {
+    // The migration reads a *per-account-scoped* key
+    // (`perAccountKey(FOLLOWING_ONLY_KEY_BASE, pubkey)`). When the
+    // provider mounts before identity hydration `pubkey` is still
+    // null/undefined and `perAccountKey` would fall back to the un-
+    // namespaced base key, potentially missing the real legacy value
+    // and persisting `WOT_MIGRATION_DONE_KEY=true` before the actual
+    // per-account legacy slot is reachable — permanently locking the
+    // user into the safe default. Wait for hydration first; the effect
+    // re-runs when `pubkey` lands.
+    if (!pubkey) return;
     (async () => {
       const done = await AsyncStorage.getItem(WOT_MIGRATION_DONE_KEY);
       if (done === 'true') return;
@@ -411,8 +430,10 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   // in-depth rule the 1:1 DM gate uses inside MessagesScreen.
   const visibleGroups = useMemo(() => {
     if (effectiveWotTier === 'all') return groups;
-    return groups.filter((g) => g.memberPubkeys.some((pk) => isTrusted(pk)));
-  }, [groups, effectiveWotTier, isTrusted]);
+    return groups.filter((g) =>
+      g.memberPubkeys.some((pk) => isTrustedAtTier(effectiveWotTier, pk)),
+    );
+  }, [groups, effectiveWotTier, isTrustedAtTier]);
 
   // Synchronous mirror of the `groups` state used as the read source
   // for `persist` so concurrent mutators serialise correctly without

--- a/src/contexts/GroupsContext.tsx
+++ b/src/contexts/GroupsContext.tsx
@@ -29,8 +29,17 @@ import {
   subscribeGroupStateForViewer,
 } from '../services/nostrService';
 import { perAccountKey } from '../services/perAccountStorage';
+import { useTrustGraph } from './TrustGraphContext';
+import { saveWotSettings, type WotTier } from '../services/wotSettingsService';
+import { deriveInitialWotTier } from '../utils/wotMigration';
 
 const FOLLOWING_ONLY_KEY_BASE = 'groups_following_only';
+// One-shot migration marker keyed off the legacy followingOnly → wotTier
+// derivation (#547). The migration only runs once per device — after the
+// first successful derive we set this flag so re-mounts of GroupsProvider
+// (account switches, hot reload) never re-stomp a wotTier the user has
+// since edited via the WoT bottom sheet.
+const WOT_MIGRATION_DONE_KEY = '@lp:wot-migration:v1-from-followingOnly';
 
 interface GroupsContextType {
   groups: Group[];
@@ -40,13 +49,24 @@ interface GroupsContextType {
    * default — see `followingOnly` / `setFollowingOnly`.
    */
   visibleGroups: Group[];
-  /**
-   * If true, only groups that include at least one OTHER member from the
-   * current user's follow list are shown. Default true; in secret_mode the
-   * user can toggle it off via the chip on GroupsScreen.
-   */
+  // @deprecated Since #547 the messages + groups filter is driven by the
+  // three-tier `wotTier` in TrustGraphContext, not this boolean. Kept
+  // exposed for the migration window so any external consumer doesn't
+  // crash — derived from `effectiveWotTier !== 'all'`. New code should
+  // read `effectiveWotTier` (or `useTrustGraph().wotTier`) directly.
   followingOnly: boolean;
+  // @deprecated See `followingOnly`. Setting this maps onto `setWotTier`:
+  // true → 'friends', false → 'all' (clamped to 'friends' when not in
+  // secret mode, matching the production hard-lock).
   setFollowingOnly: (next: boolean) => void;
+  // Effective WoT tier after the production hard-lock has been applied.
+  // Mirrors the persisted `wotTier` from TrustGraphContext except that
+  // 'all' is coerced to 'friends' when the user is not in secret mode —
+  // preventing a stale persisted 'all' from leaking past the parental-
+  // control gate after secretMode is flipped back off. Consumers should
+  // read this rather than `useTrustGraph().wotTier` when the visibility
+  // decision must honour the hard-lock.
+  effectiveWotTier: WotTier;
   /** Mirrors AsyncStorage `secret_mode`. Controls whether the chip is interactive. */
   secretMode: boolean;
   /**
@@ -141,13 +161,16 @@ const GroupsContext = createContext<GroupsContextType | undefined>(undefined);
 export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [groups, setGroups] = useState<Group[]>([]);
   const [loading, setLoading] = useState(true);
-  const [followingOnly, setFollowingOnlyState] = useState(true);
   const [secretMode, setSecretModeState] = useState(false);
+  // Tier source-of-truth lives in TrustGraphContext (#547). We read it here
+  // so visibleGroups can apply the same trust filter the Map / Hunt / Events
+  // surfaces use — keeping the three-tier model unified across the app.
+  const { wotTier, setWotTier, isTrusted } = useTrustGraph();
   // Per-group activity rollup (last message + recent senders). Populated
   // on mount from AsyncStorage and kept fresh by the inbound-message
   // listener below + a local hook from GroupConversationScreen sends.
   const [activityByGroup, setActivityByGroup] = useState<Record<string, GroupActivity>>({});
-  const { publishGroupState, pubkey, relays, isLoggedIn, contacts } = useNostr();
+  const { publishGroupState, pubkey, relays, isLoggedIn } = useNostr();
   // Track the latest reconciler in a ref so the subscription effect can
   // call it without re-subscribing on every group state change.
   const reconcilerRef = useRef<
@@ -179,22 +202,13 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       .finally(() => setLoading(false));
   }, [pubkey]);
 
-  // Load persisted user preferences for the chip + dev-mode escape hatch.
-  // secret_mode is shared with AboutScreen's hidden-tap unlock so the same
-  // override surfaces across the app. The "following only" toggle is
-  // per-account (Primal/Damus convention: filter prefs travel with the
-  // identity, not the device).
+  // Load persisted secret-mode flag with a one-shot migration from the
+  // pre-rename 'dev_mode' key. Without this, anyone who'd already
+  // unlocked the mode before that PR would silently revert to locked on
+  // upgrade (and the legacy key would linger in AsyncStorage forever).
+  // Read both, prefer the new key if present, otherwise migrate the
+  // legacy value forward + delete the old key.
   useEffect(() => {
-    AsyncStorage.getItem(perAccountKey(FOLLOWING_ONLY_KEY_BASE, pubkey)).then((v) => {
-      // Default ON; only flip OFF if the user explicitly persisted false.
-      setFollowingOnlyState(v !== 'false');
-    });
-    // Read secret-mode flag with a one-shot migration from the pre-rename
-    // 'dev_mode' key. Without this, anyone who'd already unlocked the
-    // mode before this PR would silently revert to locked on upgrade
-    // (and the legacy key would linger in AsyncStorage forever). Read
-    // both, prefer the new key if present, otherwise migrate the legacy
-    // value forward + delete the old key.
     (async () => {
       const secret = await AsyncStorage.getItem('secret_mode');
       if (secret !== null) {
@@ -210,6 +224,57 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     })();
   }, [pubkey]);
 
+  // One-shot legacy → tier migration (#547). The pre-#547 Messages /
+  // Groups filter persisted a boolean `followingOnly` per account; the
+  // unified WoT tier lives in a single device-wide key (`@lp:wot-settings:v1`).
+  // On first run after the upgrade we derive a starting tier from the
+  // legacy boolean (+ secretMode) so the user's intent survives intact:
+  //   followingOnly=true                       → 'friends'
+  //   followingOnly=false && secretMode=true   → 'all' (legacy dev escape hatch)
+  //   anything else                            → 'friends' (safe default)
+  // Guarded by `WOT_MIGRATION_DONE_KEY` so it never re-runs; also skipped
+  // entirely if the user has already saved a wotTier explicitly (so a
+  // Map-side preference isn't stomped). Mirrors the dev_mode → secret_mode
+  // migration pattern just above.
+  useEffect(() => {
+    (async () => {
+      const done = await AsyncStorage.getItem(WOT_MIGRATION_DONE_KEY);
+      if (done === 'true') return;
+      try {
+        // Skip if the user has already saved an explicit wotTier — the
+        // loadWotSettings call inside TrustGraphContext returns defaults
+        // for a missing key, so we have to probe the raw storage slot.
+        const existing = await AsyncStorage.getItem('@lp:wot-settings:v1');
+        if (existing !== null) {
+          await AsyncStorage.setItem(WOT_MIGRATION_DONE_KEY, 'true');
+          return;
+        }
+        // followingOnly was per-account; we migrate using whichever
+        // account is currently active. Defaults to true (ON) if the
+        // legacy key was never written.
+        const raw = await AsyncStorage.getItem(perAccountKey(FOLLOWING_ONLY_KEY_BASE, pubkey));
+        const followingOnlyLegacy: boolean | null = raw === null ? null : raw !== 'false';
+        const secretRaw = await AsyncStorage.getItem('secret_mode');
+        const secret = secretRaw === 'true';
+        const next = deriveInitialWotTier({
+          followingOnly: followingOnlyLegacy,
+          secretMode: secret,
+        });
+        // Persist directly via the service (cheaper than going through
+        // TrustGraphContext's setter, which would also schedule a render)
+        // and then notify the in-memory state so the UI picks it up on
+        // the next render without waiting for loadWotSettings to re-run.
+        await saveWotSettings({ wotTier: next });
+        setWotTier(next);
+        await AsyncStorage.setItem(WOT_MIGRATION_DONE_KEY, 'true');
+      } catch {
+        // Best-effort; failures leave the marker unset so a later mount
+        // can retry. The user sees the safe default ('friends') in the
+        // meantime, which is the conservative outcome.
+      }
+    })();
+  }, [pubkey, setWotTier]);
+
   // Persist + broadcast a secret-mode toggle. Used by AboutScreen's
   // triple-tap unlock — keeping the writer in the context means every
   // subscriber (the WoT picker, Messages, Groups) sees the change in
@@ -222,15 +287,31 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     AsyncStorage.setItem('secret_mode', next ? 'true' : 'false').catch(() => {});
   }, []);
 
+  // Production hard-lock guard (#547). A stale persisted 'all' must never
+  // leak past the parental-control gate after secret mode has been
+  // flipped back off — clamp to 'friends' (the safest tier) in that case.
+  // The persisted wotTier itself is left alone so the user keeps their
+  // wider tier preference if they re-enable secret mode later. This
+  // mirrors the `followingOnly || !secretMode` defence-in-depth that
+  // visibleGroups used before #547 — same rule, three-tier shape.
+  const effectiveWotTier: WotTier = !secretMode && wotTier === 'all' ? 'friends' : wotTier;
+
+  // Deprecated boolean view of the tier — see the interface docstring.
+  // Kept for any out-of-tree consumer; in-tree consumers should read
+  // `effectiveWotTier` directly. `true` = filter-on (friends or fof),
+  // `false` = filter-off ('all'). FoF is treated as "filter on" because
+  // it still applies a trust gate, just a wider one.
+  const followingOnly = effectiveWotTier !== 'all';
+
   const setFollowingOnly = useCallback(
     (next: boolean) => {
-      setFollowingOnlyState(next);
-      AsyncStorage.setItem(
-        perAccountKey(FOLLOWING_ONLY_KEY_BASE, pubkey),
-        next ? 'true' : 'false',
-      ).catch(() => {});
+      // Map the legacy boolean back onto the tier: true → 'friends',
+      // false → 'all'. The hard-lock guard in the predicate above means
+      // a non-secret-mode user who flips this to false still sees the
+      // 'friends' behaviour at the visibility layer.
+      setWotTier(next ? 'friends' : 'all');
     },
-    [pubkey],
+    [setWotTier],
   );
 
   // Keep the module-level routing registry in lock-step with React state
@@ -323,21 +404,15 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     return unsub;
   }, [groups]);
 
-  const followPubkeys = useMemo(() => {
-    const set = new Set<string>();
-    for (const c of contacts) set.add(c.pubkey.toLowerCase());
-    return set;
-  }, [contacts]);
-
   // Anti-spam: a group is visible only if at least one OTHER member is
-  // in the viewer's follow list. Mirrors the 1:1 "Following only" rule
-  // at MessagesScreen.tsx:128-143. Locked-on outside secret_mode; in
-  // secret_mode the user can flip it via the chip on GroupsScreen.
+  // in the viewer's trust set at the current tier (#547). For 'friends'
+  // the trust set is L1 follows + seeds + viewer; for 'fof' it adds L2
+  // follows-of-follows; for 'all' the filter is disabled. Same defence-
+  // in-depth rule the 1:1 DM gate uses inside MessagesScreen.
   const visibleGroups = useMemo(() => {
-    const enforce = followingOnly || !secretMode;
-    if (!enforce) return groups;
-    return groups.filter((g) => g.memberPubkeys.some((pk) => followPubkeys.has(pk.toLowerCase())));
-  }, [groups, followPubkeys, followingOnly, secretMode]);
+    if (effectiveWotTier === 'all') return groups;
+    return groups.filter((g) => g.memberPubkeys.some((pk) => isTrusted(pk)));
+  }, [groups, effectiveWotTier, isTrusted]);
 
   // Synchronous mirror of the `groups` state used as the read source
   // for `persist` so concurrent mutators serialise correctly without
@@ -765,6 +840,7 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       visibleGroups,
       followingOnly,
       setFollowingOnly,
+      effectiveWotTier,
       secretMode,
       setSecretMode,
       loading,
@@ -782,6 +858,7 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       visibleGroups,
       followingOnly,
       setFollowingOnly,
+      effectiveWotTier,
       secretMode,
       setSecretMode,
       loading,

--- a/src/contexts/TrustGraphContext.tsx
+++ b/src/contexts/TrustGraphContext.tsx
@@ -26,15 +26,31 @@ import {
 export type { WotTier } from '../services/wotSettingsService';
 
 interface TrustGraphContextType {
-  // Lowercase-hex union of every pubkey that passes the *currently selected*
-  // tier. Consumers should keep using `isTrusted(pubkey)` rather than reading
-  // `trustSet` directly so tier transitions don't require call-site changes.
+  // Lowercase-hex union of every pubkey that passes the *currently
+  // persisted* tier. Consumers that care about UI-effective tier (e.g.
+  // the parental-control hard-lock that clamps a persisted 'all' back
+  // to 'friends' when secretMode is off) should call
+  // `trustSetForTier(effectiveTier)` instead — otherwise a stale
+  // persisted 'all' can leak past the gate (#547 follow-up).
   trustSet: ReadonlySet<string>;
   // Tier-aware membership predicate (#535).
   //   'friends' — kind-3 follow list + user + seeds
   //   'fof'     — friends + cached friends-of-follows
   //   'all'     — always returns true (filter disabled)
+  // Uses the *persisted* tier — see `isTrustedAtTier` for the variant
+  // that lets callers evaluate against a specific (e.g. effective) tier.
   isTrusted: (pubkey: string) => boolean;
+  // Tier-parameterised version of `trustSet` — returns the set that
+  // *would* apply if the requested tier were active, regardless of
+  // what's persisted. Used by call sites that enforce against the
+  // UI-effective tier (e.g. MessagesScreen) so the defensive trust
+  // filter matches the hard-lock and a stale persisted 'all' can't
+  // leak.
+  trustSetForTier: (tier: WotTier) => ReadonlySet<string>;
+  // Tier-parameterised membership predicate — same role as
+  // `trustSetForTier` but for callers that prefer the predicate form
+  // (e.g. GroupsContext's `visibleGroups` filter).
+  isTrustedAtTier: (tier: WotTier, pubkey: string) => boolean;
   // Active tier (#535). Replaces the legacy `filterEnabled` boolean.
   wotTier: WotTier;
   // Persist + apply a new tier. Wider tiers (fof / all) are gated on
@@ -142,6 +158,20 @@ export const TrustGraphProvider: React.FC<ProviderProps> = ({ children }) => {
     return computeTrustSet(pubkey, l1Follows, effectiveL2, true);
   }, [pubkey, l1Follows, l2Follows, wotTier]);
 
+  // Tier-parameterised version of `trustSet`. Returns the set that
+  // *would* apply if the requested tier were active, regardless of
+  // what's persisted. Hot path: when the requested tier equals the
+  // persisted one we hand back the memoised `trustSet` directly so
+  // we don't rebuild on every consumer call.
+  const trustSetForTier = useCallback(
+    (tier: WotTier): ReadonlySet<string> => {
+      if (tier === wotTier) return trustSet;
+      const effectiveL2 = tier === 'fof' || tier === 'all' ? l2Follows : new Set<string>();
+      return computeTrustSet(pubkey, l1Follows, effectiveL2, true);
+    },
+    [trustSet, wotTier, pubkey, l1Follows, l2Follows],
+  );
+
   const isTrusted = useCallback(
     (pk: string) => {
       // 'all' tier disables the filter entirely. Consumers still call
@@ -153,17 +183,40 @@ export const TrustGraphProvider: React.FC<ProviderProps> = ({ children }) => {
     [trustSet, wotTier],
   );
 
+  // Tier-parameterised membership predicate. Same `'all'`
+  // short-circuit, but evaluates against the *requested* tier rather
+  // than the persisted one — see `trustSetForTier` for the rationale.
+  const isTrustedAtTier = useCallback(
+    (tier: WotTier, pk: string) => {
+      if (tier === 'all') return true;
+      return isPubkeyTrusted(pk, trustSetForTier(tier));
+    },
+    [trustSetForTier],
+  );
+
   const value = useMemo<TrustGraphContextType>(
     () => ({
       trustSet,
       isTrusted,
+      trustSetForTier,
+      isTrustedAtTier,
       wotTier,
       setWotTier,
       l2Loading,
       l2Size: l2Follows.size,
       refreshL2,
     }),
-    [trustSet, isTrusted, wotTier, setWotTier, l2Loading, l2Follows, refreshL2],
+    [
+      trustSet,
+      isTrusted,
+      trustSetForTier,
+      isTrustedAtTier,
+      wotTier,
+      setWotTier,
+      l2Loading,
+      l2Follows,
+      refreshL2,
+    ],
   );
 
   return <TrustGraphContext.Provider value={value}>{children}</TrustGraphContext.Provider>;

--- a/src/screens/GroupsScreen.tsx
+++ b/src/screens/GroupsScreen.tsx
@@ -30,6 +30,11 @@ const GroupsScreen: React.FC = () => {
   const navigation = useNavigation<GroupsNavigation>();
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
+  // TODO(wot): swap to wotTier + WebOfTrustChip + WebOfTrustBottomSheet when
+  // the GroupsScreen filter row gets its own three-tier picker (#547 only
+  // migrated the Messages chip; GroupsScreen still uses the legacy boolean
+  // shim — `followingOnly` is now derived from `effectiveWotTier !== 'all'`
+  // and `setFollowingOnly` writes back via `setWotTier`).
   const { visibleGroups, deleteGroup, followingOnly, setFollowingOnly, secretMode } = useGroups();
   const { isLoggedIn, refreshDmInbox, contacts, pubkey: myPubkey } = useNostr();
 

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -13,7 +13,7 @@ import { Image as ExpoImage } from 'expo-image';
 import TabBackgroundImage from '../components/TabBackgroundImage';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import Svg, { Path } from 'react-native-svg';
-import { Users, Clock, Search, X, Zap } from 'lucide-react-native';
+import { Clock, Search, X, Zap } from 'lucide-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, CompositeNavigationProp, useFocusEffect } from '@react-navigation/native';
@@ -22,6 +22,9 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNostr } from '../contexts/NostrContext';
 import { useWallet } from '../contexts/WalletContext';
 import { useGroups } from '../contexts/GroupsContext';
+import { useTrustGraph } from '../contexts/TrustGraphContext';
+import WebOfTrustChip from '../components/WebOfTrustChip';
+import WebOfTrustBottomSheet from '../components/WebOfTrustBottomSheet';
 import ConversationRow from '../components/ConversationRow';
 import GroupRow from '../components/GroupRow';
 import type { ContactInfo } from '../components/GroupAvatar';
@@ -71,9 +74,16 @@ const MessagesScreen: React.FC = () => {
     armLiveDmSub,
   } = useNostr();
   const { wallets } = useWallet();
-  const { groupSummaries, followingOnly, setFollowingOnly, secretMode } = useGroups();
-  // Production hard-lock: filter is always enforced unless secretMode AND followingOnly=off.
-  const enforceFollowingOnly = followingOnly || !secretMode;
+  const { groupSummaries, effectiveWotTier } = useGroups();
+  const { trustSet } = useTrustGraph();
+  // WoT bottom-sheet visibility — opened from the chip in the filter row.
+  // Mirrors MapScreen's setWotSheetVisible pattern (#547).
+  const [wotSheetVisible, setWotSheetVisible] = useState(false);
+  // Production hard-lock (#547): the data + UI layers still apply the
+  // trust filter unless the effective tier is 'all'. effectiveWotTier
+  // already collapses 'all' → 'friends' for non-secret-mode users, so a
+  // stale persisted 'all' can't leak past the parental-control gate.
+  const enforceFollowingOnly = effectiveWotTier !== 'all';
   // Tracks last applied value so toggling triggers a data-layer refresh, not just a UI re-filter.
   const lastAppliedEnforceRef = useRef<boolean>(true);
   const [search, setSearch] = useState('');
@@ -258,11 +268,13 @@ const MessagesScreen: React.FC = () => {
     }, [isLoggedIn, contacts]),
   );
 
-  const followPubkeys = useMemo(() => {
-    const set = new Set<string>();
-    for (const c of contacts) set.add(c.pubkey.toLowerCase());
-    return set;
-  }, [contacts]);
+  // Trust gate (#547). For 'friends' tier this is L1 follows + viewer + seeds;
+  // for 'fof' it adds L2 follows-of-follows; for 'all' it's still computed
+  // but the enforceFollowingOnly switch above disables the gate entirely.
+  // Kept named `followPubkeys` so the downstream call-sites stay diff-clean
+  // — the *semantics* widened from "raw follow list" to "tier-aware trust
+  // set" but every existing predicate (Set.has) still applies unchanged.
+  const followPubkeys = trustSet;
 
   // Single pubkey → ContactInfo lookup for the screen, shared by every
   // row + handler. Three previously-separate `contacts.find()` paths
@@ -286,12 +298,14 @@ const MessagesScreen: React.FC = () => {
   const deferredDmInbox = useDeferredValue(dmInbox);
   const deferredContacts = useDeferredValue(contacts);
   // Build the DM summaries first — this is always part of the inbox
-  // regardless of the zap-counterparties toggle. Pass followPubkeys as a
-  // defence-in-depth filter. NostrContext's refreshDmInbox already drops
-  // non-follows at the data layer, but applying it again here guards
-  // against stale dmInbox state from before a follow was revoked. The
-  // "Following only" rule is load-bearing — keep it enforced everywhere
-  // a summary is built. Skip the gate only when secretMode AND followingOnly=off (production hard-lock).
+  // regardless of the zap-counterparties toggle. Pass the tier-aware
+  // trust set (#547) as a defence-in-depth filter. NostrContext's
+  // refreshDmInbox already drops non-trusted senders at the data layer,
+  // but applying it again here guards against stale dmInbox state from
+  // before a follow was revoked or a tier was widened. The trust rule
+  // is load-bearing — keep it enforced everywhere a summary is built.
+  // Skip the gate only when effectiveWotTier === 'all' (which itself is
+  // already secret-mode-gated by GroupsContext's hard-lock).
   const dmSummaries = useMemo(() => {
     return buildDmSummaries(
       deferredDmInbox,
@@ -314,11 +328,11 @@ const MessagesScreen: React.FC = () => {
     return mergeSummaries(zapSummaries, dmSummaries);
   }, [dmSummaries, zapSummaries]);
 
-  // Following-only is always on by design (parental-control requirement);
+  // The trust gate is on by default (parental-control requirement);
   // enforcement lives inside buildDmSummaries + refreshDmInbox. This memo
   // applies the user-selectable time window + search, plus a defensive
-  // follow check for pubkey'd zap rows so non-followed zap counterparties
-  // don't slip in. Groups go through their own follow gate inside
+  // trust check for pubkey'd zap rows so untrusted zap counterparties
+  // don't slip in. Groups go through their own trust gate inside
   // GroupsContext.visibleGroups, so we just merge the result here.
   type InboxRow =
     | { kind: 'dm'; summary: ConversationSummary; sortKey: number }
@@ -331,7 +345,10 @@ const MessagesScreen: React.FC = () => {
     const dmRows: InboxRow[] = conversationSummaries
       .filter((s) => {
         if (s.lastActivityAt < cutoff) return false;
-        // Defence-in-depth follow gate using enforceFollowingOnly = followingOnly || !secretMode.
+        // Defence-in-depth trust gate (#547): apply the tier-aware trust set
+        // unless the effective tier is 'all'. effectiveWotTier already
+        // collapses 'all' → 'friends' for non-secret-mode users, so the
+        // parental-control hard-lock holds even with a stale persisted 'all'.
         if (enforceFollowingOnly && s.pubkey && !followPubkeys.has(s.pubkey.toLowerCase()))
           return false;
         if (!lower) return true;
@@ -555,36 +572,17 @@ const MessagesScreen: React.FC = () => {
       <View style={styles.content}>
         {isLoggedIn && (
           <View style={styles.filterChipRow}>
-            {secretMode ? (
-              <TouchableOpacity
-                style={followingOnly ? styles.filterChip : styles.filterChipOff}
-                onPress={() => setFollowingOnly(!followingOnly)}
-                accessibilityLabel={
-                  followingOnly
-                    ? 'Following-only filter on. Tap to show all conversations (dev mode).'
-                    : 'Following-only filter off. Tap to filter to followed senders only.'
-                }
-                accessibilityRole="button"
-                testID="messages-follows-toggle"
-              >
-                <Users
-                  size={14}
-                  color={followingOnly ? colors.brandPink : colors.textSupplementary}
-                />
-                <Text style={followingOnly ? styles.filterChipText : styles.filterChipTextOff}>
-                  {followingOnly ? 'Following only' : 'All (dev)'}
-                </Text>
-              </TouchableOpacity>
-            ) : (
-              <View
-                style={styles.filterChip}
-                accessibilityLabel="Showing conversations from people you follow only"
-                testID="messages-follows-indicator"
-              >
-                <Users size={14} color={colors.brandPink} />
-                <Text style={styles.filterChipText}>Following only</Text>
-              </View>
-            )}
+            <WebOfTrustChip
+              currentTier={effectiveWotTier}
+              onPress={() => setWotSheetVisible(true)}
+              testID="messages-wot-chip"
+            />
+            {/* Hidden marker for Maestro so flows can assert the active tier without parsing the chip label. Mirrors messages-zaps-toggle-on/off below. */}
+            <View
+              testID={`messages-wot-tier-${effectiveWotTier}`}
+              accessibilityElementsHidden
+            />
+
             <TouchableOpacity
               style={styles.filterChipInteractive}
               onPress={cycleWindowDays}
@@ -703,6 +701,11 @@ const MessagesScreen: React.FC = () => {
           setProfileSheetVisible(false);
           navigation.navigate('ContactProfile', { contact: sheetContact });
         }}
+      />
+
+      <WebOfTrustBottomSheet
+        visible={wotSheetVisible}
+        onClose={() => setWotSheetVisible(false)}
       />
     </View>
   );

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -75,7 +75,14 @@ const MessagesScreen: React.FC = () => {
   } = useNostr();
   const { wallets } = useWallet();
   const { groupSummaries, effectiveWotTier } = useGroups();
-  const { trustSet } = useTrustGraph();
+  // `trustSetForTier` rather than the raw `trustSet` so the screen's
+  // defensive trust filter is computed against `effectiveWotTier`. The
+  // persisted `wotTier` can be 'all' while the hard-lock clamps the
+  // effective tier back to 'friends' (secretMode off) — if we evaluated
+  // against the persisted set, the L2 entries would still be included
+  // and the filter would no-op past the parental-control gate (#547
+  // follow-up).
+  const { trustSetForTier } = useTrustGraph();
   // WoT bottom-sheet visibility — opened from the chip in the filter row.
   // Mirrors MapScreen's setWotSheetVisible pattern (#547).
   const [wotSheetVisible, setWotSheetVisible] = useState(false);
@@ -274,7 +281,7 @@ const MessagesScreen: React.FC = () => {
   // Kept named `followPubkeys` so the downstream call-sites stay diff-clean
   // — the *semantics* widened from "raw follow list" to "tier-aware trust
   // set" but every existing predicate (Set.has) still applies unchanged.
-  const followPubkeys = trustSet;
+  const followPubkeys = trustSetForTier(effectiveWotTier);
 
   // Single pubkey → ContactInfo lookup for the screen, shared by every
   // row + handler. Three previously-separate `contacts.find()` paths
@@ -578,10 +585,7 @@ const MessagesScreen: React.FC = () => {
               testID="messages-wot-chip"
             />
             {/* Hidden marker for Maestro so flows can assert the active tier without parsing the chip label. Mirrors messages-zaps-toggle-on/off below. */}
-            <View
-              testID={`messages-wot-tier-${effectiveWotTier}`}
-              accessibilityElementsHidden
-            />
+            <View testID={`messages-wot-tier-${effectiveWotTier}`} accessibilityElementsHidden />
 
             <TouchableOpacity
               style={styles.filterChipInteractive}
@@ -703,10 +707,7 @@ const MessagesScreen: React.FC = () => {
         }}
       />
 
-      <WebOfTrustBottomSheet
-        visible={wotSheetVisible}
-        onClose={() => setWotSheetVisible(false)}
-      />
+      <WebOfTrustBottomSheet visible={wotSheetVisible} onClose={() => setWotSheetVisible(false)} />
     </View>
   );
 };

--- a/src/utils/conversationSummaries.ts
+++ b/src/utils/conversationSummaries.ts
@@ -199,7 +199,7 @@ const DM_PREVIEW_PREFERENCE_WINDOW_SEC = 5 * 60;
 export function buildDmSummaries(
   entries: DmInboxEntry[],
   contacts: NostrContact[],
-  followPubkeys?: Set<string>,
+  followPubkeys?: ReadonlySet<string>,
 ): ConversationSummary[] {
   const contactByPubkey = new Map<string, NostrContact>();
   for (const c of contacts) contactByPubkey.set(c.pubkey.toLowerCase(), c);

--- a/src/utils/conversationSummaries.ts
+++ b/src/utils/conversationSummaries.ts
@@ -183,11 +183,19 @@ const DM_PREVIEW_PREFERENCE_WINDOW_SEC = 5 * 60;
 
 /**
  * Bucket DM entries by partner pubkey and reduce to one ConversationSummary
- * per partner. The caller passes the viewer's followed pubkeys (lowercase)
- * as a safety net: even though refreshDmInbox already filters at the data
- * layer, rebuilding the list after a contact is un-followed should also
- * drop them here — the "Following only" rule is a render-time invariant,
- * not just a fetch-time one.
+ * per partner. `trustedPubkeys` (formerly `followPubkeys`, kept on the
+ * parameter name for diff churn but the semantics have widened) is the
+ * lowercase-hex trust set the caller wants to enforce here as a render-
+ * time safety net: even though `refreshDmInbox` already filters at the
+ * data layer, rebuilding the list after a contact leaves the tier should
+ * also drop them here.
+ *
+ * Since #547 callers pass a **tier-aware trust set** (friends / fof /
+ * all), not just the L1 follow list it used to be. So `trustedPubkeys`
+ * may legitimately include friends-of-follows / seeds / the viewer
+ * themself depending on the current `wotTier`. The contract is the
+ * same — pubkeys present in the set pass the filter — but don't
+ * assume the contents are limited to direct follows.
  *
  * When a partner has both a NIP-04 and a NIP-17 message within
  * DUAL_PUBLISH_WINDOW_SEC we always pick the NIP-17 copy regardless of

--- a/src/utils/wotMigration.test.ts
+++ b/src/utils/wotMigration.test.ts
@@ -1,0 +1,21 @@
+import { deriveInitialWotTier } from './wotMigration';
+
+describe('deriveInitialWotTier', () => {
+  it('maps followingOnly=true → friends regardless of secretMode', () => {
+    expect(deriveInitialWotTier({ followingOnly: true, secretMode: false })).toBe('friends');
+    expect(deriveInitialWotTier({ followingOnly: true, secretMode: true })).toBe('friends');
+  });
+
+  it('maps followingOnly=false + secretMode=true → all (preserves the dev escape hatch)', () => {
+    expect(deriveInitialWotTier({ followingOnly: false, secretMode: true })).toBe('all');
+  });
+
+  it('maps followingOnly=false + secretMode=false → friends (production hard-lock)', () => {
+    expect(deriveInitialWotTier({ followingOnly: false, secretMode: false })).toBe('friends');
+  });
+
+  it('maps missing legacy state (cold install) → friends', () => {
+    expect(deriveInitialWotTier({ followingOnly: null, secretMode: false })).toBe('friends');
+    expect(deriveInitialWotTier({ followingOnly: null, secretMode: true })).toBe('friends');
+  });
+});

--- a/src/utils/wotMigration.ts
+++ b/src/utils/wotMigration.ts
@@ -6,7 +6,7 @@
 // Mapping rules (per the issue's "AsyncStorage migration" acceptance):
 //   followingOnly=true                       → 'friends'  (current default)
 //   followingOnly=false && secretMode=true   → 'all'      (existing dev escape hatch)
-//   anything else (incl. null / undefined)   → 'friends'  (safe default)
+//   anything else (incl. null)               → 'friends'  (safe default)
 
 import type { WotTier } from '../services/wotSettingsService';
 

--- a/src/utils/wotMigration.ts
+++ b/src/utils/wotMigration.ts
@@ -1,0 +1,25 @@
+// One-shot migration helper for #547 — collapses the legacy Messages /
+// Groups "Following only" boolean (plus the secretMode escape hatch) into
+// the unified three-tier wotTier shared with the Map / Hunt / Events
+// surfaces. Kept as a pure function so it's trivially unit-testable.
+//
+// Mapping rules (per the issue's "AsyncStorage migration" acceptance):
+//   followingOnly=true                       → 'friends'  (current default)
+//   followingOnly=false && secretMode=true   → 'all'      (existing dev escape hatch)
+//   anything else (incl. null / undefined)   → 'friends'  (safe default)
+
+import type { WotTier } from '../services/wotSettingsService';
+
+export interface LegacyMessagesFilterState {
+  followingOnly: boolean | null;
+  secretMode: boolean;
+}
+
+export const deriveInitialWotTier = ({
+  followingOnly,
+  secretMode,
+}: LegacyMessagesFilterState): WotTier => {
+  if (followingOnly === false && secretMode) return 'all';
+  // followingOnly === true OR null/missing OR secretMode=false → 'friends'.
+  return 'friends';
+};


### PR DESCRIPTION
Closes #547.

Replaces the Messages screen's binary **Following only / All** chip with the three-tier **Friends / Friends of Friends / All** Web-of-Trust chip + bottom sheet already in use on the Map side (`MapScreen` + `WebOfTrustBottomSheet` + `TrustGraphContext`). The visibility predicate for DMs now consults `wotTier` via `useTrustGraph()`, with a production hard-lock so `wotTier === 'all'` is coerced back to `'friends'` for any user not in `secretMode` — preserves the exact behaviour the old `enforceFollowingOnly` gate provided.

## Migration

One-shot, key-guarded, idempotent migration on first launch:

| Legacy state | New `wotTier` |
| --- | --- |
| `followingOnly=true` | `friends` |
| `followingOnly=false && secretMode=true` | `all` |
| `followingOnly=false && secretMode=false` | `friends` (the previous hard-lock kept this view filtered too) |
| no value persisted | `friends` (initial default) |

The migration only runs when `wot:settings:v1` has no value — Map-side preferences set first are not stomped. Pure helper `deriveInitialWotTier` extracted into `src/utils/wotMigration.ts` with 4 Jest tests covering every legacy mapping.

## Shim

`useGroups().followingOnly` / `setFollowingOnly` stay as a deprecated boolean shim that derives from / writes through `setWotTier`. Keeps `GroupsScreen` (which still uses a binary chip) green for now; the shim's call-site has a `TODO(wot)` pointing at the next migration.

## Note on FoF DMs (out of scope)

`refreshDmInbox.includeNonFollows` is now bypassed only when `wotTier === 'all'`. For `wotTier === 'fof'` the data-layer follow gate stays strict, so the UI shows L2-friend DMs as visible **only if they arrived under L1 first**. End-to-end FoF DM delivery would need `passesFollowGate` in `NostrContext.refreshDmInbox` to consult `trustSet` rather than the raw follow set — defensible to defer to a follow-up (filed separately if you'd like).

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/screens/MessagesScreen.tsx src/contexts/GroupsContext.tsx` — zero errors
- `npm test -- --silent` — **426/426 pass** (+4 new tests in `wotMigration.test.ts`)

## Out of scope

- GroupsScreen binary chip migration (TODO comment in place)
- Outbound DM allow-listing
- Notification gating
- Visual redesign of chip/sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)