### PR TITLE
fix(hunt): Try-prize confetti pops on cache detail + reader-mode beats OS chooser (#579)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,7 @@ import AppNavigator, {
   navigateToHuntPiggyDetail,
 } from './src/navigation/AppNavigator';
 import * as nip19 from 'nostr-tools/nip19';
-import { wasRecentlyRead } from './src/services/nfcService';
+import { wasRecentlyRead, initNfc } from './src/services/nfcService';
 import PaymentProgressOverlay from './src/components/PaymentProgressOverlay';
 import BootSplash from './src/components/BootSplash';
 import { BrandedAlertHost } from './src/components/BrandedAlert';
@@ -63,6 +63,19 @@ export default function App() {
   useEffect(() => {
     const t = setTimeout(() => setBootDone(true), 600);
     return () => clearTimeout(t);
+  }, []);
+
+  // Pre-warm NfcManager.start() at app mount so the first NfcReadSheet
+  // / NfcWriteSheet open can call requestTechnology immediately
+  // (reader-mode active within ms) instead of waiting on the native
+  // bridge. Without this warm-up there's a ~150–300 ms window after
+  // tapping "Try prize" where reader-mode hasn't activated yet — fast
+  // hiders bring the tag to the phone in that window and the OS
+  // dispatches a "Open with…" chooser instead of routing through our
+  // in-app reader. Fire-and-forget; failure is non-fatal (each sheet
+  // re-tries via `ensureNfcStarted` on its own).
+  useEffect(() => {
+    void initNfc();
   }, []);
 
   // `lightning:` deep-link listener (Hunt finder flow, #468). LP registers

--- a/src/components/NfcReadSheet.tsx
+++ b/src/components/NfcReadSheet.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator,
   AppState,
   type AppStateStatus,
-  Platform,
 } from 'react-native';
 import {
   BottomSheetModal,
@@ -17,7 +16,7 @@ import {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { AlertCircle, Nfc, PartyPopper, PiggyBank } from 'lucide-react-native';
-import { readHuntTagPayload, cancelNfcOperation, isNfcEnabled } from '../services/nfcService';
+import { readHuntTagPayload, cancelNfcOperation } from '../services/nfcService';
 import {
   LnurlWithdrawError,
   claimLnurlWithdraw,
@@ -131,18 +130,16 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const startRead = useCallback(async () => {
     setErrorMessage('');
     setClaimedSats(null);
-    const enabled = await isNfcEnabled();
-    if (!enabled) {
-      if (mountedRef.current) {
-        setStage('error');
-        setErrorMessage(
-          Platform.OS === 'android'
-            ? 'NFC is turned off. Please enable NFC in your device settings.'
-            : 'NFC is turned off. Go to Settings to enable NFC.',
-        );
-      }
-      return;
-    }
+    // Skip the synchronous `isNfcEnabled()` pre-flight here so we
+    // can call requestTechnology (which is what activates Android
+    // reader-mode and stops the OS NDEF dispatcher from showing
+    // "Open with…") as quickly as possible after the sheet opens.
+    // Each native round-trip on Android costs ~100 ms; the previous
+    // pre-flight gave a fast hider enough time to bring the tag to
+    // the phone BEFORE reader-mode came up, so the OS chooser
+    // intercepted. If NFC is actually disabled, readHuntTagPayload's
+    // `ensureNfcStarted()` returns false and surfaces the same error
+    // message below.
     setStage('ready');
     try {
       const result = await readHuntTagPayload({

--- a/src/components/NfcReadSheet.tsx
+++ b/src/components/NfcReadSheet.tsx
@@ -16,8 +16,8 @@ import {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { AlertCircle, Nfc, PartyPopper, PiggyBank } from 'lucide-react-native';
-import { decode as bolt11Decode } from 'light-bolt11-decoder';
 import { readHuntTagPayload, cancelNfcOperation } from '../services/nfcService';
+import { paymentHashFromBolt11 } from '../utils/bolt11';
 import {
   LnurlWithdrawError,
   claimLnurlWithdraw,
@@ -75,23 +75,6 @@ const formatCountdown = (seconds: number): string => {
   return `${m}:${String(s).padStart(2, '0')}`;
 };
 
-// Pull the payment_hash off a bolt11 so we can hand it to
-// WalletContext.expectPayment for fast settlement detection. Mirrors
-// the helper in ReceiveSheet — light-bolt11-decoder exposes the hash
-// under `sections[].value` keyed by `name === 'payment_hash'`.
-function paymentHashFromBolt11(bolt11: string): string | null {
-  try {
-    const decoded = bolt11Decode(bolt11);
-    const section = decoded.sections?.find((s: { name: string }) => s.name === 'payment_hash') as
-      | { value?: string }
-      | undefined;
-    return section?.value ?? null;
-  } catch (error) {
-    if (__DEV__) console.warn('[NfcReadSheet] bolt11 decode failed:', error);
-    return null;
-  }
-}
-
 const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
@@ -106,12 +89,19 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const sheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ['55%'], []);
   const mountedRef = useRef(true);
-  // Timestamp of the moment we entered `claimed` (LNURL-w issuer
-  // accepted our invoice). Used to gate the auto-dismiss below so
-  // only payments that land AFTER the claim trigger sheet close —
-  // not unrelated wallet activity from before the user tapped Try
-  // prize.
+  // Stamped at the moment we enter `claimed` (LNURL-w issuer accepted
+  // our invoice). The auto-dismiss effect below uses both this AND
+  // the expected payment hash to scope which `lastIncomingPayment`
+  // events are "our" settlement — otherwise an unrelated incoming
+  // payment to a different wallet (or even the same wallet, e.g.
+  // someone Zapping you mid-claim) would close the sheet prematurely.
   const claimedAtRef = useRef<number | null>(null);
+  // Payment hash extracted from our claim's bolt11. The wallet
+  // context fills `IncomingPayment.paymentHash` whenever detection
+  // came through expectPayment's hash-keyed path (vs the
+  // balance-diff fallback). When it matches, we know THIS settlement
+  // is ours — not some coincidental wallet credit.
+  const expectedPaymentHashRef = useRef<string | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -139,11 +129,29 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
     ) {
       return;
     }
+    // Tightened scope per Copilot #580 r1: the bare timestamp gate
+    // would dismiss the sheet on ANY incoming payment that happens
+    // to land after the claim moment (different wallet, unrelated
+    // zap, balance-poll detecting an unrelated credit, …). Match on
+    // walletId AND, when the wallet detected via the expectPayment
+    // hash-keyed path, also match the payment hash to be sure this
+    // settlement is the one we just kicked off. If detection came
+    // via balance-diff (paymentHash === null), we fall back to
+    // walletId + the post-claim timestamp window — the best we can
+    // do without an invoice hash.
+    if (lastIncomingPayment.walletId !== activeWalletId) return;
+    if (
+      expectedPaymentHashRef.current &&
+      lastIncomingPayment.paymentHash &&
+      lastIncomingPayment.paymentHash !== expectedPaymentHashRef.current
+    ) {
+      return;
+    }
     const t = setTimeout(() => {
       if (mountedRef.current) onClose();
     }, 250);
     return () => clearTimeout(t);
-  }, [lastIncomingPayment, stage, onClose]);
+  }, [lastIncomingPayment, stage, onClose, activeWalletId]);
 
   const startRead = useCallback(async () => {
     setErrorMessage('');
@@ -220,6 +228,10 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
         if (activeWalletId) {
           const paymentHash = paymentHashFromBolt11(claim.bolt11);
           if (paymentHash) {
+            // Stash so the auto-dismiss effect can match against
+            // `lastIncomingPayment.paymentHash` — defends against
+            // unrelated incoming payments triggering close.
+            expectedPaymentHashRef.current = paymentHash;
             expectPayment(activeWalletId, paymentHash, claim.sats);
           }
         }
@@ -239,7 +251,18 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
     } catch (err) {
       if (mountedRef.current) {
         setStage('error');
-        setErrorMessage(err instanceof Error ? err.message : 'Failed to read NFC tag');
+        const raw = err instanceof Error ? err.message : 'Failed to read NFC tag';
+        // Map nfcService's `NFC unavailable on this device` (raised by
+        // ensureNfcStarted when NfcManager.start() rejected, which is
+        // the disabled-NFC path on Android) to the same friendlier
+        // "NFC is turned off" copy the write / unlock sheets show.
+        // Pre-fix (Copilot #580 r1) dropping isNfcEnabled() left the
+        // user with a bare "NFC unavailable" message inconsistent with
+        // the other sheets in the family.
+        const isDisabled = /NFC unavailable on this device/i.test(raw);
+        setErrorMessage(
+          isDisabled ? 'NFC is turned off. Please enable NFC in your device settings.' : raw,
+        );
       }
     }
   }, [expectedCoord, activeWalletId, makeInvoice, expectPayment]);
@@ -251,6 +274,7 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
       setClaimedSats(null);
       setCooldownRemaining(null);
       claimedAtRef.current = null;
+      expectedPaymentHashRef.current = null;
       sheetRef.current?.present();
       startRead();
     } else {
@@ -261,6 +285,7 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
       setClaimedSats(null);
       setCooldownRemaining(null);
       claimedAtRef.current = null;
+      expectedPaymentHashRef.current = null;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);

--- a/src/components/NfcReadSheet.tsx
+++ b/src/components/NfcReadSheet.tsx
@@ -78,7 +78,7 @@ const formatCountdown = (seconds: number): string => {
 const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const { activeWalletId, makeInvoice } = useWallet();
+  const { activeWalletId, makeInvoice, lastIncomingPayment } = useWallet();
   const [stage, setStage] = useState<SheetStage>('ready');
   const [errorMessage, setErrorMessage] = useState('');
   const [claimedSats, setClaimedSats] = useState<number | null>(null);
@@ -89,6 +89,12 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const sheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ['55%'], []);
   const mountedRef = useRef(true);
+  // Timestamp of the moment we entered `claimed` (LNURL-w issuer
+  // accepted our invoice). Used to gate the auto-dismiss below so
+  // only payments that land AFTER the claim trigger sheet close —
+  // not unrelated wallet activity from before the user tapped Try
+  // prize.
+  const claimedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -96,6 +102,31 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
       mountedRef.current = false;
     };
   }, []);
