### PR TITLE
perf(explore): coalesce per-event setState bursts (#31, audit P1) (#605)

### DIFF
--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -340,6 +340,78 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     () => new Map(peekCachedEventsSync().map((e) => [e.coord, e])),
   );
 
+  // Coalesce per-event setState bursts during relay backfill (#31, audit
+  // P1, #605). The relay subscription `onevent` callback can fire 50+
+  // times in <200 ms on cold-start; pre-fix every event ran a Map clone
+  // + setState + render, blocking the JS thread for the entire backfill.
+  // Mirrors the DM inbox pattern in NostrContext.tsx (~3550).
+  //
+  // Per-event work stays cheap: trust filter + createdAt-staleness check
+  // run inline (no React state). Only the merge into the React Map is
+  // batched, so the rails still update incrementally as the queue
+  // flushes — just every ~100 ms instead of every event.
+  const pendingCachesRef = useRef<Map<string, ParsedCache>>(new Map());
+  const pendingEventsRef = useRef<Map<string, ParsedEvent>>(new Map());
+  const pendingCachesTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingEventsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 100 ms flush window: feels instant to the user (the eye perceives
+  // ≤120 ms as same-frame), short enough that the rail doesn't sit
+  // empty during a slow backfill, long enough to coalesce a typical
+  // relay event burst (~50 events in 200 ms) into 2–3 commits.
+  const PENDING_FLUSH_MS = 100;
+  // 25-event threshold flushes early when a fast relay dumps a big
+  // backlog. Without it, a 200-event burst would sit in the buffer for
+  // the full 100 ms even if it landed in 20 ms.
+  const PENDING_FLUSH_THRESHOLD = 25;
+  const flushPendingCaches = useCallback(() => {
+    if (pendingCachesTimerRef.current) {
+      clearTimeout(pendingCachesTimerRef.current);
+      pendingCachesTimerRef.current = null;
+    }
+    const batch = pendingCachesRef.current;
+    if (batch.size === 0) return;
+    pendingCachesRef.current = new Map();
+    setCaches((prev) => {
+      const __t0 = performance.now();
+      const next = new Map(prev);
+      for (const [coord, c] of batch) {
+        const existing = next.get(coord);
+        if (!existing || existing.createdAt < c.createdAt) next.set(coord, c);
+      }
+      const __dt = performance.now() - __t0;
+      if (__dt > 30) {
+        console.log(
+          `[PerfBlock] Explore setCaches flush: ${Math.round(__dt)}ms batch=${batch.size} size=${prev.size}→${next.size}`,
+        );
+      }
+      return next;
+    });
+  }, []);
+  const flushPendingEvents = useCallback(() => {
+    if (pendingEventsTimerRef.current) {
+      clearTimeout(pendingEventsTimerRef.current);
+      pendingEventsTimerRef.current = null;
+    }
+    const batch = pendingEventsRef.current;
+    if (batch.size === 0) return;
+    pendingEventsRef.current = new Map();
+    setEvents((prev) => {
+      const __t0 = performance.now();
+      const next = new Map(prev);
+      for (const [coord, e] of batch) {
+        const existing = next.get(coord);
+        if (!existing || existing.startsAt !== e.startsAt) next.set(coord, e);
+      }
+      const __dt = performance.now() - __t0;
+      if (__dt > 30) {
+        console.log(
+          `[PerfBlock] Explore setEvents flush: ${Math.round(__dt)}ms batch=${batch.size} size=${prev.size}→${next.size}`,
+        );
+      }
+      return next;
+    });
+  }, []);
+
   // Stable array projections of the caches/events Maps so React.memo on
   // the consuming LibreMiniMap can short-circuit re-renders. Without
   // these the parent's `[...caches.values()]` literal returns a fresh
@@ -485,24 +557,19 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
             setUntrustedCacheCount((n) => n + 1);
             return;
           }
