### PR TITLE
perf(wallet): demand-gate the 30s NWC balance poll (#569)

### DIFF
--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -192,6 +192,21 @@ interface WalletContextType {
     durationMs?: number,
   ) => void;
 
+  /**
+   * Demand-counted gate on the 30 s background `getBalance` poll. The
+   * poll runs only while at least one caller has an outstanding request
+   * — typical pattern is a balance-displaying screen calling
+   * `requestBalancePoll()` inside `useFocusEffect` and using the
+   * returned unsubscribe in the cleanup. When the demand count drops to
+   * zero the interval is torn down, saving the ~700-1300 ms NWC round
+   * trip + the cascading WalletCarousel/TransactionList re-render that
+   * fires on every poll. See #569 + #560 for the perf rationale. The
+   * `expectPayment` 1 s tick is independent and unaffected — it's a
+   * separate per-invoice poller. Returns an unsubscribe fn; safe to
+   * call the unsubscribe multiple times (idempotent past zero).
+   */
+  requestBalancePoll: () => () => void;
+
   // Legacy compatibility
   isConnected: boolean;
   balance: number | null;
@@ -1868,8 +1883,32 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const activeWalletConnected =
     activeWallet?.walletType !== 'onchain' && activeWallet?.isConnected === true;
 
+  // Demand-counter for the 30 s balance poll. Incremented by
+  // `requestBalancePoll()` callers (typically balance-displaying screens
+  // inside `useFocusEffect`) and decremented by their returned cleanup.
+  // The poll effect below gates on `balancePollDemand > 0` so we only
+  // pay the NWC round-trip + downstream render cost when at least one
+  // surface is actively showing the balance. See #569.
+  const [balancePollDemand, setBalancePollDemand] = useState(0);
+
+  const requestBalancePoll = useCallback<WalletContextType['requestBalancePoll']>(() => {
+    setBalancePollDemand((d) => d + 1);
+    let released = false;
+    return () => {
+      // Idempotent on repeat-release so a defensive double-cleanup in
+      // an unmount path can't drag the counter below zero.
+      if (released) return;
+      released = true;
+      setBalancePollDemand((d) => Math.max(0, d - 1));
+    };
+  }, []);
+
   useEffect(() => {
     if (!activeWalletId || !activeWalletConnected) return;
+    // No focused surface needs the balance right now — skip the
+    // interval setup entirely. Re-runs when demand transitions 0 → 1
+    // (focus event in a balance-displaying screen).
+    if (balancePollDemand <= 0) return;
 
     const refreshOnce = () => {
       // Bail if the wallet has since disconnected — we read through
@@ -1912,7 +1951,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       stopPoll();
       sub.remove();
     };
-  }, [activeWalletId, activeWalletConnected, updateWalletInState]);
+  }, [activeWalletId, activeWalletConnected, updateWalletInState, balancePollDemand]);
 
   // Stable context value — without `useMemo` here the inline `{{...}}`
   // literal produced a fresh object identity on every render of
@@ -1953,6 +1992,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       lastIncomingPayment,
       clearLastIncomingPayment,
       expectPayment,
+      requestBalancePoll,
       isConnected,
       balance,
       walletAlias,
@@ -1991,6 +2031,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       lastIncomingPayment,
       clearLastIncomingPayment,
       expectPayment,
+      requestBalancePoll,
     ],
   );
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -51,6 +51,7 @@ const HomeScreen: React.FC = () => {
     setActiveWallet,
     btcPrice,
     currency,
+    requestBalancePoll,
   } = useWallet();
   const { isLoggedIn, profile, refreshProfile } = useNostr();
   const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList, 'Home'>>();
@@ -85,6 +86,20 @@ const HomeScreen: React.FC = () => {
       const handle = InteractionManager.runAfterInteractions(() => refreshProfile());
       return () => handle.cancel();
     }, [isLoggedIn, refreshProfile]),