+
+  // Auto-dismiss the sheet when the actual bolt11 settlement lands
+  // for our claim. The app-root `GlobalIncomingPaymentOverlay`
+  // already pops the confetti celebration on every
+  // `lastIncomingPayment` event — but its native Modal layer sits
+  // BELOW the bottom-sheet's portal while we're open, so the user
+  // can't see the celebration until they dismiss. Closing the sheet
+  // automatically reveals the overlay on HuntPiggyDetail with the
+  // exact same animation Home shows, no duplicated celebration
+  // code. The 250 ms timeout lets the success state's "X sats
+  // inbound!" copy register first before the sheet animates away.
+  useEffect(() => {
+    if (
+      stage !== 'claimed' ||
+      !lastIncomingPayment ||
+      !claimedAtRef.current ||
+      lastIncomingPayment.at < claimedAtRef.current
+    ) {
+      return;
+    }
+    const t = setTimeout(() => {
+      if (mountedRef.current) onClose();
+    }, 250);
+    return () => clearTimeout(t);
+  }, [lastIncomingPayment, stage, onClose]);
 
   const startRead = useCallback(async () => {
     setErrorMessage('');
@@ -158,6 +189,11 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
           piggyId: expectedCoord,
         });
         setClaimedSats(claim.sats);
+        // Stamp the claim moment so the auto-dismiss effect above
+        // only reacts to bolt11 settlements that land AFTER this
+        // point — unrelated wallet activity that happened before
+        // the user tapped Try prize must not close the sheet.
+        claimedAtRef.current = Date.now();
         setStage('claimed');
       } catch (e) {
         if (!mountedRef.current) return;
@@ -186,6 +222,7 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
       setErrorMessage('');
       setClaimedSats(null);
       setCooldownRemaining(null);
+      claimedAtRef.current = null;
       sheetRef.current?.present();
       startRead();
     } else {
@@ -195,6 +232,7 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
       setErrorMessage('');
       setClaimedSats(null);
       setCooldownRemaining(null);
+      claimedAtRef.current = null;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);