-          setCaches((prev) => {
-            const existing = prev.get(c.coord);
-            if (existing && existing.createdAt >= c.createdAt) return prev;
-            // The Map clone is O(N); cache it for the SLOW-path log so
-            // an unusually large mirror surfaces in logcat. Pre-fix the
-            // reducer ran silently for every relay event, even when
-            // doing a 1000-entry clone per push during a backfill burst.
-            const __t0 = performance.now();
-            const next = new Map(prev);
-            next.set(c.coord, c);
-            const __dt = performance.now() - __t0;
-            if (__dt > 30) {
-              console.log(
-                `[PerfBlock] Explore setCaches clone: ${Math.round(__dt)}ms size=${prev.size}→${next.size}`,
-              );
-            }
-            return next;
-          });
+          // Stale-event drop happens here too so a stale wrap doesn't
+          // even enter the pending queue. The flush re-checks against
+          // the committed state in case the queue itself raced.
+          const existing = pendingCachesRef.current.get(c.coord);
+          if (existing && existing.createdAt >= c.createdAt) return;
+          pendingCachesRef.current.set(c.coord, c);
+          if (pendingCachesRef.current.size >= PENDING_FLUSH_THRESHOLD) {
+            flushPendingCaches();
+            return;
+          }
+          if (pendingCachesTimerRef.current === null) {
+            pendingCachesTimerRef.current = setTimeout(flushPendingCaches, PENDING_FLUSH_MS);
+          }
         }),
       );
       subsCloserRef.current.push(
@@ -513,27 +580,28 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
             setUntrustedEventCount((n) => n + 1);
             return;
           }
-          setEvents((prev) => {
-            const existing = prev.get(e.coord);
-            if (existing && existing.startsAt === e.startsAt) return prev;
-            const __t0 = performance.now();
-            const next = new Map(prev);
-            next.set(e.coord, e);
-            const __dt = performance.now() - __t0;
-            if (__dt > 30) {
-              console.log(
-                `[PerfBlock] Explore setEvents clone: ${Math.round(__dt)}ms size=${prev.size}→${next.size}`,
-              );
-            }
-            return next;
-          });
+          const existing = pendingEventsRef.current.get(e.coord);
+          if (existing && existing.startsAt === e.startsAt) return;
+          pendingEventsRef.current.set(e.coord, e);
+          if (pendingEventsRef.current.size >= PENDING_FLUSH_THRESHOLD) {
+            flushPendingEvents();
+            return;
+          }
+          if (pendingEventsTimerRef.current === null) {
+            pendingEventsTimerRef.current = setTimeout(flushPendingEvents, PENDING_FLUSH_MS);
+          }
         }),
       );
       return () => {
         subsCloserRef.current.forEach((c) => c());
         subsCloserRef.current = [];
+        // Drain whatever's queued so a tab blur mid-backfill doesn't
+        // silently discard the last few events. Both flushers are
+        // null-safe + no-op when the buffer is already empty.
+        flushPendingCaches();
+        flushPendingEvents();
       };