+  );
+
+  // Drive the 30 s NWC balance poll only while Home is focused — see
+  // #569. The poll lives in WalletContext but is now demand-gated: this
+  // screen signals "the balance is on screen, keep refreshing it" on
+  // focus, and the cleanup signals "I no longer need it" on blur. The
+  // initial in-effect `refreshOnce()` inside WalletContext means the
+  // balance refreshes immediately on return to Home rather than waiting
+  // up to 30 s for the next tick.
+  useFocusEffect(
+    useCallback(() => {
+      const release = requestBalancePoll();
+      return release;
+    }, [requestBalancePoll]),
   );
 
   // Handle sendToAddress from navigation params (e.g., from Friends tab zap)


### PR DESCRIPTION
Closes #569.

## Symptom

`WalletContext.tsx` runs a 30 s `setInterval(refreshOnce, 30000)` polling `nwcService.getBalance(activeWalletId)`. It only pauses on `AppState` change to background — NOT on screen-focus change. While the user is on Explore / Messages / Friends / Map (where balance isn't displayed) the app still polls the NWC relay every 30 s, costing ~700-1300 ms wall-clock per call (per the `[PerfBlock] NWC.getBalance` markers in Pixel preview logcat). Wasteful relay traffic + a render of HomeScreen + WalletCarousel + TransactionList every poll cycle while none of those are visible.

## Fix

**Demand-counter pattern** (option 1 from the issue):

- `WalletContext` exposes `requestBalancePoll(): () => void`. Caller increments a private demand counter; returned cleanup decrements (idempotent past zero so a double-release on unmount is safe).
- The polling `useEffect` adds `balancePollDemand` to its deps and early-returns when demand is zero. So the interval is torn down when no surface needs the balance and re-armed when one does. The in-effect `refreshOnce()` on (re-)mount means the balance refreshes immediately on return to Home rather than waiting up to 30 s.
- `HomeScreen.tsx` calls `requestBalancePoll()` inside a `useFocusEffect` and uses the returned cleanup on blur. Other screens that don't display the balance simply don't call it — no widening required.

`expectPayment` is unaffected — it's a separate per-invoice poller that lives outside this gating layer.

## Why this design over the alternatives

Issue #569 listed three options. Picked the demand-counter one because:

- **No navigation coupling.** `WalletContext` stays unaware of route names — only HomeScreen knows it displays the balance. Any future balance-displaying screen (Account balance card? Wallet picker? a future widget?) just calls `requestBalancePoll()` and the gate Just Works.
- **No risk of dropping the balance while focused.** The counter > 0 guarantee means the interval runs *as long as* a focused screen demands it, even across mid-focus context changes.
- **Idempotent release** so a double-cleanup in an unmount path can't drag the counter into negative territory.

## Test plan

- [x] `npx tsc --noEmit` — clean (the pre-existing MapLibre dep TS error in this local env is unrelated and goes away on a fresh `npm install`).
- [x] `npx prettier --check` — clean.
- [x] `npx eslint` on touched files — no new warnings (4 pre-existing on HomeScreen unrelated to this PR).
- [ ] AVD walk-through: open Home → check logcat shows `[PerfBlock] NWC.getBalance` at 30 s cadence → switch to Messages → markers stop → switch back to Home → markers resume + immediate refresh fires.
- [ ] Pixel preview build: same flow on real device — confirms behaviour on a real OS scheduler (the AVD's `setInterval` is generally well-behaved; real Doze / battery-saver paths can surprise).

## What to expect

On Explore / Map / Messages / Friends the `[PerfBlock] NWC.getBalance` markers no longer fire on the 30 s cadence. Home behaviour unchanged — balance refreshes within 30 s as before (or sooner via `expectPayment`).

## Out of scope

- **BTC price fetch** — issue noted this could share the same gating, but the current cadence is 5 min so it's not a meaningful perf win. Filed under #560 if anyone wants it later.

Closes #569 — tracked under #560 (perf umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
