### PR TITLE
fix(wallet): retry BTC-price fetch on app-foreground when rate missing

### DIFF
--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -653,6 +653,24 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     };
   }, [currency, fetchPrice]);
 
+  // Retry the fiat-price fetch when the app comes to foreground if we
+  // don't yet have a rate. Covers the cold-start-offline case: app
+  // launches without internet → `fetchPrice` returns null → `btcPrice`
+  // stays null → the wallet card's fiat line + the sats↔fiat toggle in
+  // `AmountEntryScreen` both silently disable (they gate on
+  // `btcPrice !== null`). Without this retry, the user has to wait up
+  // to 5 min for the interval tick or kill + relaunch the app to recover
+  // once connectivity returns. Gate on `btcPrice === null` so we don't
+  // spam CoinGecko in the happy path where the rate is already cached.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active' && btcPrice === null) {
+        fetchPrice(currency);
+      }
+    });
+    return () => sub.remove();
+  }, [btcPrice, currency, fetchPrice]);
+
   // NWC connection status: check WebSocket state every 30 seconds and
   // reconnect if dropped (prevents idle timeout disconnections).
   //


### PR DESCRIPTION
## Summary

Closes #638.

Reproduced by a user on the production app: launched offline → CoinGecko fetch returned null → `btcPrice` stayed null → the wallet card's fiat-balance row vanished and the Sats↔fiat unit toggle silently no-op'd. The only workaround was kill + relaunch the app once connectivity returned.

## Root cause

`WalletContext.tsx` arms a single `setInterval(fetchPrice, 5 min)` and one cold-start `fetchPrice` call. There's no foreground / connectivity-restored retry path. Once `btcPrice === null` sticks for a session, the user waits up to 5 minutes — or restarts the app.

## Fix

Subscribe to `AppState.change` and retry `fetchPrice(currency)` when the app comes to `'active'` if (and only if) `btcPrice === null`. Mirrors the existing wallet-balance refresh pattern already in place a few hundred lines below in the same file.

```ts
useEffect(() => {
  const sub = AppState.addEventListener('change', (next) => {
    if (next === 'active' && btcPrice === null) {
      fetchPrice(currency);
    }
  });
  return () => sub.remove();
}, [btcPrice, currency, fetchPrice]);
```

The `btcPrice === null` gate keeps us off the CoinGecko free-tier rate limit in the happy path — once we've got a rate, the 5-minute interval handles freshness.

## Affected surfaces (all gate on `btcPrice !== null`)

- `WalletCard.tsx:158` — the fiat-balance row under the sats balance
- `AmountEntryScreen.tsx:79` — auto-reverts to sats unit if no rate
- `AmountEntryScreen.tsx:153` — toggle blocked entirely if no rate
- `SendSheet.tsx:1117`, `:396` — fiat parenthetical on send amounts
- `TransferSheet.tsx:525` — fiat parenthetical on transfer amounts

All come back to life automatically once `btcPrice` lands.

## Test plan

- ✓ `npx tsc --noEmit` clean
- ✓ `npx prettier --check` clean
- ✓ `npx eslint` — only pre-existing warnings, none introduced
- Manual repro: airplane-mode the device, cold-start the app, observe the wallet card shows sats only; disable airplane mode, background the app, foreground it — fiat row + toggle should return within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)