--- a/src/components/NfcReadSheet.tsx
+++ b/src/components/NfcReadSheet.tsx
@@ -16,6 +16,7 @@ import {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { AlertCircle, Nfc, PartyPopper, PiggyBank } from 'lucide-react-native';
+import { decode as bolt11Decode } from 'light-bolt11-decoder';
 import { readHuntTagPayload, cancelNfcOperation } from '../services/nfcService';
 import {
   LnurlWithdrawError,
@@ -74,10 +75,27 @@ const formatCountdown = (seconds: number): string => {
   return `${m}:${String(s).padStart(2, '0')}`;
 };
 
+// Pull the payment_hash off a bolt11 so we can hand it to
+// WalletContext.expectPayment for fast settlement detection. Mirrors
+// the helper in ReceiveSheet — light-bolt11-decoder exposes the hash
+// under `sections[].value` keyed by `name === 'payment_hash'`.
+function paymentHashFromBolt11(bolt11: string): string | null {
+  try {
+    const decoded = bolt11Decode(bolt11);
+    const section = decoded.sections?.find((s: { name: string }) => s.name === 'payment_hash') as
+      | { value?: string }
+      | undefined;
+    return section?.value ?? null;
+  } catch (error) {
+    if (__DEV__) console.warn('[NfcReadSheet] bolt11 decode failed:', error);
+    return null;
+  }
+}
+
 const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const { activeWalletId, makeInvoice, lastIncomingPayment } = useWallet();
+  const { activeWalletId, makeInvoice, lastIncomingPayment, expectPayment } = useWallet();
   const [stage, setStage] = useState<SheetStage>('ready');
   const [errorMessage, setErrorMessage] = useState('');
   const [claimedSats, setClaimedSats] = useState<number | null>(null);
@@ -192,6 +210,19 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
         // the user tapped Try prize must not close the sheet.
         claimedAtRef.current = Date.now();
         setStage('claimed');
+        // Kick off 1 s aggressive polling for THIS bolt11 in the
+        // wallet context, so `lastIncomingPayment` fires within ~1 s
+        // of LNbits actually paying our invoice. Without it, the
+        // baseline 30 s balance poll is the only signal, which means
+        // the sheet sits on "X sats inbound!" for up to half a
+        // minute and the user manually taps Done before the auto-
+        // dismiss + confetti can fire (#579 follow-up).
+        if (activeWalletId) {
+          const paymentHash = paymentHashFromBolt11(claim.bolt11);
+          if (paymentHash) {
+            expectPayment(activeWalletId, paymentHash, claim.sats);
+          }
+        }
       } catch (e) {
         if (!mountedRef.current) return;
         const reason =
@@ -211,7 +242,7 @@ const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
         setErrorMessage(err instanceof Error ? err.message : 'Failed to read NFC tag');
       }
     }
