### PR TITLE
feat(explore): default nearby radius 100 km, boosted merchants 200 km

### DIFF
--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -45,6 +45,7 @@ import {
   refreshDataset,
 } from '../services/btcMapService';
 import { useNearbyRadius } from '../hooks/useNearbyRadius';
+import { BOOSTED_RADIUS_METRES } from '../services/nearbyRadiusService';
 import { type ParsedCache, type ParsedEvent } from '../services/nostrPlacesService';
 import {
   fetchCachesByAuthor,
@@ -714,7 +715,15 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
       distance: haversineMetres({ lat: posLat, lon: posLon }, { lat: place.lat, lon: place.lon }),
     }));
     if (maxDistanceMetres !== null) {
-      items = items.filter((m) => m.distance <= maxDistanceMetres);
+      // Boosted/"Featured" merchants get a wider per-row cap so the user
+      // sees paid placements even when their general radius is tight.
+      // Max-wins: a user who's set the slider above 200 km keeps that.
+      items = items.filter((m) => {
+        const cap = isBoosted(m.place)
+          ? Math.max(maxDistanceMetres, BOOSTED_RADIUS_METRES)
+          : maxDistanceMetres;
+        return m.distance <= cap;
+      });
     }
     return (
       items

--- a/src/screens/PlacesScreen.tsx
+++ b/src/screens/PlacesScreen.tsx
@@ -325,7 +325,7 @@ const PlacesScreen: React.FC<Props> = ({ navigation }) => {
                 <MapPin size={56} color={colors.textSupplementary} strokeWidth={1.5} />
                 <Text style={styles.emptyTitle}>No places nearby</Text>
                 <Text style={styles.subtle}>
-                  We searched a ~50 km area. Try opening the full map to pan further afield, or
+                  We searched a ~100 km area. Try opening the full map to pan further afield, or
                   refresh later — the OSM merchant list updates daily.
                 </Text>
               </View>

--- a/src/services/nearbyRadiusService.ts
+++ b/src/services/nearbyRadiusService.ts
@@ -10,7 +10,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
  */
 const STORAGE_KEY = '@lp:nearby-radius-v1';
 
-export const DEFAULT_RADIUS_METRES = 50_000; // 50 km
+// Bumped from 50 km on user feedback — 50 km from a sparser area left
+// rails like "Places near you" with only 1-2 BTC Map merchants visible.
+// 100 km comfortably reaches a city centre from most suburbs/villages
+// while still staying well under the fetcher's outer tier (500 km), so
+// the merchant payload doesn't grow unexpectedly.
+export const DEFAULT_RADIUS_METRES = 100_000; // 100 km
 
 export interface RadiusOption {
   label: string;
@@ -27,6 +32,7 @@ export const RADIUS_OPTIONS: ReadonlyArray<RadiusOption> = [
   { label: '5 km', value: 5_000 },
   { label: '25 km', value: 25_000 },
   { label: '50 km', value: 50_000 },
+  { label: '100 km', value: 100_000 },
   { label: '150 km', value: 150_000 },
   { label: 'All', value: null },
 ];

--- a/src/services/nearbyRadiusService.ts
+++ b/src/services/nearbyRadiusService.ts
@@ -17,6 +17,14 @@ const STORAGE_KEY = '@lp:nearby-radius-v1';
 // the merchant payload doesn't grow unexpectedly.
 export const DEFAULT_RADIUS_METRES = 100_000; // 100 km
 
+// Boosted / "Featured" merchants from BTC Map are sparser per area than
+// regular merchants and the merchants themselves are explicitly paying
+// for distribution, so we widen the cap for them to 200 km regardless
+// of the user's general nearby radius. A user with the radius set to
+// 25 km still sees boosted merchants out to 200 km; a user with the
+// radius set wider than 200 km keeps their wider preference (max wins).
+export const BOOSTED_RADIUS_METRES = 200_000; // 200 km
+
 export interface RadiusOption {
   label: string;
   value: number | null; // metres; null = All


### PR DESCRIPTION
## Why

In sparser areas (e.g. Cambridge satellite villages), the **Places near you** rail only surfaced 1–2 BTC Map merchants at the 50 km cap. Users reading the rail thought it was broken when in reality the area is just lightly mapped at that distance.

Featured merchants are a separate problem: BTC Map's paid placements are sparser still, and even at 100 km a user can easily have zero of them in view. We want featured merchants to reach further so the user actually sees what the BTC Map programme is highlighting.

## What

* **Default radius bumped 50 km → 100 km** in `src/services/nearbyRadiusService.ts`. `useNearbyRadius` already feeds all three consumers — Places rail, Geo-caches list, Places list — so they pick it up automatically.
* **New `100 km` chip** in `RADIUS_OPTIONS` so the picker shows the new default by name.
* **Boosted/Featured merchants get a wider 200 km cap** on the Explore rail (`BOOSTED_RADIUS_METRES`), max-wins against the user's general slider: tighter sliders don't hide them; sliders above 200 km keep the wider preference.
* Empty-state copy on `PlacesScreen` `~50 km` → `~100 km` to match the search area.

## Notes

* BTC Map fetcher uses `NEAREST_RADIUS_TIERS_KM = [25, 100, 500]`, so both 100 km (default) and 200 km (boosted) land inside the existing payload — no extra network round-trips.
* Storage migration: `loadNearbyRadius` returns the default only when the user has never persisted a value. Anyone who explicitly picked 50 km keeps 50 km; fresh installs (and people who never opened the picker) move to 100 km.
* `PlacesScreen` is viewport-driven (no user-radius cap of its own), so the boosted exception only applies on the Explore rail.

## Test plan

* Cold install + grant location → confirm Places rail loads with a noticeably wider set of merchants and that any Featured merchants up to 200 km away appear with a "Featured" badge.
* Pick 25 km in the radius picker → confirm regular merchants compress to a tight ring but Featured rows still reach out to ~200 km.
* Pick 50 km → confirm the rail shrinks back to the pre-PR coverage for non-boosted; Featured still extends.
* Switch back to 100 km → confirm the broader default returns.
* `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` all clean on touched files.
