### PR TITLE
perf(explore): pause NIP-GC + NIP-52 subscriptions on tab blur (#554)

### DIFF
--- a/scripts/_piggyFixtures.mjs
+++ b/scripts/_piggyFixtures.mjs
@@ -11,9 +11,9 @@
 //   EVIL   → MAESTRO_NSEC_EVIL      (the antagonist — for moderation /
 //                                    untrusted-publisher test paths)
 //
-// Reference: reference_ben_nostr_identity memory + the existing
-// MAESTRO_NSEC_* convention already in publish-test-find-logs.mjs,
-// send-nip17-test.mjs, verify-bigpiggy-outbox.mjs, verify-recv.mjs.
+// Reference: the existing MAESTRO_NSEC_* convention already in use
+// across publish-test-find-logs.mjs, send-nip17-test.mjs,
+// verify-bigpiggy-outbox.mjs, and verify-recv.mjs.
 
 import { getPublicKey } from 'nostr-tools/pure';
 import * as nip19 from 'nostr-tools/nip19';
@@ -52,9 +52,7 @@ export function decodeNsec(nsec, contextLabel = 'nsec') {
 //   const { sk, pk } = resolvePiggy('BIG');
 export function resolvePiggy(role) {
   if (!PIGGY_NSEC_ENV[role]) {
-    throw new Error(
-      `Unknown Piggy role "${role}". Known roles: ${PIGGY_ROLES.join(', ')}`,
-    );
+    throw new Error(`Unknown Piggy role "${role}". Known roles: ${PIGGY_ROLES.join(', ')}`);
   }
   const envVar = PIGGY_NSEC_ENV[role];
   const nsec = process.env[envVar];

--- a/scripts/delete-piglet.mjs
+++ b/scripts/delete-piglet.mjs
@@ -5,13 +5,14 @@
 // kind 5 still sees the listing as effectively retracted (NIP-01
 // replaceable: newest per (author, kind, d) wins).
 //
-// The signing key is one of the named Piggy fixtures (see
-// scripts/_piggyFixtures.mjs). Default is BIG; pass --piggy=ROLE or
-// set PIGGY_ROLE to delete a Piglet hidden by a different fixture.
-// The author of the targeted event must match the chosen Piggy.
+// The signing key comes from the named Piggy fixture chosen via
+// `--piggy=ROLE` (or the `PIGGY_ROLE` env var) — see scripts/
+// _piggyFixtures.mjs for the role → MAESTRO_NSEC_* mapping. Defaults
+// to BIG; the legacy `PIGGY_NSEC` env var is no longer read. The
+// author of the targeted event must match the chosen Piggy.
 //
 // Usage:
-//   PIGGY_NSEC=nsec1… node scripts/delete-piglet.mjs <eventId> <dTag>
+//   node scripts/delete-piglet.mjs [--piggy=ROLE] <eventId> <dTag>
 //
 // Example:
 //   node scripts/delete-piglet.mjs \
@@ -91,16 +92,24 @@ async function publish(url, evt) {
   return new Promise((resolve) => {
     const ws = new WebSocket(url);
     const timer = setTimeout(() => {
-      try { ws.close(); } catch {}
+      try {
+        ws.close();
+      } catch {}
       resolve({ url, ok: false, note: 'timeout' });
     }, 5000);
     ws.on('open', () => ws.send(JSON.stringify(['EVENT', evt])));
     ws.on('message', (raw) => {
       let msg;
-      try { msg = JSON.parse(raw.toString()); } catch { return; }
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
       if (msg[0] === 'OK' && msg[1] === evt.id) {
         clearTimeout(timer);
-        try { ws.close(); } catch {}
+        try {
+          ws.close();
+        } catch {}
         resolve({ url, ok: msg[2], note: msg[3] ?? '' });
       } else if (msg[0] === 'NOTICE') {
         console.error(`NOTICE from ${url}: ${JSON.stringify(msg[1])}`);

--- a/scripts/publish-test-event-batch.mjs
+++ b/scripts/publish-test-event-batch.mjs
@@ -1,15 +1,17 @@
 // Seeds a handful of NIP-52 kind 31923 events from Big Piggy so the
 // Events sub-screen has realistic-looking content for screenshots
 // and demo videos. Each event:
-//   - Signs with $NSEC (defaults to $MAESTRO_NSEC_BIG) so the WoT
-//     filter passes
+//   - Signs with a named Piggy fixture sourced via `pickRole` /
+//     `resolvePiggy` from scripts/_piggyFixtures.mjs (default: BIG,
+//     i.e. `MAESTRO_NSEC_BIG`) so the WoT filter passes. The legacy
+//     `NSEC` env var is no longer read.
 //   - Has multi-precision g tags so geohash-prefix subs catch it
 //   - Carries an `image` tag pointing at a flyer in `docs/test-fixtures/`
 //   - Has start times spread across the next 4 weeks so the Events
 //     screen's "UP NEXT" highlight + chronological ordering both
 //     have material to work with
 //
-//   NSEC=nsec1... node scripts/publish-test-event-batch.mjs
+//   node scripts/publish-test-event-batch.mjs [--piggy=ROLE]
 import { finalizeEvent, nip19 } from 'nostr-tools';
 import { SimplePool } from 'nostr-tools/pool';
 import { useWebSocketImplementation } from 'nostr-tools/relay';

--- a/scripts/publish-test-find-logs.mjs
+++ b/scripts/publish-test-find-logs.mjs
@@ -2,12 +2,14 @@
 // Geo-Cache 1 so the HuntPiggyDetail screen's "Find log" section has
 // realistic entries for screenshots + UX testing.
 //
-// Each find is signed by a different Piggy fixture (Big / Middle /
-// Little) so the in-app `usePubkeyProfile` lookup resolves real
+// Each find is signed by a different Piggy fixture (Middle / Little /
+// Evil) so the in-app `usePubkeyProfile` lookup resolves real
 // kind-0 display names + avatars, not anonymous hex pubkeys. (An
 // earlier version used `generateSecretKey()` per find — fresh
 // disposable keys that have no published kind-0 profile, so the find
-// rows fell back to a generic User icon.)
+// rows fell back to a generic User icon.) The Evil-signed entry is
+// deliberate: it exercises the find-log row's untrusted-publisher path
+// without needing a separate test script.
 //
 //   node scripts/publish-test-find-logs.mjs
 //

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -325,57 +325,71 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   const [untrustedCacheCount, setUntrustedCacheCount] = useState(0);
   const [untrustedEventCount, setUntrustedEventCount] = useState(0);
   const subsCloserRef = useRef<(() => void)[]>([]);
-  useEffect(() => {
-    if (!pos) return;
-    const myGh = encodeGeohash(pos.lat, pos.lon, 7);
-    // Caches sit at precision 5 (~5 km) — geocaching is inherently
-    // hyper-local. Events broaden to precision 3 (~150 km) so a rural
-    // user catches the nearest city's Bitcoin meetup; most NIP-52
-    // publishers emit g tags at every precision 3..9.
-    const cachePrefixes = geohashPrefixes(myGh, 5).filter((p) => p.length === 5);
-    const eventPrefixes = geohashPrefixes(myGh, 3).filter((p) => p.length === 3);
+  // NIP-GC + NIP-52 subscriptions are wrapped in useFocusEffect so they
+  // pause on tab blur. Previously the subs stayed open for the rest of
+  // the session once the user visited Explore even once — relay events
+  // kept landing on the JS thread (a Map clone per delivery is small
+  // but not free) while the user was on Home/Messages/Friends, eating
+  // into bridge dispatches for payment-settlement polls + QR-scan
+  // callbacks (#554). Reconnect on re-focus is ~100 ms; foreground
+  // JS-thread responsiveness is the better trade.
+  useFocusEffect(
+    useCallback(() => {
+      // refreshKey is a dep but not referenced in the body — it bumps
+      // on pull-to-refresh and we want that to tear down + re-run the
+      // subscriptions. The explicit `void` keeps exhaustive-deps happy.
+      void refreshKey;
+      if (!pos) return;
+      const myGh = encodeGeohash(pos.lat, pos.lon, 7);
+      // Caches sit at precision 5 (~5 km) — geocaching is inherently
+      // hyper-local. Events broaden to precision 3 (~150 km) so a rural
+      // user catches the nearest city's Bitcoin meetup; most NIP-52
+      // publishers emit g tags at every precision 3..9.
+      const cachePrefixes = geohashPrefixes(myGh, 5).filter((p) => p.length === 5);
+      const eventPrefixes = geohashPrefixes(myGh, 3).filter((p) => p.length === 3);
 
-    subsCloserRef.current.push(
-      subscribeNearbyCaches(cachePrefixes, (c) => {
-        // WoT filter: silently drop caches from pubkeys outside the
-        // trust graph (an unverified cache could be a phishing LNURL
-        // or, worse, a physical lure). Surfaced as a count instead so
-        // users know they exist without being lured into inspecting them.
-        if (!isTrustedRef.current(c.hiderPubkey)) {
-          setUntrustedCacheCount((n) => n + 1);
-          return;
-        }
-        setCaches((prev) => {
-          const existing = prev.get(c.coord);
-          if (existing && existing.createdAt >= c.createdAt) return prev;
-          const next = new Map(prev);
-          next.set(c.coord, c);
-          return next;
-        });
-      }),
-    );
-    subsCloserRef.current.push(
-      subscribeNearbyEvents(eventPrefixes, (e) => {
-        // Skip events that already started > 1h ago.
-        if (e.startsAt && e.startsAt < Math.floor(Date.now() / 1000) - 60 * 60) return;
-        if (!isTrustedRef.current(e.organiserPubkey)) {
-          setUntrustedEventCount((n) => n + 1);
-          return;
-        }
-        setEvents((prev) => {
-          const existing = prev.get(e.coord);
-          if (existing && existing.startsAt === e.startsAt) return prev;
-          const next = new Map(prev);
-          next.set(e.coord, e);
-          return next;
-        });
-      }),
-    );
-    return () => {
-      subsCloserRef.current.forEach((c) => c());
-      subsCloserRef.current = [];
-    };
-  }, [pos, refreshKey]);
+      subsCloserRef.current.push(
+        subscribeNearbyCaches(cachePrefixes, (c) => {
+          // WoT filter: silently drop caches from pubkeys outside the
+          // trust graph (an unverified cache could be a phishing LNURL
+          // or, worse, a physical lure). Surfaced as a count instead so
+          // users know they exist without being lured into inspecting them.
+          if (!isTrustedRef.current(c.hiderPubkey)) {
+            setUntrustedCacheCount((n) => n + 1);
+            return;
+          }
+          setCaches((prev) => {
+            const existing = prev.get(c.coord);
+            if (existing && existing.createdAt >= c.createdAt) return prev;
+            const next = new Map(prev);
+            next.set(c.coord, c);
+            return next;
+          });
+        }),
+      );
+      subsCloserRef.current.push(
+        subscribeNearbyEvents(eventPrefixes, (e) => {
+          // Skip events that already started > 1h ago.
+          if (e.startsAt && e.startsAt < Math.floor(Date.now() / 1000) - 60 * 60) return;
+          if (!isTrustedRef.current(e.organiserPubkey)) {
+            setUntrustedEventCount((n) => n + 1);
+            return;
+          }
+          setEvents((prev) => {
+            const existing = prev.get(e.coord);
+            if (existing && existing.startsAt === e.startsAt) return prev;
+            const next = new Map(prev);
+            next.set(e.coord, e);
+            return next;
+          });
+        }),
+      );
+      return () => {
+        subsCloserRef.current.forEach((c) => c());
+        subsCloserRef.current = [];
+      };
+    }, [pos, refreshKey]),
+  );
 
   // ----- lessons progress (local) -----------------------------------------
 

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -335,10 +335,10 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // JS-thread responsiveness is the better trade.
   useFocusEffect(
     useCallback(() => {
-      // refreshKey is a dep but not referenced in the body — it bumps
-      // on pull-to-refresh and we want that to tear down + re-run the
-      // subscriptions. The explicit `void` keeps exhaustive-deps happy.
-      void refreshKey;
+      // `refreshKey` is intentionally listed in the deps below so that
+      // pull-to-refresh (which bumps it) tears down + re-runs the
+      // subscriptions, even though the value isn't referenced inside
+      // the body.
       if (!pos) return;
       const myGh = encodeGeohash(pos.lat, pos.lon, 7);
       // Caches sit at precision 5 (~5 km) — geocaching is inherently


### PR DESCRIPTION
Part 2 of #554 (background contention investigation). Sister PR: #556.

## Symptom

Once the user visited Explore even once, the kind-37516 (NIP-GC caches) and kind-31923 (NIP-52 events) subscriptions stayed open for the rest of the session — relay events kept landing on the JS thread while the user was on Home / Messages / Friends. Each delivery does a small `Map` clone in `setCaches` / `setEvents`; per event it's cheap, but a relay burst of 50 events while a payment is in flight is exactly the kind of contention that delays the NWC reply dispatch.

## Fix

Wrap the subscription effect in `useFocusEffect` so the subs tear down on tab blur and re-open on focus. Teardown body unchanged.

Reconnect on re-focus costs ~100 ms of WebSocket handshake to the NIP-GC relays; foreground JS-thread responsiveness during a payment is the better trade.

## Also bundled in (Copilot review fodder from the earlier review pass on this PR)

A handful of script-doc cleanups + prettier-fix lines that the Copilot reviewer flagged during the first review of this branch. They're cosmetic and live in `scripts/` (so they don't touch any app-runtime code), but worth listing so the file count doesn't surprise reviewers:

- `scripts/delete-piglet.mjs` — Usage block updated to `[--piggy=ROLE] <eventId> <dTag>` (legacy `PIGGY_NSEC` env-var docs removed).
- `scripts/publish-test-event-batch.mjs` — header references `pickRole` / `resolvePiggy` (legacy `$NSEC` example removed).
- `scripts/_piggyFixtures.mjs` — dropped the repo-foreign `reference_ben_nostr_identity memory` reference; kept the cross-reference to the existing `MAESTRO_NSEC_*` convention used across sibling scripts.
- `scripts/publish-test-find-logs.mjs` — header now reads "Middle / Little / Evil" to match the actual FINDS roster + a sentence noting the EVIL-signed entry exercises the untrusted-publisher path.
- A few prettier whitespace fixes around `[PerfBlock]` console.log lines in `ExploreHomeScreen.tsx`.

None of those are perf-related — they're piggy-backing the merge.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` — no new warnings
- `npm test` — 422 / 422 passing
- AVD (LP_API34, dev client) smoke test — open Explore once so subs are live, switch to Home, return: rails re-populate on focus from `peekCachedCachesSync` / `peekCachedEventsSync` and a fresh REQ kicks in. Pull-to-refresh still bumps `refreshKey` and re-runs the effect as intended.

## What to expect

Settlement-status polls and QR-scan callbacks get more JS-thread time when you're not actively on the Explore tab. The Explore rails will re-populate on focus — the first re-render after switching back to Explore will trigger a fresh relay event stream (cached items still paint synchronously from `peekCachedCachesSync` / `peekCachedEventsSync`).

### Known minor trade-offs

- **Cache freshness gap on return.** Events arriving on relays while the tab was blurred are missed for that window; NIP-GC + NIP-52 publishers generally re-stream recent events when a new REQ subscribes, so the gap closes within seconds of re-focus.
- **Subscription churn at the relay.** Every tab switch round-trips `CLOSE` + new `REQ`. Public relays generally tolerate this; if anyone reports "events stop arriving on Explore after rapid tab switching" we'll revisit.

Closes part of #554. Pair with #556 for the full contention fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