-  }, [expectedCoord, activeWalletId, makeInvoice]);
+  }, [expectedCoord, activeWalletId, makeInvoice, expectPayment]);
 
   useEffect(() => {
     if (visible) {

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -20,8 +20,8 @@ import * as Clipboard from 'expo-clipboard';
 import Toast from './BrandedToast';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { decode as bolt11Decode } from 'light-bolt11-decoder';
 import { buildBip21 } from '../utils/bip21';
+import { paymentHashFromBolt11 } from '../utils/bolt11';
 import { useWallet } from '../contexts/WalletContext';
 import { useNostr } from '../contexts/NostrContext';
 import { useThemeColors } from '../contexts/ThemeContext';
@@ -31,22 +31,6 @@ import { satsToFiat, formatFiat } from '../services/fiatService';
 import AmountEntryScreen from './AmountEntryScreen';
 import FriendPickerSheet, { PickedFriend } from './FriendPickerSheet';
 import type { RootStackParamList } from '../navigation/types';
-
-function paymentHashFromBolt11(bolt11: string): string | null {
-  try {
-    const decoded = bolt11Decode(bolt11);
-    const section = decoded.sections?.find((s: { name: string }) => s.name === 'payment_hash') as
-      | { value?: string }
-      | undefined;
-    return section?.value ?? null;
-  } catch (error) {
-    // Silent null returns would mask broken invoice generation; at
-    // least surface it in dev logs so the fallback-to-balance-poll is
-    // traceable.
-    if (__DEV__) console.warn('[Receive] bolt11 decode failed:', error);
-    return null;
-  }
-}
 
 // On-chain address fetching is done via WalletContext.getReceiveAddress
 

--- a/src/utils/bolt11.ts
+++ b/src/utils/bolt11.ts
@@ -1,0 +1,21 @@
+import { decode as bolt11Decode } from 'light-bolt11-decoder';
+
+// Pull the `payment_hash` field off a bolt11 invoice. Used wherever
+// we need to correlate a generated invoice with a settlement event
+// (ReceiveSheet, NfcReadSheet, …) — `WalletContext.expectPayment`
+// + `WalletContext.lastIncomingPayment` both key on this hash. The
+// helper was inlined in three places before this; one source of
+// truth keeps decode behaviour consistent and lets the dev-warning
+// strategy live in one spot.
+export function paymentHashFromBolt11(bolt11: string): string | null {
+  try {
+    const decoded = bolt11Decode(bolt11);
+    const section = decoded.sections?.find((s: { name: string }) => s.name === 'payment_hash') as
+      | { value?: string }
+      | undefined;
+    return section?.value ?? null;
+  } catch (error) {
+    if (__DEV__) console.warn('[bolt11] payment-hash decode failed:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Why

Three related Try-prize UX bugs spotted on the Pixel during dev-client testing:

1. **No celebration on HuntPiggyDetail** — the `'X sats inbound!'` claim state appeared, but the user had to manually tap Done and walk to Home to see the standard confetti popup. The settlement event drives the app-root `GlobalIncomingPaymentOverlay`, but it sits beneath the bottom-sheet's portal while open.
2. **Settlement detection took ~30 s** — `WalletContext.lastIncomingPayment` only fires on the next baseline balance poll, so the sheet sat on `'X sats inbound!'` long enough that users tapped Done first.
3. **OS "Open with…" chooser intercepting fast taps** — three sequential native round-trips before reader-mode activated (`isNfcEnabled` + `ensureNfcStarted` + `requestTechnology`). Reflexive hiders brought the tag in that window and the OS NDEF dispatcher won the race.

## Fix

Three small commits on this branch:

- **`f2e1ac2`** — Subscribe NfcReadSheet to `WalletContext.lastIncomingPayment`. When a settlement lands AFTER the `claimedAtRef` timestamp (guards against unrelated wallet activity from before the user tapped Try prize), close the sheet on a 250 ms beat so the existing app-root overlay becomes visible on HuntPiggyDetail. **No duplicated celebration code** — the standard Home confetti now pops on the cache detail page too.

- **`3642a7a`** — Decode the bolt11 returned by `claimLnurlWithdraw` and hand the `payment_hash` to `WalletContext.expectPayment(walletId, paymentHash, sats)`. That kicks off the context's 1 s aggressive per-invoice poll, so `lastIncomingPayment` fires within ~1 s of LNbits paying us rather than the 30 s baseline. Mirrors the same `paymentHashFromBolt11` helper ReceiveSheet uses.

- **`5b0eae1`** — Fire-and-forget `initNfc()` on app mount so the first sheet open finds `NfcManager` already started (~100 ms saved). Drop the redundant `isNfcEnabled()` pre-flight in `startRead()` — `readHuntTagPayload`'s own `ensureNfcStarted()` surfaces the same disabled-NFC error path. Reader-mode now activates ~50 ms after sheet open instead of ~250 ms, beating the OS NDEF dispatcher's race.

## Test plan

On a Hide-a-Piglet with a working LNURL-w:

1. **OS chooser race**: tap Try prize and bring the tag to the phone as fast as you can. The bottom sheet should be the only thing that reacts — no "Open with…" picker.
2. **Settlement → auto-dismiss → confetti**: sheet shows `'X sats inbound!'`, then auto-closes ~1.25 s later (1 s expectPayment poll + 250 ms post-claim beat) and the standard Home-style confetti + amount pop appears on HuntPiggyDetail.
3. **Pre-existing claimed Piglet**: scan the same tag immediately after the first claim — sleeping/cooldown state still shows correctly (unchanged code path).

`npx tsc --noEmit` + `npx jest` (485 specs) + `npx eslint App.tsx src/components/NfcReadSheet.tsx` all green.

Manually verified on the Pixel dev client.

Closes #579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)