### PR TITLE
refactor(map): extract Leaflet bridge + tile + pin builders to mapWebview/ (#18)

### DIFF
--- a/src/components/ExploreMiniMap.tsx
+++ b/src/components/ExploreMiniMap.tsx
@@ -10,6 +10,15 @@ import type { ParsedCache, ParsedEvent } from '../services/nostrPlacesService';
 import LegendSheet from './LegendSheet';
 import { ME_DOT_CSS, ME_DOT_JS } from '../utils/mapMeDot';
 import { MAP_PIN_SVG_PALETTE_JS } from '../utils/mapPinSvgs';
+import { decodeGeohash } from '../utils/geohash';
+import {
+  LEAFLET_BASE_CSS,
+  LEAFLET_HEAD_TAGS,
+  LEAFLET_MAP_BACKGROUND_CSS,
+  LEAFLET_SCRIPT_TAG,
+  POST_BRIDGE_JS,
+  tileLayerJs,
+} from '../utils/mapWebview/tiles';
 
 export interface MiniMapBbox {
   minLat: number;
@@ -380,11 +389,10 @@ const makeHtml = (
 ): string => `<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="initial-scale=1.0,maximum-scale=1.0,user-scalable=no" />
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  ${LEAFLET_HEAD_TAGS}
   <style>
-    html,body,#map{margin:0;padding:0;height:100%;width:100%;background:#eee}
+    ${LEAFLET_BASE_CSS}
+    ${LEAFLET_MAP_BACKGROUND_CSS}
     .lp-pin{width:14px;height:14px;border-radius:7px;background:#EC008C;border:1.5px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,0.4)}
     .lp-pin.onchain{background:#F5A623}
     /* Round circles match the list-row iconWrap (pink for Piglet,
@@ -408,10 +416,10 @@ const makeHtml = (
 </head>
 <body>
 <div id="map"></div>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+${LEAFLET_SCRIPT_TAG}
 <script>
 ${ME_DOT_JS}
-const post=(m)=>window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(JSON.stringify(m));
+${POST_BRIDGE_JS}
 // minZoom 7 caps the bbox at about 400 km wide at UK latitudes — wider
 // than that and the list becomes "everything within a country" rather
 // than "nearby", which is the wrong product for an Explore-hub mini-map.
@@ -420,7 +428,7 @@ const post=(m)=>window.ReactNativeWebView&&window.ReactNativeWebView.postMessage
 // maxZoom 18 matches OSM tile availability.
 const __interactive=${interactive ? 'true' : 'false'};
 const map=L.map('map',{zoomControl:false,dragging:__interactive,scrollWheelZoom:__interactive,doubleClickZoom:__interactive,touchZoom:__interactive,boxZoom:false,keyboard:false,minZoom:7,maxZoom:18,tap:__interactive}).setView([${lat},${lon}],${defaultZoom});
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19}).addTo(map);
+${tileLayerJs()}
 let merchantLayer=L.layerGroup().addTo(map),cacheLayer=L.layerGroup().addTo(map),eventLayer=L.layerGroup().addTo(map);
 const dot=(cls,size)=>L.divIcon({className:'',html:'<div class="'+cls+'"></div>',iconSize:[size,size]});
 // SVG palette + categorySvg() helper — sourced from
@@ -507,35 +515,6 @@ post({type:'ready'});
 emitBounds();
 </script>
 </body></html>`;
-
-// Inline geohash decoder — same algorithm as MapScreen (kept duplicated
-// rather than extracted because both files want zero-overhead inline use).
-const GEOHASH_BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
-const decodeGeohash = (gh: string): { lat: number; lng: number } => {
-  let latLo = -90,
-    latHi = 90,
-    lonLo = -180,
-    lonHi = 180,
-    even = true;
-  for (let i = 0; i < gh.length; i += 1) {
-    const idx = GEOHASH_BASE32.indexOf(gh[i].toLowerCase());
-    if (idx < 0) continue;
-    for (let bit = 4; bit >= 0; bit -= 1) {
-      const set = (idx >> bit) & 1;
-      if (even) {
-        const m = (lonLo + lonHi) / 2;
-        if (set) lonLo = m;
-        else lonHi = m;
-      } else {
-        const m = (latLo + latHi) / 2;
-        if (set) latLo = m;
-        else latHi = m;
-      }
-      even = !even;
-    }
-  }
-  return { lat: (latLo + latHi) / 2, lng: (lonLo + lonHi) / 2 };
-};
 
 const createStyles = (colors: Palette) =>
   StyleSheet.create({

--- a/src/components/LocationPickerSheet.tsx
+++ b/src/components/LocationPickerSheet.tsx
@@ -10,6 +10,14 @@ import { WebView } from 'react-native-webview';
 import { MapPin, Check } from 'lucide-react-native';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
+import {
+  LEAFLET_BASE_CSS,
+  LEAFLET_HEAD_TAGS,
+  LEAFLET_MAP_BACKGROUND_CSS,
+  LEAFLET_SCRIPT_TAG,
+  POST_BRIDGE_JS,
+  tileLayerJs,
+} from '../utils/mapWebview/tiles';
 
 interface Props {
   visible: boolean;
@@ -187,22 +195,21 @@ const LocationPickerSheet: React.FC<Props> = ({
 const makeHtml = (lat: number, lon: number, zoom: number): string => `<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="initial-scale=1.0,maximum-scale=1.0,user-scalable=no" />
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  ${LEAFLET_HEAD_TAGS}
   <style>
-    html,body,#map{margin:0;padding:0;height:100%;width:100%;background:#eee}
+    ${LEAFLET_BASE_CSS}
+    ${LEAFLET_MAP_BACKGROUND_CSS}
     .lp-drop{width:20px;height:20px;border-radius:10px;background:#EC008C;border:3px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,0.45)}
     .leaflet-control-attribution{font-size:9px}
   </style>
 </head>
 <body>
 <div id="map"></div>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+${LEAFLET_SCRIPT_TAG}
 <script>
-  const post=(m)=>window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(JSON.stringify(m));
+  ${POST_BRIDGE_JS}
   const map=L.map('map',{zoomControl:true,minZoom:3,maxZoom:19}).setView([${lat},${lon}],${zoom});
-  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19}).addTo(map);
+  ${tileLayerJs()}
   const icon=L.divIcon({className:'',html:'<div class="lp-drop"></div>',iconSize:[20,20],iconAnchor:[10,10]});
   const marker=L.marker([${lat},${lon}],{icon:icon,draggable:true}).addTo(map);
   const emit=(userMoved)=>{const p=marker.getLatLng();post({type:'pin',lat:p.lat,lon:p.lng,userMoved:!!userMoved});};

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -48,7 +48,7 @@ import {
 } from '../services/btcMapService';
 import type { ParsedCache } from '../services/nostrPlacesService';
 import { subscribeNearbyCaches } from '../services/nostrPlacesPublisher';
-import { encodeGeohash, geohashPrefixes } from '../utils/geohash';
+import { decodeGeohash, encodeGeohash, geohashPrefixes } from '../utils/geohash';
 import { getDevPinnedLocation } from '../utils/devLocation';
 import { btcMapIconComponent } from '../utils/btcMapIcon';
 import SocialIcon from '../components/SocialIcon';
@@ -56,6 +56,13 @@ import WebOfTrustChip from '../components/WebOfTrustChip';
 import WebOfTrustBottomSheet from '../components/WebOfTrustBottomSheet';
 import LegendSheet from '../components/LegendSheet';
 import { ME_DOT_CSS, ME_DOT_JS } from '../utils/mapMeDot';
+import {
+  LEAFLET_BASE_CSS,
+  LEAFLET_HEAD_TAGS,
+  LEAFLET_SCRIPT_TAG,
+  POST_BRIDGE_JS,
+  tileLayerJs,
+} from '../utils/mapWebview/tiles';
 
 interface Props {
   navigation: ExploreNavigation;
@@ -1251,36 +1258,6 @@ const bboxAround = (lat: number, lng: number, halfDegrees: number): Bbox => ({
   maxLat: lat + halfDegrees,
 });
 
-// Geohash → centroid (lat, lng) — inverse of utils/geohash.ts encoder.
-// Used here because cache events publish only the geohash string, not
-// raw lat/lon (NIP-GC convention).
-const GEOHASH_BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
-const decodeGeohash = (gh: string): { lat: number; lng: number } => {
-  let latLo = -90;
-  let latHi = 90;
-  let lonLo = -180;
-  let lonHi = 180;
-  let evenBit = true;
-  for (let i = 0; i < gh.length; i += 1) {
-    const idx = GEOHASH_BASE32.indexOf(gh[i].toLowerCase());
-    if (idx < 0) continue;
-    for (let bit = 4; bit >= 0; bit -= 1) {
-      const set = (idx >> bit) & 1;
-      if (evenBit) {
-        const mid = (lonLo + lonHi) / 2;
-        if (set) lonLo = mid;
-        else lonHi = mid;
-      } else {
-        const mid = (latLo + latHi) / 2;
-        if (set) latLo = mid;
-        else latHi = mid;
-      }
-      evenBit = !evenBit;
-    }
-  }
-  return { lat: (latLo + latHi) / 2, lng: (lonLo + lonHi) / 2 };
-};
-
 // -----------------------------------------------------------------------------
 // Leaflet HTML — kept inline so the bundle has no runtime CDN dependency
 // for the loader, while tile imagery itself still streams from OSM at use
@@ -1292,16 +1269,14 @@ const decodeGeohash = (gh: string): { lat: number; lng: number } => {
 const LEAFLET_HTML = `<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="initial-scale=1.0,maximum-scale=1.0,user-scalable=no" />
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  ${LEAFLET_HEAD_TAGS}
   <!-- Material Symbols Outlined — same icon family BTC Map ships, so
        every BtcMapPlace.icon name resolves to a recognisable glyph
        (storefront, chalet, cafe, pub, bicycle, …). Self-hosted from
        Google Fonts CDN; no JS, just a single CSS+woff2 fetch. -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined" />
   <style>
-    html, body, #map { margin: 0; padding: 0; height: 100%; width: 100%; }
+    ${LEAFLET_BASE_CSS}
     /* Leaflet's default zoom buttons are small + tucked top-left.
        Bump size + contrast so they land at thumb-tappable size and
        are obvious to users who don't realise they can pinch. */
@@ -1362,10 +1337,10 @@ const LEAFLET_HTML = `<!DOCTYPE html>
 </head>
 <body>
   <div id="map"></div>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  ${LEAFLET_SCRIPT_TAG}
   <script>
     ${ME_DOT_JS}
-    const post = (msg) => window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+    ${POST_BRIDGE_JS}
     // Honor a viewport injected via injectedJavaScriptBeforeContentLoaded
     // — that's MapScreen's saved-viewport hydrate. Falls back to a UK
     // central default only when there's truly nothing better.
@@ -1373,10 +1348,7 @@ const LEAFLET_HTML = `<!DOCTYPE html>
       ? window.LP_initialViewport
       : { lat: 51.5074, lng: -0.1278, zoom: 12 };
     const map = L.map('map', { zoomControl: true }).setView([__iv.lat, __iv.lng], __iv.zoom);
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 19,
-      attribution: '© OpenStreetMap contributors',
-    }).addTo(map);
+    ${tileLayerJs("attribution:'© OpenStreetMap contributors'")}
 
     // meMarker / meAccuracyCircle live in __lpMeState inside ME_DOT_JS
     // — no need to track them here.

--- a/src/utils/mapWebview/tiles.test.ts
+++ b/src/utils/mapWebview/tiles.test.ts
@@ -1,0 +1,54 @@
+// Locks the contracts of the Leaflet WebView head/body string builders
+// in mapWebview/tiles.ts. These strings are interpolated into makeHtml
+// template literals across MapScreen / ExploreMiniMap /
+// LocationPickerSheet — drifting any one of them silently breaks one
+// or more of those maps, so we pin the exact text shape here.
+
+import {
+  LEAFLET_BASE_CSS,
+  LEAFLET_HEAD_TAGS,
+  LEAFLET_MAP_BACKGROUND_CSS,
+  LEAFLET_SCRIPT_TAG,
+  LEAFLET_VERSION,
+  POST_BRIDGE_JS,
+  tileLayerJs,
+} from './tiles';
+
+describe('mapWebview/tiles', () => {
+  it('pins the Leaflet CDN version so all three maps bump in lock-step', () => {
+    expect(LEAFLET_VERSION).toBe('1.9.4');
+    expect(LEAFLET_HEAD_TAGS).toContain(`leaflet@${LEAFLET_VERSION}/dist/leaflet.css`);
+    expect(LEAFLET_SCRIPT_TAG).toContain(`leaflet@${LEAFLET_VERSION}/dist/leaflet.js`);
+  });
+
+  it('head tags carry the no-scale viewport meta', () => {
+    expect(LEAFLET_HEAD_TAGS).toContain('user-scalable=no');
+    expect(LEAFLET_HEAD_TAGS).toContain('initial-scale=1.0');
+  });
+
+  it('base CSS zeroes margin / padding and fills the viewport', () => {
+    expect(LEAFLET_BASE_CSS).toBe('html,body,#map{margin:0;padding:0;height:100%;width:100%}');
+  });
+
+  it('map-background CSS is a separate rule so MapScreen can opt out', () => {
+    expect(LEAFLET_MAP_BACKGROUND_CSS).toBe('#map{background:#eee}');
+    expect(LEAFLET_BASE_CSS).not.toContain('background');
+  });
+
+  it('tileLayerJs emits the OSM URL + maxZoom:19', () => {
+    expect(tileLayerJs()).toBe(
+      "L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19}).addTo(map);",
+    );
+  });
+
+  it('tileLayerJs appends extra options inside the same options object', () => {
+    expect(tileLayerJs("attribution:'© OpenStreetMap contributors'")).toBe(
+      "L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'© OpenStreetMap contributors'}).addTo(map);",
+    );
+  });
+
+  it('post bridge helper guards against a missing ReactNativeWebView', () => {
+    expect(POST_BRIDGE_JS).toContain('window.ReactNativeWebView&&');
+    expect(POST_BRIDGE_JS).toContain('postMessage(JSON.stringify');
+  });
+});

--- a/src/utils/mapWebview/tiles.ts
+++ b/src/utils/mapWebview/tiles.ts
@@ -1,0 +1,60 @@
+// Shared boilerplate for every Leaflet WebView in the app —
+// MapScreen.tsx (full-screen map), ExploreMiniMap.tsx (inline preview)
+// and LocationPickerSheet.tsx (draggable pin). Each of those files
+// used to inline its own copy of the Leaflet CDN <link>/<script>, the
+// base `html,body,#map { … }` reset, the OSM tile-layer init line and
+// a one-liner `post()` bridge helper. Drift between them broke
+// silently — bump leaflet here, every map gets the bump.
+//
+// All exports are plain TS strings interpolated into the WebView's
+// makeHtml(…) template literal. The WebView is a sandboxed HTML
+// island so React modules cannot reach it; string-template injection
+// is the next-best abstraction (mirrors the pattern used by
+// `mapMeDot.ts` and `mapPinSvgs/`).
+
+// Leaflet version is centralised here so all three maps stay aligned.
+export const LEAFLET_VERSION = '1.9.4';
+
+// Head-tag boilerplate: viewport meta + Leaflet CSS. Interpolated into
+// the `<head>` block of every map. The viewport meta locks scale so
+// pinch-zoom drives Leaflet's own zoom instead of the WebView's text
+// zoom layer (which would blur tiles).
+export const LEAFLET_HEAD_TAGS = `
+  <meta charset="utf-8" />
+  <meta name="viewport" content="initial-scale=1.0,maximum-scale=1.0,user-scalable=no" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.css" />
+`.trim();
+
+// Base reset used by every map. ExploreMiniMap + LocationPickerSheet
+// stack a `background:#eee` rule on top of this so the tile gutter
+// doesn't flash white before the first tile decodes; MapScreen omits
+// the background entirely. The base rule is identical across all
+// three sites — the optional background lives in each caller.
+export const LEAFLET_BASE_CSS = 'html,body,#map{margin:0;padding:0;height:100%;width:100%}';
+
+// Mini-map / picker pre-tile background — paired with LEAFLET_BASE_CSS
+// in `<style>`. Kept as a separate rule so MapScreen can opt out
+// without forking the reset.
+export const LEAFLET_MAP_BACKGROUND_CSS = '#map{background:#eee}';
+
+// Leaflet `<script>` import tag — paired with LEAFLET_HEAD_TAGS for a
+// consistent CDN version. Goes inside `<body>` immediately before the
+// inline script that uses `L.…`.
+export const LEAFLET_SCRIPT_TAG = `<script src="https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.js"></script>`;
+
+// OSM tile-layer JS — every map uses the same OSM tile endpoint and
+// the same maxZoom of 19 (Leaflet's default zoom ceiling that OSM
+// reliably ships tiles for). MapScreen adds an attribution string;
+// the mini-maps suppress the control entirely so it's not lost on
+// them. Callers can pass extra options via `extraOptions`.
+export const tileLayerJs = (extraOptions?: string): string => {
+  const opts = extraOptions ? `,${extraOptions}` : '';
+  return `L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19${opts}}).addTo(map);`;
+};
+
+// One-line `post()` helper bound to React Native's WebView bridge.
+// All three maps had identical copies of this. Inlined into the
+// WebView's `<script>` block so handler code can call `post({…})`
+// without any further plumbing.
+export const POST_BRIDGE_JS =
+  'const post=(m)=>window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(JSON.stringify(m));';


### PR DESCRIPTION
Closes #18.

Three WebView-Leaflet maps lived in this codebase — `MapScreen.tsx`, `ExploreMiniMap.tsx`, `LocationPickerSheet.tsx` — and each carried its own copy of the same CDN tags, base CSS reset, OSM tile-layer init, and `post()` bridge helper. Pull them into a single shared module on the same pattern as the existing `mapMeDot.ts` + `mapPinSvgs/` modules.

## LOC delta

`git diff --stat origin/feat/explore-tab`:

| File | + | − |
| --- | --- | --- |
| `src/components/ExploreMiniMap.tsx` | 17 | 34 |
| `src/components/LocationPickerSheet.tsx` | 13 | 8 |
| `src/screens/MapScreen.tsx` | 12 | 42 |
| `src/utils/mapWebview/tiles.ts` | 60 | 0 |
| `src/utils/mapWebview/tiles.test.ts` | 54 | 0 |

**84 lines removed from the three call-sites; 60 added to `mapWebview/tiles.ts` (+ 54 of tests).** Net –30 lines of source if you exclude tests, or +30 including them.

## Shared module introduced

`src/utils/mapWebview/tiles.ts`:

- `LEAFLET_VERSION` — single source of truth for the CDN pin (currently `1.9.4`).
- `LEAFLET_HEAD_TAGS` — `<meta>` viewport + `<link>` to `leaflet.css`.
- `LEAFLET_BASE_CSS` — the `html,body,#map{margin:0;…}` reset.
- `LEAFLET_MAP_BACKGROUND_CSS` — the `#map{background:#eee}` pre-tile rule (opt-in so MapScreen can skip it).
- `LEAFLET_SCRIPT_TAG` — `<script src="…leaflet.js">`.
- `tileLayerJs(extraOptions?)` — emits the OSM `L.tileLayer(…)` call with consistent maxZoom and an optional extra-options pass-through (MapScreen uses it for the OSM attribution string).
- `POST_BRIDGE_JS` — the one-liner `const post=(m)=>window.ReactNativeWebView&&…` helper.

Backed by `src/utils/mapWebview/tiles.test.ts` (7 tests) that pin every string to its exact expected shape so silent drift gets caught at unit-test time.

Also dropped the inline `decodeGeohash` copies from `MapScreen.tsx` + `ExploreMiniMap.tsx` — both were byte-for-byte equivalent to the existing export in `src/utils/geohash.ts`.

## Deliberately NOT unified

These pieces look superficially shared but unifying them would be a behaviour change, not a dedup:

1. **Per-map pin builders.** `MapScreen` uses Material Symbols + class-based pin CSS (`.lp-pin`, `.lp-piglet`, `.lp-cache`). `ExploreMiniMap` uses inline lucide SVGs via `MAP_PIN_SVG_PALETTE_JS` and the `placeCircle()` / `cacheCircle()` / `pinIcon()` helpers. They are different visual designs (round Material-glyph pins on the full map vs SVG-glyph circles on the mini-map), not drift.
2. **`LP_…` bridge handlers.** `MapScreen` exposes `LP_setViewport` / `LP_setMarkers` / `LP_setCaches` / `LP_setMeMarker` with viewport-persistence semantics. `ExploreMiniMap` exposes `LP_setHub` / `LP_zoomBy` / `LP_recenter` with zoom-aware no-recentre semantics. `LocationPickerSheet` exposes no bridges (it's a drag-pin model). Forcing them into one shared module would mean awkward feature-flag branches on every call.

## Verification

- `npx tsc --noEmit` — clean.
- `npm test -- --silent` — 42 suites / 429 tests pass (same as `feat/explore-tab` base).
- `npx prettier --check` — clean.
- ESLint — no new errors or warnings.
- All `explore-minimap*` testIDs preserved exactly; no accessibility-label changes; no `BrandedAlert` / `BrandedToast` rules touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
