### PR TITLE
fix(nav): seed Explore stack on NFC deep-link so back + tab-tap behave (#576)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -119,11 +119,7 @@ export default function App() {
       });
     };
     const isDuplicate = async (url: string): Promise<boolean> => {
-      if (
-        lastRouted &&
-        lastRouted.url === url &&
-        Date.now() - lastRouted.at < ROUTE_DEDUPE_MS
-      ) {
+      if (lastRouted && lastRouted.url === url && Date.now() - lastRouted.at < ROUTE_DEDUPE_MS) {
         return true;
       }
       // Disk fallback for the race where getInitialURL fires before
@@ -143,7 +139,9 @@ export default function App() {
       void isDuplicate(trimmed).then((dup) => {
         if (cancelled) return;
         if (dup) {
-          console.log(`[Link] de-duped Android-resurrected NDEF intent within ${ROUTE_DEDUPE_MS}ms`);
+          console.log(
+            `[Link] de-duped Android-resurrected NDEF intent within ${ROUTE_DEDUPE_MS}ms`,
+          );
           return;
         }
         const entry = { url: trimmed, at: Date.now() };

--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,6 @@ import './src/polyfills';
 
 import React, { useEffect, useState } from 'react';
 import { Linking, StyleSheet } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -78,77 +77,33 @@ export default function App() {
   // mount, so we retry briefly until `navigationRef.isReady()`.
   useEffect(() => {
     let cancelled = false;
-    // De-dupe NFC-tag launch URLs across JS restarts. Android keeps
-    // the NDEF_DISCOVERED intent attached to the activity's
-    // `baseIntent`. Every time the OS resurrects the task (recents
-    // switcher, low-memory restart, fresh process spawn) the
-    // activity relaunches with that same intent, the JS bundle
-    // starts fresh, and `Linking.getInitialURL()` returns the SAME
-    // `lightningpiggy://hunt/<coord>` URL. Pre-fix that re-pushed
-    // HuntPiggyDetail onto the Explore stack on every wake — the
-    // user's "Explore tab keeps taking me back" symptom.
-    //
-    // In-memory dedupe alone doesn't work because the JS module
-    // re-evaluates on each fresh process — `lastRouted` is reset to
-    // null and we navigate again. The fix has to be persistent
-    // across process boundaries → AsyncStorage. Window is 5 min:
-    // generous enough to cover recents/wake within a session, short
-    // enough that a genuine re-scan tomorrow still routes.
-    const ROUTE_DEDUPE_MS = 5 * 60 * 1000;
-    const DEDUPE_KEY = '@lp:last-routed-link-v1';
+    // Very short in-memory dedupe to absorb the cold-start race where
+    // both `getInitialURL()` and `addEventListener('url')` deliver the
+    // SAME URL within a few hundred ms of JS init. Tens of seconds
+    // would be safer, but persistent dedupe (across JS restarts via
+    // AsyncStorage) turned out to over-fire when the user re-scans
+    // the same tag in the same hour — stale storage swallowed
+    // genuine fresh taps. The "Explore tab takes you to the cached
+    // detail" bug was actually a different problem (deep-link
+    // navigator didn't seed ExploreHome / Hunt below HuntPiggyDetail,
+    // see `navigateToHuntPiggyDetail`); now that's fixed, 2 seconds
+    // is plenty to catch the cold-start double-fire without
+    // mis-blocking deliberate re-scans.
+    const ROUTE_DEDUPE_MS = 2_000;
     let lastRouted: { url: string; at: number } | null = null;
-    // Warm the in-memory copy from disk. The async read can lose the
-    // race against `getInitialURL().then(route)` below — that's why
-    // `route()` does its own disk check too, not just the memory
-    // copy. Memory is the fast path; disk is the source of truth.
-    AsyncStorage.getItem(DEDUPE_KEY)
-      .then((raw) => {
-        if (cancelled || !raw) return;
-        try {
-          lastRouted = JSON.parse(raw) as { url: string; at: number };
-        } catch {
-          // Bad value — drop it. Next route() write replaces it.
-        }
-      })
-      .catch(() => {
-        // Non-fatal — fall through to in-memory only.
-      });
-    const persistRouted = (entry: { url: string; at: number }) => {
-      AsyncStorage.setItem(DEDUPE_KEY, JSON.stringify(entry)).catch(() => {
-        // Non-fatal — next launch will route again, no worse than today.
-      });
-    };
-    const isDuplicate = async (url: string): Promise<boolean> => {
-      if (lastRouted && lastRouted.url === url && Date.now() - lastRouted.at < ROUTE_DEDUPE_MS) {
-        return true;
-      }
-      // Disk fallback for the race where getInitialURL fires before
-      // the async load completes.
-      try {
-        const raw = await AsyncStorage.getItem(DEDUPE_KEY);
-        if (!raw) return false;
-        const stored = JSON.parse(raw) as { url: string; at: number };
-        return stored.url === url && Date.now() - stored.at < ROUTE_DEDUPE_MS;
-      } catch {
-        return false;
-      }
-    };
     const route = (raw: string | null | undefined) => {
       if (cancelled || !raw) return;
       const trimmed = raw.trim();
-      void isDuplicate(trimmed).then((dup) => {
-        if (cancelled) return;
-        if (dup) {
-          console.log(
-            `[Link] de-duped Android-resurrected NDEF intent within ${ROUTE_DEDUPE_MS}ms`,
-          );
-          return;
-        }
-        const entry = { url: trimmed, at: Date.now() };
-        lastRouted = entry;
-        persistRouted(entry);
-        routeFresh(trimmed);
-      });
+      if (
+        lastRouted &&
+        lastRouted.url === trimmed &&
+        Date.now() - lastRouted.at < ROUTE_DEDUPE_MS
+      ) {
+        console.log(`[Link] de-duped cold-start double-fire within ${ROUTE_DEDUPE_MS}ms`);
+        return;
+      }
+      lastRouted = { url: trimmed, at: Date.now() };
+      routeFresh(trimmed);
     };
     const routeFresh = (trimmed: string) => {
       // Truncate noisy URIs so the log doesn't blow past logcat's

--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import './src/polyfills';
 
 import React, { useEffect, useState } from 'react';
 import { Linking, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -77,33 +78,81 @@ export default function App() {
   // mount, so we retry briefly until `navigationRef.isReady()`.
   useEffect(() => {
     let cancelled = false;
-    // De-dupe NFC-tag launch URLs. Android keeps the NDEF_DISCOVERED
-    // intent attached to the activity's `baseIntent`, so every time
-    // the user brings the app back from recents (or after a low-
-    // memory restart) `Linking.getInitialURL()` re-returns the same
-    // `lightningpiggy://hunt/<coord>` URL — and the in-process Linking
-    // event listener also re-fires for the redelivered intent. Pre-
-    // fix this meant every tab-tap that woke the app shoved
-    // HuntPiggyDetail back onto the Explore stack, even after the
-    // user explicitly tapped Explore to pop to root. Track the most
-    // recent routed URL + its timestamp; ignore re-deliveries within
-    // 30s (covers the recents/wake re-entry window). After that
-    // window a genuine fresh tap on the same physical tag still
-    // routes normally.
+    // De-dupe NFC-tag launch URLs across JS restarts. Android keeps
+    // the NDEF_DISCOVERED intent attached to the activity's
+    // `baseIntent`. Every time the OS resurrects the task (recents
+    // switcher, low-memory restart, fresh process spawn) the
+    // activity relaunches with that same intent, the JS bundle
+    // starts fresh, and `Linking.getInitialURL()` returns the SAME
+    // `lightningpiggy://hunt/<coord>` URL. Pre-fix that re-pushed
+    // HuntPiggyDetail onto the Explore stack on every wake — the
+    // user's "Explore tab keeps taking me back" symptom.
+    //
+    // In-memory dedupe alone doesn't work because the JS module
+    // re-evaluates on each fresh process — `lastRouted` is reset to
+    // null and we navigate again. The fix has to be persistent
+    // across process boundaries → AsyncStorage. Window is 5 min:
+    // generous enough to cover recents/wake within a session, short
+    // enough that a genuine re-scan tomorrow still routes.
+    const ROUTE_DEDUPE_MS = 5 * 60 * 1000;
+    const DEDUPE_KEY = '@lp:last-routed-link-v1';
     let lastRouted: { url: string; at: number } | null = null;
-    const ROUTE_DEDUPE_MS = 30_000;
+    // Warm the in-memory copy from disk. The async read can lose the
+    // race against `getInitialURL().then(route)` below — that's why
+    // `route()` does its own disk check too, not just the memory
+    // copy. Memory is the fast path; disk is the source of truth.
+    AsyncStorage.getItem(DEDUPE_KEY)
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        try {
+          lastRouted = JSON.parse(raw) as { url: string; at: number };
+        } catch {
+          // Bad value — drop it. Next route() write replaces it.
+        }
+      })
+      .catch(() => {
+        // Non-fatal — fall through to in-memory only.
+      });
+    const persistRouted = (entry: { url: string; at: number }) => {
+      AsyncStorage.setItem(DEDUPE_KEY, JSON.stringify(entry)).catch(() => {
+        // Non-fatal — next launch will route again, no worse than today.
+      });
+    };
+    const isDuplicate = async (url: string): Promise<boolean> => {
+      if (
+        lastRouted &&
+        lastRouted.url === url &&
+        Date.now() - lastRouted.at < ROUTE_DEDUPE_MS
+      ) {
+        return true;
+      }
+      // Disk fallback for the race where getInitialURL fires before
+      // the async load completes.
+      try {
+        const raw = await AsyncStorage.getItem(DEDUPE_KEY);
+        if (!raw) return false;
+        const stored = JSON.parse(raw) as { url: string; at: number };
+        return stored.url === url && Date.now() - stored.at < ROUTE_DEDUPE_MS;
+      } catch {
+        return false;
+      }
+    };
     const route = (raw: string | null | undefined) => {
       if (cancelled || !raw) return;
       const trimmed = raw.trim();
-      if (
-        lastRouted &&
-        lastRouted.url === trimmed &&
-        Date.now() - lastRouted.at < ROUTE_DEDUPE_MS
-      ) {
-        console.log(`[Link] de-duped Android-resurrected NDEF intent within ${ROUTE_DEDUPE_MS}ms`);
-        return;
-      }
-      lastRouted = { url: trimmed, at: Date.now() };
+      void isDuplicate(trimmed).then((dup) => {
+        if (cancelled) return;
+        if (dup) {
+          console.log(`[Link] de-duped Android-resurrected NDEF intent within ${ROUTE_DEDUPE_MS}ms`);
+          return;
+        }
+        const entry = { url: trimmed, at: Date.now() };
+        lastRouted = entry;
+        persistRouted(entry);
+        routeFresh(trimmed);
+      });
+    };
+    const routeFresh = (trimmed: string) => {
       // Truncate noisy URIs so the log doesn't blow past logcat's
       // line limit but keep enough head + tail to identify them.
       const peek = trimmed.length > 96 ? trimmed.slice(0, 60) + '…' + trimmed.slice(-20) : trimmed;

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -208,13 +208,13 @@ function HomeTabs() {
             const state = navigation.getState();
             const tabRoute = state?.routes.find((r) => r.name === 'Explore');
             const subState = tabRoute?.state;
+            const exploreIsFocused = state.routes[state.index]?.name === 'Explore';
+            console.log(
+              `[Tab:Explore] tabPress focused=${exploreIsFocused} subIdx=${subState?.index} subKey=${subState?.key} routes=[${(subState?.routes ?? []).map((r) => r.name).join(',')}]`,
+            );
             if (subState && typeof subState.index === 'number' && subState.index > 0) {
-              // When Explore isn't yet focused, let RN's default
-              // tab-switch run too (so focus actually shifts) — only
-              // preventDefault when Explore IS focused, since then
-              // tapping again is a no-op without our intervention.
-              const exploreIsFocused = state.routes[state.index]?.name === 'Explore';
               if (exploreIsFocused) e.preventDefault();
+              console.log(`[Tab:Explore] dispatching popToTop target=${subState.key}`);
               navigation.dispatch({
                 ...StackActions.popToTop(),
                 target: subState.key,

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -81,11 +81,28 @@ export const navigateToHuntFound = (lnurl: string): boolean => {
 // emitted by the multi-record NFC tags (#73).
 export const navigateToHuntPiggyDetail = (coord: string): boolean => {
   if (!navigationRef.isReady()) return false;
+  // Set the Explore stack state explicitly so back from HuntPiggyDetail
+  // walks through Hunt (Geo-caches list) → ExploreHome, matching the
+  // user's mental model. Pre-fix the nested `navigate(..., { screen:
+  // 'HuntPiggyDetail' })` shortcut left the Explore stack with only
+  // HuntPiggyDetail at index 0 — back-press exited Explore to the
+  // previous tab (usually Home), and Explore-tab-tap was a no-op
+  // because there was nothing to pop. Bug spotted on Pixel: "back
+  // goes to home — not to Geo-caches".
   navigationRef.navigate('Main', {
     screen: 'MainTabs',
     params: {
       screen: 'Explore',
-      params: { screen: 'HuntPiggyDetail', params: { coord } },
+      params: {
+        state: {
+          index: 2,
+          routes: [
+            { name: 'ExploreHome' },
+            { name: 'Hunt' },
+            { name: 'HuntPiggyDetail', params: { coord } },
+          ],
+        },
+      },
     },
   });
   return true;

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -226,12 +226,20 @@ function HomeTabs() {
             const tabRoute = state?.routes.find((r) => r.name === 'Explore');
             const subState = tabRoute?.state;
             const exploreIsFocused = state.routes[state.index]?.name === 'Explore';
-            console.log(
-              `[Tab:Explore] tabPress focused=${exploreIsFocused} subIdx=${subState?.index} subKey=${subState?.key} routes=[${(subState?.routes ?? []).map((r) => r.name).join(',')}]`,
-            );
+            // Gated on __DEV__ so the diagnostic doesn't leak into
+            // perf-instrumented release builds — EXPO_PUBLIC_KEEP_PERF_LOGS
+            // disables babel's transform-remove-console plugin, which
+            // would otherwise strip these (Copilot #578 r1 catch).
+            if (__DEV__) {
+              console.log(
+                `[Tab:Explore] tabPress focused=${exploreIsFocused} subIdx=${subState?.index} subKey=${subState?.key} routes=[${(subState?.routes ?? []).map((r) => r.name).join(',')}]`,
+              );
+            }
             if (subState && typeof subState.index === 'number' && subState.index > 0) {
               if (exploreIsFocused) e.preventDefault();
-              console.log(`[Tab:Explore] dispatching popToTop target=${subState.key}`);
+              if (__DEV__) {
+                console.log(`[Tab:Explore] dispatching popToTop target=${subState.key}`);
+              }
               navigation.dispatch({
                 ...StackActions.popToTop(),
                 target: subState.key,


### PR DESCRIPTION
## Why

After scanning a Hide-a-Piglet NFC tag the user reported two related-looking symptoms on the Pixel:

- *"Explore tab keeps taking me to the cached Piglet detail"* — every tap on Explore restored HuntPiggyDetail instead of the Explore home rails.
- *"Back goes to home, not to Geo-caches"* — pressing back from HuntPiggyDetail exited Explore to the previous tab.

That second clue was the smoking gun.

## Root cause

`navigateToHuntPiggyDetail` used React Navigation's nested `navigate(..., { screen: 'HuntPiggyDetail' })` shortcut. On first entry into the Explore tab — exactly what happens on a cold-launch tag tap from any other tab — the inner Explore stack ended up with **only** `[HuntPiggyDetail]` at index 0. That explained every symptom:

- **Back** had nothing below it in the Explore stack, so it exited to the previous tab (usually Home).
- **Tap Explore tab** fired the popToTop listener I added in #577, but `subState.index === 0` meant there was nothing to pop — Explore stayed on HuntPiggyDetail.
- The `Linking` handler dedupe I shipped earlier wasn't fixing the actual bug; the URL wasn't re-firing, the stack just had no history below HuntPiggyDetail to escape to.

## Fix

Seed the Explore stack explicitly when deep-linking, via the nested-navigator state form:

```ts
navigationRef.navigate('Main', {
  screen: 'MainTabs',
  params: {
    screen: 'Explore',
    params: {
      state: {
        index: 2,
        routes: [
          { name: 'ExploreHome' },
          { name: 'Hunt' },
          { name: 'HuntPiggyDetail', params: { coord } },
        ],
      },
    },
  },
});
```

Now back walks `HuntPiggyDetail → Hunt (Geo-caches) → ExploreHome → previous tab`, matching the user's mental model. The Explore-tab `popToTop` listener has a non-zero `subState.index` to act on so tab-tap pops cleanly.

I also tried two iterations of `Linking` handler dedupe (in-memory in an earlier commit, then AsyncStorage-persisted) but both turned out to be cures worse than the disease — the AsyncStorage layer in particular silently swallowed deliberate fresh re-scans when stale entries from previous taps were still in the 5-minute window. Final form: a 2-second in-memory race-guard, just enough to catch the cold-start case where `getInitialURL()` and `addEventListener('url')` deliver the same URL within a few hundred ms of JS init.

Diagnostic `console.log`s added to the Explore tab's `tabPress` listener so future regressions in the popToTop path surface in Metro logs without needing ad-hoc instrumentation.

## Test plan

1. Cold-launch the app by tapping a Hide-a-Piglet NFC tag.
2. Confirm it lands on HuntPiggyDetail for that cache (correct, deep-link routes through).
3. Press back → should land on **Geo-caches** (Hunt list). Pre-fix it exited to Home.
4. Press back again → should land on **Explore home rails**.
5. Tap a tag again, then tap the **Explore tab** while on HuntPiggyDetail → pops to ExploreHome. Pre-fix the tab tap did nothing.
6. Re-scan the same tag while the app is open → routes to HuntPiggyDetail again (no over-eager dedupe).

Manually verified by Ben on a real Pixel running the dev client.

`npx tsc --noEmit` + `npx jest` (485 specs) + `npx eslint App.tsx src/navigation/AppNavigator.tsx` all green.

Closes #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)