### PR TITLE
fix(picker): show live user position as the blue dot, not the seeded centre (#624)

### DIFF
--- a/src/components/LocationPickerSheet.tsx
+++ b/src/components/LocationPickerSheet.tsx
@@ -17,6 +17,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import { MapPin, Check, X } from 'lucide-react-native';
 import { LibreMiniMap } from './LibreMiniMap';
+import { useUserLocation } from '../contexts/UserLocationContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 
@@ -50,6 +51,13 @@ const LocationPickerSheet: React.FC<Props> = ({
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const sheetRef = useRef<BottomSheetModal>(null);
+  // Live user position for the dot on the picker map — separate from
+  // the camera centre (which is the saved pin in edit mode or the
+  // user's open-time fix in create mode) and from the crosshair
+  // (which tracks the camera). Without this the dot is wherever the
+  // CAMERA was seeded, which looks like the dot drifted as the user
+  // panned the crosshair to a new spot.
+  const { pos: livePos } = useUserLocation();
   // Map gets a fixed slice of the window (50%) so the sheet has a
   // determinate height for Gorhom's dynamic sizing to measure. Plenty of
   // pin-placement area, leaves the wizard header peeking behind, scales
@@ -256,7 +264,16 @@ const LocationPickerSheet: React.FC<Props> = ({
             <LibreMiniMap
               lat={resolvedStart.lat}
               lon={resolvedStart.lon}
-              userAccuracyMetres={null}
+              // Pass the LIVE user position explicitly so the dot
+              // renders where the user actually is, not at the
+              // seeded camera centre. Without these, LibreMiniMap's
+              // dot falls back to `lat`/`lon` (the initial seed),
+              // which on the edit-Piglet path is the SAVED pin —
+              // making the dot look like it drifted away from the
+              // user as the user pans the crosshair around.
+              userLat={livePos?.lat ?? null}
+              userLon={livePos?.lon ?? null}
+              userAccuracyMetres={livePos?.accuracy ?? null}
               merchants={[]}
               caches={[]}
               events={[]}


### PR DESCRIPTION
## Summary

Opening Edit Piglet → Pick the location step 3 ("Where did you hide it?") showed the blue dot at the saved pin to start with, then as the user panned the crosshair to a new spot the dot stayed put — looking like the dot had "drifted away from my actual location."

## Root cause

\`LocationPickerSheet\` wasn't passing \`userLat\`/\`userLon\` to \`LibreMiniMap\`, so the dot fell back to \`lat\`/\`lon\` (the camera anchor, which is the saved pin in edit mode or the open-time fix in create mode). That value is static while the crosshair tracks the camera as you pan — visually looking like the dot was the user's GPS drifting away.

## Fix

Consume the shared \`useUserLocation\` context in the picker and pass \`livePos.lat / .lon / .accuracy\` explicitly. Now the picker shows three distinct things on the map, each doing what its name implies:

| Element | Source | Behaviour |
|---|---|---|
| **Camera centre** | \`lat\` / \`lon\` — seeded once | Static; the spot you're editing or where you opened the picker |
| **Crosshair** | Camera viewport centre | Tracks the camera as you pan — this is what you're picking |
| **Blue dot + halo** | Live \`useUserLocation\` | Updates every 15 s / 20 m via the shared watch — your actual GPS |

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx jest\` — 550 tests pass
- [ ] Manual on Pixel: open Edit Piglet → step 3 → pan the crosshair → dot stays where you are, not where the pin was
- [ ] Manual: open Hide a Piglet (create mode) → dot starts at your location → pan crosshair → dot tracks you, crosshair moves with the map

Closes #624