### PR TITLE
fix(nav): de-dupe Android-resurrected NDEF intent on app wake (#576)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -77,9 +77,33 @@ export default function App() {
   // mount, so we retry briefly until `navigationRef.isReady()`.
   useEffect(() => {
     let cancelled = false;
+    // De-dupe NFC-tag launch URLs. Android keeps the NDEF_DISCOVERED
+    // intent attached to the activity's `baseIntent`, so every time
+    // the user brings the app back from recents (or after a low-
+    // memory restart) `Linking.getInitialURL()` re-returns the same
+    // `lightningpiggy://hunt/<coord>` URL — and the in-process Linking
+    // event listener also re-fires for the redelivered intent. Pre-
+    // fix this meant every tab-tap that woke the app shoved
+    // HuntPiggyDetail back onto the Explore stack, even after the
+    // user explicitly tapped Explore to pop to root. Track the most
+    // recent routed URL + its timestamp; ignore re-deliveries within
+    // 30s (covers the recents/wake re-entry window). After that
+    // window a genuine fresh tap on the same physical tag still
+    // routes normally.
+    let lastRouted: { url: string; at: number } | null = null;
+    const ROUTE_DEDUPE_MS = 30_000;
     const route = (raw: string | null | undefined) => {
       if (cancelled || !raw) return;
       const trimmed = raw.trim();
+      if (
+        lastRouted &&
+        lastRouted.url === trimmed &&
+        Date.now() - lastRouted.at < ROUTE_DEDUPE_MS
+      ) {
+        console.log(`[Link] de-duped Android-resurrected NDEF intent within ${ROUTE_DEDUPE_MS}ms`);
+        return;
+      }
+      lastRouted = { url: trimmed, at: Date.now() };
       // Truncate noisy URIs so the log doesn't blow past logcat's
       // line limit but keep enough head + tail to identify them.
       const peek = trimmed.length > 96 ? trimmed.slice(0, 60) + '…' + trimmed.slice(-20) : trimmed;


### PR DESCRIPTION
## Why

After scanning a Hide-a-Piglet NFC tag, tapping the Explore tab kept landing on HuntPiggyDetail for the cached tag instead of the Explore home rails — even after the popToTop listener I added in #572. Spotted on the Pixel during preview-build testing.

## Root cause

From Pixel logcat (`adb logcat | grep NDEF_DISCOVERED`):

```
baseIntent=Intent {
  act=android.nfc.action.NDEF_DISCOVERED
  dat=lightningpiggy://hunt/...
  flg=0x13000000
  cmp=com.lightningpiggy.app.preview/.MainActivity
}
... debugName = LaunchFromRecents
```

The activity's `baseIntent` stays as the NDEF discovery intent that originally launched it. Every time Android brings the task back to the foreground (recents switcher, low-memory restart, etc.) the JS `Linking.getInitialURL()` re-returns the same `lightningpiggy://hunt/<coord>` URL — and the in-process `url` listener also re-fires with the redelivered intent. The Linking handler dutifully navigates to HuntPiggyDetail. The Explore-tab popToTop runs correctly but a frame later the re-delivered URL re-pushes the detail screen.

## Fix

Track the most recent routed URL + timestamp in the Linking handler. Ignore re-deliveries of the same URL within a 30-second window. A genuine fresh tap on the same physical tag after the window still routes normally; a wake-from-recents tens of seconds after the original scan no longer hijacks navigation.

## Test plan

1. On the Pixel preview build, tap a Hide-a-Piglet NFC tag → lands on HuntPiggyDetail (correct, fresh tap routes through).
2. Press home, switch apps, then bring Lightning Piggy back from recents.
3. Tap the Explore tab → should land on the Explore home rails. Pre-fix this still landed on HuntPiggyDetail.
4. Logcat shows `[Link] de-duped Android-resurrected NDEF intent within 30000ms` confirming the dedupe fired.

`npx tsc --noEmit` + `npx jest` + `npx eslint App.tsx` all green.

Closes #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)