### PR TITLE
fix(map): no size-flash when opening full Map (#601)

### DIFF
--- a/src/components/LibreMiniMap.tsx
+++ b/src/components/LibreMiniMap.tsx
@@ -236,7 +236,15 @@ const LibreMiniMapInner: React.FC<Props> = ({
     });
   };
 
-  if (lat === null || lon === null) return <View style={styles.container} />;
+  if (lat === null || lon === null) {
+    // Empty-state placeholder while GPS is still resolving. Must honour
+    // `fill` — otherwise full-screen consumers (MapScreen,
+    // LocationPickerSheet) briefly render the mini-map chassis (16 px
+    // margin, 16 px radius, small fixed height) before the layout flips
+    // to fill once a fix arrives. #601 caught this as a visible
+    // size-flash on the Map-screen open transition.
+    return <View style={fill ? styles.containerFill : styles.container} testID={testID} />;
+  }
 
   return (
     <View style={fill ? styles.containerFill : styles.container} testID={testID}>

--- a/src/components/LibreMiniMap.tsx
+++ b/src/components/LibreMiniMap.tsx
@@ -240,7 +240,7 @@ const LibreMiniMapInner: React.FC<Props> = ({
     // Empty-state placeholder while GPS is still resolving. Must honour
     // `fill` — otherwise full-screen consumers (MapScreen,
     // LocationPickerSheet) briefly render the mini-map chassis (16 px
-    // margin, 16 px radius, small fixed height) before the layout flips
+    // margin, 14 px radius, small fixed height) before the layout flips
     // to fill once a fix arrives. #601 caught this as a visible
     // size-flash on the Map-screen open transition.
     return <View style={fill ? styles.containerFill : styles.container} testID={testID} />;


### PR DESCRIPTION
## Summary

Opening the full-screen Map briefly rendered the map container at the embedded mini-map's size (rounded card, 16 px margin, ~200 px tall) before flipping to full-screen.

Root cause: \`LibreMiniMap.tsx\` returned \`styles.container\` (mini-map chassis) as the placeholder while GPS resolved, ignoring its \`fill\` prop. MapScreen and LocationPickerSheet pass \`fill={true}\` but render before the first GPS fix, so the wrong-size chassis showed for one frame and then the layout jumped to fill.

Honour \`fill\` in the placeholder branch too — empty surface still shows while GPS resolves, but at the right size from the first frame.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] Prettier clean
- [ ] Manual: open Explore → tap *Open map*. Confirm no visible mini-map → full-screen flash on entry. (Hard to capture in a static screenshot — the issue is a single-frame artefact.)

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)