-    }, [pos, refreshKey]),
+    }, [pos, refreshKey, flushPendingCaches, flushPendingEvents]),
   );
 
   // ----- lessons progress (local) -----------------------------------------

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -354,6 +354,18 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   const pendingEventsRef = useRef<Map<string, ParsedEvent>>(new Map());
   const pendingCachesTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingEventsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks whether the screen has unmounted entirely (logout / navigator
+  // reset). Distinct from focus blur, which only pauses the screen — the
+  // tab-blur cleanup still wants to flush so the next focus shows the
+  // tail of the queue. Full unmount means React will throw on any
+  // setState here, so flushers early-return.
+  const isUnmountedRef = useRef(false);
+  useEffect(
+    () => () => {
+      isUnmountedRef.current = true;
+    },
+    [],
+  );
   // 100 ms flush window: feels instant to the user (the eye perceives
   // ≤120 ms as same-frame), short enough that the rail doesn't sit
   // empty during a slow backfill, long enough to coalesce a typical
@@ -367,6 +379,13 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     if (pendingCachesTimerRef.current) {
       clearTimeout(pendingCachesTimerRef.current);
       pendingCachesTimerRef.current = null;
+    }
+    // Clear buffer + skip setState on unmount so a stale subscription
+    // tear-down post-logout / navigator-reset doesn't trigger the
+    // "setState on unmounted component" warning (Copilot review on #612).
+    if (isUnmountedRef.current) {
+      pendingCachesRef.current = new Map();
+      return;
     }
     const batch = pendingCachesRef.current;
     if (batch.size === 0) return;
@@ -391,6 +410,11 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     if (pendingEventsTimerRef.current) {
       clearTimeout(pendingEventsTimerRef.current);
       pendingEventsTimerRef.current = null;
+    }
+    // See flushPendingCaches above for the unmount guard rationale.
+    if (isUnmountedRef.current) {
+      pendingEventsRef.current = new Map();
+      return;
     }
     const batch = pendingEventsRef.current;
     if (batch.size === 0) return;

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -556,14 +556,29 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // into bridge dispatches for payment-settlement polls + QR-scan
   // callbacks (#554). Reconnect on re-focus is ~100 ms; foreground
   // JS-thread responsiveness is the better trade.
+  // Destructure pos into primitives so the focus effect's deps don't
+  // re-trigger every time `setPos` writes a fresh `{lat, lon, accuracy}`
+  // object (which happens 2–3 times on cold start: last-known fix →
+  // current fix → high-accuracy refinement). Pre-fix that thrashed the
+  // relay subscription open/close 2–3 times per cold-start; each round-
+  // trip is ~100–300 ms. Stev.ie's #612 review surfaced this.
+  const posLat = pos?.lat;
+  const posLon = pos?.lon;
   useFocusEffect(
     useCallback(() => {
       // `refreshKey` is intentionally listed in the deps below so that
       // pull-to-refresh (which bumps it) tears down + re-runs the
       // subscriptions, even though the value isn't referenced inside
       // the body.
-      if (!pos) return;
-      const myGh = encodeGeohash(pos.lat, pos.lon, 7);
+      if (typeof posLat !== 'number' || typeof posLon !== 'number') return;
+      // `cancelled` covers the window between focus-effect cleanup
+      // firing (subsCloserRef.current.forEach(c => c())) and the
+      // underlying relay socket actually closing — a stray event in
+      // that gap would otherwise mutate pendingCachesRef and arm a
+      // fresh flush timer that fires while the screen is blurred.
+      // Mirrors NostrContext.tsx's DM inbox precedent.
+      let cancelled = false;
+      const myGh = encodeGeohash(posLat, posLon, 7);
       // Caches sit at precision 5 (~5 km) — geocaching is inherently
       // hyper-local. Events broaden to precision 3 (~150 km) so a rural
       // user catches the nearest city's Bitcoin meetup; most NIP-52
@@ -573,6 +588,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
 
       subsCloserRef.current.push(
         subscribeNearbyCaches(cachePrefixes, (c) => {
+          if (cancelled) return;
           // WoT filter: silently drop caches from pubkeys outside the
           // trust graph (an unverified cache could be a phishing LNURL
           // or, worse, a physical lure). Surfaced as a count instead so
@@ -598,6 +614,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
       );
       subsCloserRef.current.push(
         subscribeNearbyEvents(eventPrefixes, (e) => {
+          if (cancelled) return;
           // Skip events that already started > 1h ago.
           if (e.startsAt && e.startsAt < Math.floor(Date.now() / 1000) - 60 * 60) return;
           if (!isTrustedRef.current(e.organiserPubkey)) {
@@ -617,6 +634,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
         }),
       );
       return () => {
+        cancelled = true;
         subsCloserRef.current.forEach((c) => c());
         subsCloserRef.current = [];
         // Drain whatever's queued so a tab blur mid-backfill doesn't
@@ -625,7 +643,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
         flushPendingCaches();
         flushPendingEvents();
       };
-    }, [pos, refreshKey, flushPendingCaches, flushPendingEvents]),
+    }, [posLat, posLon, refreshKey, flushPendingCaches, flushPendingEvents]),
   );
 
   // ----- lessons progress (local) -----------------------------------------


### PR DESCRIPTION
## Why

The 30 s Explore tab freeze tracked as #31 — surfaced repeatedly in user reports, last measured at **~24 s mean** on emulator via `scripts/perf-explore-cold-start.sh 3`.

Diagnosed in the 2026-05-17 deep perf audit: `ExploreHomeScreen`'s relay subscription callbacks fire `setCaches` / `setEvents` **once per arriving event**, each with a full `Map` clone. During a relay backfill (50–200 events in <200 ms) this is roughly *N × 40 ms* on a Pixel 4 — pre-fix scales linearly with the cache count already in state, so a busier relay or denser geohash multiplies the wall-clock cost.

Two existing PerfBlock slow-path logs at `Explore setCaches clone` and `Explore setEvents clone` were the smoking gun: they fire during every cold-start backfill.

## What changes

Adopt the DM inbox coalescing pattern (`src/contexts/NostrContext.tsx:3549–3571`) for the Explore subscriptions:

- **Ref-backed pending Maps** (`pendingCachesRef`, `pendingEventsRef`) accumulate incoming events without touching React state.
- **100 ms flush window** — short enough to feel instant (the eye perceives ≤120 ms as same-frame), long enough to coalesce a typical 50-event burst into 2–3 commits.
- **25-event flush threshold** — flushes early when a fast relay dumps a big backlog.
- **One Map clone per flush**, not per event. Same N items committed, but in one render pass instead of N.
- **`cancelled` flag in subscription callbacks** (matches the DM precedent — Stev.ie review). Stops stray events from mutating pending state during the gap between focus-effect cleanup and socket close.
- **Unmount guard** (Copilot review round 1). `isUnmountedRef` makes both flushers early-return when the screen has fully unmounted (logout / navigator reset), preventing the "setState on unmounted component" warning.
- **Primitive `pos` deps in `useFocusEffect`** (Stev.ie review). `setPos` writes a fresh object 2–3 times during location resolution; depending on `posLat` + `posLon` numbers instead of the `pos` object stops the focus effect tearing down + re-opening the subscription on each write — reclaims 200–900 ms of cold-start wall-clock that the original coalescing fix didn't address.

## Realistic impact estimate

**~24 s → 6–10 s median** on the audit harness. The dominant per-event setState term is gone, but three smaller terms remain:

- Relay handshake (~100 ms unavoidable)
- `loadCachedCaches/Events` AsyncStorage hydrate (~200–800 ms blocking, *not* deferred — filed as a follow-up)
- `fetchPlacesInBbox` cold path (~1–3 s for the BTC Map fetch)

The previous PR-body claim of "<6 s" was Stev.ie-flagged as optimistic. The honest range is 6–10 s — we can chase further once #614 (perf script upgrade) lands and we have p99 + Perfetto numbers, not just a 3-sample mean.

## Test plan

**Numeric** (post-#614 / proper protocol):

```
PIGGY_DEVICE=emulator-5554 bash scripts/perf-explore-cold-start.sh 10
```

Stev.ie's recommended verification: **N≥10** samples (a 30 s freeze is by definition an outlier; N=3 hides too much variance), report **median + p95 + max** (not mean), run on both emulator and real Pixel.

**Behavioural:**

1. Cold-start the app, tap Explore.
2. *Before:* rail sits empty for ~24 s, then everything appears at once.
3. *After:* rail starts populating within 100–200 ms of the first relay event; updates incrementally every ~100 ms during the burst.

**Regression checks:**

- WoT trust-filter still drops untrusted hides (per-event filter, untouched)
- `createdAt` staleness still preserved (re-checked at both queue and flush time)
- Tab blur mid-burst doesn't drop pending events (focus cleanup drains)
- Full unmount (logout / navigator reset) doesn't trigger the "setState on unmounted" warning (`isUnmountedRef` guard)
- Stray relay event after cleanup doesn't mutate pending state (`cancelled` flag)
- `refreshKey` pull-to-refresh still tears down + re-runs the subscription cleanly

## Gates

- ✅ `npx tsc --noEmit`
- ✅ `npx eslint` (4 pre-existing warnings, none from this PR)
- ✅ `npx prettier --check`
- ✅ `npx jest` (47 suites / 541 tests)

Closes #605

## Audit context

Priority 1 of 5 from the 2026-05-17 perf audit. Sibling issues:
- #606 — defer tx-cache JSON.parse off cold-start
- #607 — memoize parsed place-cache
- #608 — fix trust-filter stale closure
- #609 — lazy-load detail screens
- #610 — upgrade perf scripts (gfxinfo + p99 + Perfetto) — **PR #614 open**
- #611 — dev-time profiling stack (Hermes profiler exposure, perf marks)

Stev.ie's review-of-PR-#612 surfaced 5 additional issues in the same file — to be filed as a single follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)