### PR TITLE
fix(receive): default memo "Sent with Lightning Piggy" (#586)

### DIFF
--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -121,7 +121,7 @@ const ReceiveSheet: React.FC<Props> = ({
       try {
         const wId = capturedWalletId;
         if (!wId) return;
-        const inv = await makeInvoiceForWallet(wId, sats, 'Lightning Piggy');
+        const inv = await makeInvoiceForWallet(wId, sats, 'Sent with Lightning Piggy');
         setInvoice(inv);
 
         // Hand the invoice off to WalletContext.expectPayment, which

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -341,7 +341,7 @@ export async function makeInvoice(
   if (!provider) throw new Error('Not connected');
   const invoice = await provider.makeInvoice({
     amount,
-    defaultMemo: memo || 'Lightning Piggy',
+    defaultMemo: memo || 'Sent with Lightning Piggy',
   });
   return invoice.paymentRequest;
 }


### PR DESCRIPTION
## Summary

When the user issued an invoice via Receive without entering a memo, LP hard-coded the bolt11 description as the bare string `"Lightning Piggy"`. On the recipient's side, `TransactionList` renders any non-empty description as the primary tx label — so the recipient saw a row labelled "Lightning Piggy" instead of "Received".

## Fix

Change the default in two places (`ReceiveSheet.tsx` + the `nwcService.makeInvoice` fallback) to `"Sent with Lightning Piggy"`. Reads naturally as an attribution on the recipient side; signals the sender is using LP rather than looking like a bug.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` — 485 tests pass
- [ ] Manual: open Receive, generate an invoice without a memo, decode the bolt11 — description = "Sent with Lightning Piggy"
- [ ] Manual: have a friend pay your LP invoice — their tx row reads "Sent with Lightning Piggy" instead of the bare brand name

Closes #586