### PR TITLE
fix(nwc): use WebLN paid flag + cap reply timeout for fast receive-side settlement (#553)

### DIFF
--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -622,4 +622,38 @@ walk away. +
 true` + Settings → "Don't lock when on this network" disabled (default), and
 the phone won't auto-lock for the duration of the build (~20 min) and the
 follow-on perf-suite (~3 min).
+
+| Receive sheet slow to mark invoice as paid — fast `lookupInvoice` poll
+never fires settlement, only the slow balance-diff fallback eventually
+catches it (~30 s – 3 min lag, see #553)
+| The `expectPayment` poll calls `nwcService.lookupInvoice` every 1 s and
+checks the returned `paid` flag. Two non-obvious gotchas around the result
+shape: +
+**(1) WebLN vs NIP-47.** We use `NostrWebLNProvider` from `@getalby/sdk`,
+whose `lookupInvoice` translates the underlying NIP-47 `Nip47Transaction`
+response into the **WebLN** `LookupInvoiceResponse` shape. So *even though
+LNbits' nwcprovider correctly emits the spec-compliant
+`{type, invoice, settled_at, payment_hash, …}`*, what we receive is
+`{preimage, paymentRequest, paid}`. A predicate that only checks
+`result.settled_at` or `result.state` is dead code on this path and will
+never fire — every tick returns `false`, and settlement only catches via
+the slow balance-diff fallback. Fix: check `result.paid === true`. +
+**(2) Field rename.** WebLN names the bolt11 field `paymentRequest`, not
+`invoice`. Returning `result.invoice` to consumers gives them `undefined`
+forever. `nwcService.lookupInvoice` maps `paymentRequest → invoice` once
+inside the function, so callers can keep using `.invoice`. +
+**Where the layer-confusion bites:** the Alby SDK's *type declaration*
+for `NWCClient.lookupInvoice` returns `Nip47Transaction` (with
+`settled_at`/`state`), but we don't call that — we call
+`NostrWebLNProvider.lookupInvoice`, which returns the WebLN shape. The
+type cast on the result must reflect the WebLN shape, not the NIP-47
+spec. If you ever refactor to the raw `NWCClient`, flip both the field
+names AND the settlement predicate. +
+**Diagnostic recipe** if this regresses: temporarily add
+`console.warn('keys:', Object.keys(result), 'raw:', JSON.stringify(result));`
+inside `nwcService.lookupInvoice` after the call resolves, then issue a
+small test invoice and watch `adb logcat | grep '\[NWC lookupInvoice\]'`
+— the wire shape will tell you immediately whether you're on the WebLN
+or NIP-47 path. Cross-reference: PR #555 (`fix(nwc): cap lookupInvoice
+reply timeout`).
 |===

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1678,7 +1678,11 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         current.inFlight = true;
         try {
           const [lookupResult] = await Promise.allSettled([
-            nwcService.lookupInvoice(walletId, paymentHash),
+            // Same 2500 ms ceiling as the sibling getBalance call below
+            // — without it, a slow NIP-47 reply blocks the pile-up-
+            // guarded tick for ~10 s and recipients see the payment
+            // land before we mark it paid. See #553.
+            nwcService.lookupInvoice(walletId, paymentHash, { replyTimeoutMs: 2500 }),
             // The balance refresh feeds the generic balance-diff
             // detector as a fallback; run it every tick so a flaky
             // lookup_invoice path still settles detection.

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -768,9 +768,10 @@ function isTerminalLookupError(error: unknown): boolean {
 
 // LNbits (and some other NWC backends) omit preimage/invoice from
 // list_transactions; this fills them in. Returns null on failure.
-// `paid` relies on `settled_at` (a non-zero timestamp when the invoice
-// was paid). `preimage` alone isn't a safe signal — some backends
-// pre-populate it or return a placeholder while unsettled.
+// `paid` reflects the WebLN-shape `paid` boolean returned by
+// `NostrWebLNProvider.lookupInvoice` — see the block comment inside
+// the function for why the NIP-47 `settled_at` / `state` fields aren't
+// what we read here.
 export interface LookupInvoiceOptions {
   /**
    * Per-call ceiling for the underlying NIP-47 round trip. When unset,
@@ -806,8 +807,8 @@ export async function lookupInvoice(
     // `{preimage, paymentRequest, paid}` for us. Don't reach for `settled_at`
     // or `state` here — they're never populated on this path. If we ever
     // switch to the raw `NWCClient` we'd need to flip both the field names
-    // and the settlement predicate; see docs/TROUBLESHOOTING.adoc → "Receive
-    // sheet slow to show paid (NIP-47 settlement detection)" for context.
+    // and the settlement predicate; see docs/TROUBLESHOOTING.adoc →
+    // "Receive sheet slow to mark invoice as paid" for context.
     const call = provider.lookupInvoice({ paymentHash });
     const result = (await (options.replyTimeoutMs !== undefined
       ? withTimeout(call, options.replyTimeoutMs, `lookupInvoice(${walletId})`)

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -485,7 +485,15 @@ export async function payInvoice(
       const paymentHash = extractPaymentHash(bolt11);
       if (paymentHash) {
         try {
-          const lookup = await provider.lookupInvoice({ paymentHash });
+          // 2500 ms ceiling — this is a pre-flight check before a
+          // retry. A slow relay shouldn't block the retry; if the
+          // wallet really has paid, the duplicate-payment guard in
+          // the wallet itself catches it on the second attempt.
+          const lookup = await withTimeout(
+            provider.lookupInvoice({ paymentHash }),
+            2500,
+            `lookupInvoice(${walletId})`,
+          );
           if (lookup?.preimage) {
             console.log('[NWC] Invoice already paid — returning existing preimage');
             return { preimage: lookup.preimage };
@@ -527,8 +535,18 @@ export async function payInvoice(
           // `abortable` lets Cancel win the race even while the SDK is
           // blocked inside lookupInvoice's own NIP-47 round-trip; the
           // underlying promise completes in the background and its
-          // result is discarded.
-          const lookup = await abortable(provider.lookupInvoice({ paymentHash }), signal);
+          // result is discarded. 5000 ms cap on the SDK call itself so
+          // a slow relay doesn't pin the 5 s sleep + ~10 s SDK default
+          // into a 15 s effective tick — recipients had been seeing
+          // payments land before our app marked them paid (#553).
+          const lookup = await abortable(
+            withTimeout(
+              provider.lookupInvoice({ paymentHash }),
+              5000,
+              `lookupInvoice(${walletId})`,
+            ),
+            signal,
+          );
           if (lookup?.preimage) {
             console.log('[NWC] Payment completed after timeout:', paymentHash);
             return { preimage: lookup.preimage };
@@ -556,7 +574,14 @@ export async function payInvoice(
       const paymentHash = extractPaymentHash(bolt11);
       if (paymentHash) {
         try {
-          const lookup = await provider.lookupInvoice({ paymentHash });
+          // 2500 ms cap — this is a one-shot disambiguation, not a
+          // poll loop, but a stalled relay reply here delays surfacing
+          // the real error to the user. Mirror the receive-side ceiling.
+          const lookup = await withTimeout(
+            provider.lookupInvoice({ paymentHash }),
+            2500,
+            `lookupInvoice(${walletId})`,
+          );
           if (lookup?.paid && lookup.preimage) {
             // `warn` (not `log`) so this survives the production
             // `transform-remove-console` strip — without it field logs
@@ -746,16 +771,38 @@ function isTerminalLookupError(error: unknown): boolean {
 // `paid` relies on `settled_at` (a non-zero timestamp when the invoice
 // was paid). `preimage` alone isn't a safe signal — some backends
 // pre-populate it or return a placeholder while unsettled.
+export interface LookupInvoiceOptions {
+  /**
+   * Per-call ceiling for the underlying NIP-47 round trip. When unset,
+   * defers to the SDK's own ~10 s `replyTimeout`. When set, a timed-out
+   * call fails fast so the caller's next poll tick can race a fresh
+   * request rather than waiting on a slow reply.
+   *
+   * Passed by both settlement-detection callers: the receive-side
+   * `expectPayment` poll in `WalletContext` (1 s ticks, 2500 ms cap
+   * mirrors the sibling `getBalance` ceiling) and the send-side
+   * post-reply-timeout poll here in `nwcService.payInvoice` (5 s
+   * ticks, 5000 ms cap). Without this, a slow relay reply blocked
+   * the pile-up-guarded tick for the SDK's full default — recipients
+   * saw the payment land before our app marked it paid (#553).
+   */
+  replyTimeoutMs?: number;
+}
+
 export async function lookupInvoice(
   walletId: string,
   paymentHash: string,
+  options: LookupInvoiceOptions = {},
 ): Promise<{ preimage?: string; invoice?: string; paid: boolean } | null> {
   if (!isValidPaymentHash(paymentHash)) return null;
   if (hasFailedLookup(walletId, paymentHash)) return null;
   const provider = await ensureConnected(walletId);
   if (!provider) return null;
   try {
-    const result = (await provider.lookupInvoice({ paymentHash })) as {
+    const call = provider.lookupInvoice({ paymentHash });
+    const result = (await (options.replyTimeoutMs !== undefined
+      ? withTimeout(call, options.replyTimeoutMs, `lookupInvoice(${walletId})`)
+      : call)) as {
       preimage?: string;
       invoice?: string;
       settled_at?: number;

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -799,19 +799,29 @@ export async function lookupInvoice(
   const provider = await ensureConnected(walletId);
   if (!provider) return null;
   try {
+    // We use `NostrWebLNProvider` from @getalby/sdk, whose `lookupInvoice`
+    // returns the **WebLN** `LookupInvoiceResponse` shape — *not* the raw
+    // NIP-47 `Nip47Transaction` shape. So the SDK translates LNbits'
+    // spec-compliant `{type, invoice, settled_at, ...}` into WebLN's
+    // `{preimage, paymentRequest, paid}` for us. Don't reach for `settled_at`
+    // or `state` here — they're never populated on this path. If we ever
+    // switch to the raw `NWCClient` we'd need to flip both the field names
+    // and the settlement predicate; see docs/TROUBLESHOOTING.adoc → "Receive
+    // sheet slow to show paid (NIP-47 settlement detection)" for context.
     const call = provider.lookupInvoice({ paymentHash });
     const result = (await (options.replyTimeoutMs !== undefined
       ? withTimeout(call, options.replyTimeoutMs, `lookupInvoice(${walletId})`)
       : call)) as {
       preimage?: string;
-      invoice?: string;
-      settled_at?: number;
+      paymentRequest?: string;
+      paid?: boolean;
     };
-    const paid = Boolean(result?.settled_at && result.settled_at > 0);
     return {
       preimage: result?.preimage,
-      invoice: result?.invoice,
-      paid,
+      // WebLN names the bolt11 field `paymentRequest`; our caller contract
+      // exposes it as `invoice` so consumers stay decoupled from the SDK.
+      invoice: result?.paymentRequest,
+      paid: result?.paid === true,
     };
   } catch (error) {
     if (isTerminalLookupError(error)) {


### PR DESCRIPTION
Closes #553.

## What

Two complementary fixes for the recipient-sees-the-payment-before-our-app-marks-it-paid symptom in #553. Both live in `nwcService.ts`; they address different links in the same chain.

### Fix 1 — Settlement predicate matched the wrong shape

`nwcService.lookupInvoice` was checking `result.settled_at` and `result.state` to decide `paid`. Those are NIP-47 spec fields — but we don't call the raw `NWCClient`. We call `NostrWebLNProvider.lookupInvoice` from `@getalby/sdk`, which translates the underlying NIP-47 response into the **WebLN** `LookupInvoiceResponse` shape (`{preimage, paymentRequest, paid}`). So the predicate was dead code against our actual SDK path — every tick returned `false`, and settlement only ever caught via the slow 30 s balance-diff fallback (typical observed lag: 30 s on a good day, up to 3 min on a slow LN route).

Verified empirically against a live LNbits today with a 21-sat self-payment:
- **Before:** 2 m 50 s end-to-end (balance-diff fallback).
- **After:** 21 s end-to-end, of which ~1 s is the app's tick latency post-settlement and the rest is Lightning Network routing on LNbits' side.

Knock-on bug also fixed: `nwcService.lookupInvoice` was returning `result.invoice` to callers, but WebLN names the bolt11 field `paymentRequest` — so consumers like `TransactionDetailSheet`'s enrichment path were silently getting `undefined`. Now mapped once inside `lookupInvoice` so the existing caller contract (which uses `invoice`) actually populates.

### Fix 2 — `replyTimeoutMs` ceiling on `lookupInvoice`

(Original PR scope.) Adds an optional `replyTimeoutMs` ceiling to `nwcService.lookupInvoice` and passes it from all four settlement-relevant call-sites. Without it, a slow NIP-47 reply blocked the 1 s / 5 s pile-up-guarded tick for the SDK's ~10 s default, blowing latency into payment detection.

| Call-site | Cap | Rationale |
|---|---:|---|
| `WalletContext.expectPayment` 1 s receive-side poll | 2500 ms | Matches sibling `getBalance` ceiling |
| `nwcService.payInvoice` post-publish-failure retry pre-flight | 2500 ms | One-shot duplicate-pay guard, safe to fail fast |
| `nwcService.payInvoice` reply-timeout 5 s poll | 5000 ms | Past the SDK's main timeout; bounded to avoid 15 s effective tick |
| `nwcService.payInvoice` INTERNAL/unknown error recovery | 2500 ms | One-shot disambiguation |

The sibling `getBalance` call has used an explicit 2500 ms cap for months (#133, `WalletContext.tsx:1696`); `lookupInvoice` was the gap.

## Why this is safe

- `withTimeout` rejects the wait, but the SDK's underlying promise completes in the background — no leaked round-trip.
- A timed-out tick is functionally identical to "still in-flight" — the next tick races again.
- Recipient-side settlement is unaffected — this is polling latency, not settlement correctness.
- Same `withTimeout` primitive `getBalance` has used safely in production for months.
- The WebLN-vs-NIP-47 fix is a strict bug fix — the prior predicate could never return `true` on this code path, so widening it doesn't introduce new false-positive surface.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean (no new errors; 7 pre-existing warnings unrelated to this change)
- [x] `npm test` — **277 / 277 passing** (timeout-caps half of the PR)
- [x] Live verified on a Pixel-equivalent emulator against `bank.weeksfamily.me` LNbits: 21-sat self-payment detected in **21 s end-to-end**, of which ≤1 s is our tick latency after LNbits sees settlement (vs **~3 min** before the fix). Diagnostic capture of the wire-format and full investigation in `docs/TROUBLESHOOTING.adoc` → "Receive sheet slow to mark invoice as paid".
- [ ] Pixel smoke test (production-ish flow): receive a small WoS payment, confirm the app marks paid within ~2 s of the recipient seeing it.
- [ ] Pixel smoke test: send a small payment, confirm the "in-flight" overlay clears at the same rate.
- [ ] Confirm no regression on slow-network conditions: a single slow NIP-47 round-trip should no longer block subsequent poll ticks.

## Out of scope (filed separately)

- #554 — broader JS-thread contention investigation (settlement lag + QR-scan flakiness may share a deeper root cause; this PR closes one specific gap in the polling path regardless).
- NIP-47 push notifications: investigated and not currently feasible — `riccardobl/nwcprovider` doesn't implement kind 23196/23197 yet, and the open PR #15 there (adds `state` field) explicitly defers push as out of scope. A prefer-push-fallback-poll design would be the right follow-up once a notifications-capable wallet service is in play; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
