### PR TITLE
chore(release): bump to v1.1.0

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -180,7 +180,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     //   eas build:list --platform android --status finished --limit 1
     //
     // See docs/DEPLOYMENT.adoc → "Local production builds".
-    versionCode: 65,
+    versionCode: 66,
   },
   web: {
     favicon: './assets/favicon.png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Why

The last 24 hours shipped substantial Hunt-feature additions; bumping marketing version 1.0.3 → 1.1.0 to mark the release.

What landed since 1.0.3:

- **#572** — NTAG21x reversible PWD/PACK lock + viewable PIN in the Hide-a-Piglet wizard
- **#573** — My Piglets friends'-finds flicker on cache refresh (#574)
- **#577** — initial NDEF dedupe attempt (#576)
- **#578** — Explore stack seeded with `[ExploreHome, Hunt]` on NFC deep-link so back / tab-tap behave (real fix for #576)
- **#580** — Try-prize confetti pops on cache detail + reader-mode beats OS chooser + shared bolt11 util (#579)

## What

- `package.json` 1.0.3 → 1.1.0 — cascades into iOS `CFBundleShortVersionString` and Android `versionName` via `pkg.version` in `app.config.ts`.
- `app.config.ts` `versionCode` 65 → 66 so the local Android prod APK installs over Ben's Pixel's current install without `INSTALL_FAILED_VERSION_DOWNGRADE`. (`eas build --local` reads `versionCode` straight from `app.config.ts`; `appVersionSource: remote` in `eas.json` only affects EAS cloud builds.)

## Test plan

N/A — pure version bump. `npx tsc --noEmit` + `npx jest` (485 specs) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)