### PR TITLE
perf(wallet): tighten NWC balance poll 30 s → 10 s on Home (#585)

### DIFF
--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1926,7 +1926,14 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     let interval: ReturnType<typeof setInterval> | null = null;
     const startPoll = () => {
       if (interval) return;
-      interval = setInterval(refreshOnce, 30000);
+      // 10 s tick (down from 30 s). LUD-16 receives — payments sent to
+      // the user's lightning address rather than to a specific invoice
+      // we issued — can only be detected via the balance-diff polling
+      // here; the 30 s cadence made these receives feel laggy in
+      // testing. Demand-gating (#569) means the poll only runs while
+      // a balance surface is focused, so this doesn't change idle
+      // battery / NWC traffic costs.
+      interval = setInterval(refreshOnce, 10000);
     };
     const stopPoll = () => {
       if (interval) {

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1929,8 +1929,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       // 10 s tick (down from 30 s). LUD-16 receives — payments sent to
       // the user's lightning address rather than to a specific invoice
       // we issued — can only be detected via the balance-diff polling
-      // here; the 30 s cadence made these receives feel laggy in
-      // testing. Demand-gating (#569) means the poll only runs while
+      // here; the previous 30 s interval made these receives feel laggy
+      // in testing. Demand-gating (#569) means the poll only runs while
       // a balance surface is focused, so this doesn't change idle
       // battery / NWC traffic costs.
       interval = setInterval(refreshOnce, 10000);


### PR DESCRIPTION
## Summary

Drops NWC balance-poll interval from **30 s → 10 s** while Home is focused. Cuts the LUD-16-receive detection latency from up-to-30s to up-to-10s. Observed live with CoinOS: a 2 sat zap took ~25 s to appear; this brings worst case under 15 s.

## Why

When the user receives a payment to their lightning address (e.g. someone zaps `dustyotter14@coinos.io`), Lightning Piggy never sees the bolt11 ahead of time — we issued no invoice, the sender's wallet asked the issuer to mint one. The only signal we have is the balance changing on the next poll tick.

At the 30 s cadence this felt sluggish in live testing — a payment landing 3 s after a tick had to wait ~27 s before the UI noticed. 10 s puts the worst case under a quarter-minute.

## Cost

Demand-gating (added in #569) means the poll **only runs while a balance-displaying surface is focused**. Tab away to Messages / Friends / Explore and ticks stop entirely. So this is cost-free at idle — the 3× tick frequency only fires while the user is actively staring at the Home card.

For coinos.io specifically, that's three `get_balance` NWC requests per minute over WSS instead of two — negligible relay traffic, negligible JS-thread cost (the result merge is a single `setWallets` call with one balance field changed).

## Follow-up

The proper fix is a **NIP-47 notifications subscription** — wallets that implement the notifications extension push `payment_received` events to subscribed clients as they settle. CoinOS supports this (`notifications: ["payment_received", "payment_sent"]` in their NIP-47 info event) but the client side isn't wired yet. Tighter polling is the right interim until that lands.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` — 485 tests pass
- [ ] Manual: open Home, send a small LUD-16 zap from a second wallet, confirm balance updates inside ~15 s
- [ ] Manual: tab to Messages, confirm the poll stops

Closes #585