### PR TITLE
perf: React.Profiler + tighter NIP-17 yield to surface 24-57s freeze (#560)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -484,8 +484,15 @@ const DECRYPT_YIELD_EVERY = 15;
  * breathing room for gorhom-bottom-sheet's open animation to schedule
  * frames. Halving this doubles yield frequency, drops the per-burst
  * blocking from ~8 ms to ~4 ms, and lets bottom-sheet opens stay
- * smooth during inbox drain. */
-const NIP17_LOOP_YIELD_EVERY = 4;
+ * smooth during inbox drain.
+ *
+ * Lowered again 2026-05-16 from 4 → 2: tonight's instrumented Pixel
+ * logs (issue #560) showed refreshDmInbox running for 8.6 s wall-clock
+ * with 3 s heartbeat gaps stacking during the decrypt loop. Yielding
+ * every 2 wraps cuts each per-burst block back to ~2 ms; the
+ * setImmediate cost is amortised across the still-significant
+ * per-wrap decrypt work so the overhead is < 5%. */
+const NIP17_LOOP_YIELD_EVERY = 2;
 
 /**
  * Minimum gap between `refreshDmInbox` calls fired by

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -1053,4 +1053,24 @@ const createLocalStyles = (colors: Palette) =>
     },
   });
 
-export default ExploreHomeScreen;
+// React.Profiler wrapper — see HomeScreen for the rationale (#560).
+// Explore is the screen Ben saw the 24-57 s freezes on; this surfaces
+// the render-commit cost so we can finally see whether the freezes are
+// React work (Profiler fires) or something else (silent).
+const ProfiledExploreHomeScreen: React.FC<Props> = (props) => (
+  <React.Profiler
+    id="ExploreHomeScreen"
+    onRender={(id, phase, actualDuration) => {
+      if (actualDuration > 100) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[PerfBlock] render:${id} ${phase}=${Math.round(actualDuration)}ms`,
+        );
+      }
+    }}
+  >
+    <ExploreHomeScreen {...props} />
+  </React.Profiler>
+);
+
+export default ProfiledExploreHomeScreen;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -364,4 +364,27 @@ const HomeScreen: React.FC = () => {
   );
 };
 
-export default HomeScreen;
+// React.Profiler wrapper to surface render-commit costs as
+// [PerfBlock] log lines. Threshold-gated to ≥ 100 ms (the user-perceived
+// jank floor) so the log doesn't drown on healthy frames. The id arg
+// is the screen name so multi-screen Profiler output is greppable as
+// [PerfBlock] render:<screen>. Pre-fix the silent 20-45 s freezes in
+// #560 had no React-side instrumentation, so render-storm cost from
+// the 596-contact setContacts dispatch was completely invisible.
+const ProfiledHomeScreen: React.FC = () => (
+  <React.Profiler
+    id="HomeScreen"
+    onRender={(id, phase, actualDuration) => {
+      if (actualDuration > 100) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[PerfBlock] render:${id} ${phase}=${Math.round(actualDuration)}ms`,
+        );
+      }
+    }}
+  >
+    <HomeScreen />
+  </React.Profiler>
+);
+
+export default ProfiledHomeScreen;


### PR DESCRIPTION
Closes part of #560.

## What

Two complementary changes targeting the 20-57 s JS-thread freezes Ben hit on the Pixel:

1. **`NIP17_LOOP_YIELD_EVERY: 4 → 2`** — `refreshDmInbox` was running 8.6 s wall-clock with 3 s heartbeat gaps stacking during the unwrap loop. Halving the yield cadence cuts per-burst blocking back to ~2 ms; the setImmediate cost amortises across the still-significant per-wrap decrypt work so overhead is < 5%.

2. **React.Profiler wrappers around HomeScreen + ExploreHomeScreen** — tonight's logs showed the dominant freeze is in code without `[PerfBlock]` markers. The most likely culprit is render-commit cost from the 596-contact `setContacts` dispatch triggering tree-wide re-renders. Profiler measures the commit phase directly; `onRender` threshold of 100 ms (user-perceived jank floor) keeps logcat quiet on healthy frames and only fires on real outliers.

Output as `[PerfBlock] render:<id> <phase>=<ms>ms`, greppable alongside the existing PerfBlock markers (`subscribeNearbyCaches`, `NWC.getBalance`, etc.).

## Why this PR exists separately from #488

#488 already carries a lot of feature work for the Explore tab; the perf instrumentation here is targeted at the residual freeze that's not directly tied to the new surfaces. Keeping it on a sibling branch makes the diff readable and the perf-vs-feature decision easier to revert independently.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Re-run Pixel perf suite after merge + compare heartbeat gap distribution
- [ ] On a Pixel session: navigate Home → Explore → cache detail → back, and verify each render takes < 100 ms or shows up in logcat with its cost

## Follow-ups (NOT in this PR)

- The proper fix is GH #561 (NIP-47 notifications instead of polling) — once the wallet service pushes `payment_received` / `balance_updated` events, the polling that drives most of the NWC retry storm goes away.
- If Profiler shows render-storm is the dominant cost, the next step is memo-ising heavy children of HomeScreen / ExploreHomeScreen (TransactionList, WalletCarousel, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)