### PR TITLE
fix(wot): drop secret-mode clamp; add currentTier prop to sheet (#640)

### DIFF
--- a/src/components/WebOfTrustBottomSheet.tsx
+++ b/src/components/WebOfTrustBottomSheet.tsx
@@ -25,6 +25,13 @@ import type { WotTier } from '../services/wotSettingsService';
 interface Props {
   visible: boolean;
   onClose: () => void;
+  /** Optional explicit "current" tier. When provided, the sheet renders
+   * that as the active row instead of reading the global value from
+   * `useTrustGraph()`. Lets a caller surface a *derived* tier in its
+   * chip — most cleanly used by the per-rail override design in #636.
+   * When omitted, falls back to the global persisted tier — every
+   * existing caller's behaviour. */
+  currentTier?: WotTier;
 }
 
 interface TierRowProps {
@@ -72,10 +79,15 @@ const TierRow: React.FC<TierRowProps> = ({ tier, title, subtitle, active, disabl
   );
 };
 
-const WebOfTrustBottomSheet: React.FC<Props> = ({ visible, onClose }) => {
+const WebOfTrustBottomSheet: React.FC<Props> = ({ visible, onClose, currentTier }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const { wotTier, setWotTier } = useTrustGraph();
+  // `activeTier` is what the picker renders as "checked". Defaults to
+  // the global persisted tier; a caller can pass `currentTier` to
+  // override this when its chip surfaces a derived value (per-rail —
+  // #636) so the sheet's active state matches what the user just tapped.
+  const activeTier = currentTier ?? wotTier;
 
   // `lastTierRef` is retained for the future FoF re-enable so the
   // "compute now" affordance can compare incoming vs persisted tier
@@ -121,7 +133,7 @@ const WebOfTrustBottomSheet: React.FC<Props> = ({ visible, onClose }) => {
             tier="friends"
             title="Friends"
             subtitle="Only people you follow."
-            active={wotTier === 'friends'}
+            active={activeTier === 'friends'}
             disabled={false}
             onSelect={() => handleSelect('friends')}
           />
@@ -137,7 +149,7 @@ const WebOfTrustBottomSheet: React.FC<Props> = ({ visible, onClose }) => {
             tier="all"
             title="All"
             subtitle="Everything from every relay. Default until your trust graph is ready — switch to Friends to tighten."
-            active={wotTier === 'all'}
+            active={activeTier === 'all'}
             disabled={false}
             onSelect={() => handleSelect('all')}
           />

--- a/src/contexts/GroupsContext.tsx
+++ b/src/contexts/GroupsContext.tsx
@@ -59,17 +59,16 @@ interface GroupsContextType {
   followingOnly: boolean;
   /**
    * @deprecated See `followingOnly`. Setting this maps onto `setWotTier`:
-   * true → 'friends', false → 'all' (clamped to 'friends' when not in
-   * secret mode, matching the production hard-lock).
+   * true → 'friends', false → 'all'. Since #640 removed the secret-mode
+   * clamp this is simply a pass-through to the global WoT picker — kept
+   * for any out-of-tree consumer that still flips the boolean.
    */
   setFollowingOnly: (next: boolean) => void;
-  // Effective WoT tier after the production hard-lock has been applied.
-  // Mirrors the persisted `wotTier` from TrustGraphContext except that
-  // 'all' is coerced to 'friends' when the user is not in secret mode —
-  // preventing a stale persisted 'all' from leaking past the parental-
-  // control gate after secretMode is flipped back off. Consumers should
-  // read this rather than `useTrustGraph().wotTier` when the visibility
-  // decision must honour the hard-lock.
+  // Effective WoT tier. Used to differ from `wotTier` via a secret-mode
+  // clamp (#547); since #640 removed that clamp the two values are
+  // identical. The field is retained so in-tree readers don't all need
+  // changing in one go — new code should prefer `useTrustGraph().wotTier`
+  // directly.
   effectiveWotTier: WotTier;
   /** Mirrors AsyncStorage `secret_mode`. Controls whether the chip is interactive. */
   secretMode: boolean;
@@ -306,14 +305,18 @@ export const GroupsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     AsyncStorage.setItem('secret_mode', next ? 'true' : 'false').catch(() => {});
   }, []);
 
-  // Production hard-lock guard (#547). A stale persisted 'all' must never
-  // leak past the parental-control gate after secret mode has been
-  // flipped back off — clamp to 'friends' (the safest tier) in that case.
-  // The persisted wotTier itself is left alone so the user keeps their
-  // wider tier preference if they re-enable secret mode later. This
-  // mirrors the `followingOnly || !secretMode` defence-in-depth that
-  // visibleGroups used before #547 — same rule, three-tier shape.
-  const effectiveWotTier: WotTier = !secretMode && wotTier === 'all' ? 'friends' : wotTier;
+  // `effectiveWotTier` previously clamped 'all' → 'friends' when secret
+  // mode was off (#547 parental-control hard-lock). That clamp has been
+  // removed (#640): the WoT picker is now the single source of truth
+  // and what the user sees in the bottom sheet is what every surface —
+  // including Messages — actually applies. Secret mode still controls
+  // its other UI-affordance reveals (delete-group, dev build hash, etc.)
+  // but no longer over-rides the tier. The field is retained on the
+  // context so the wide audience of `useGroups().effectiveWotTier`
+  // readers (Messages, Groups, the dev-only TestID hooks, plus the
+  // deprecated `followingOnly` derivation below) don't all need
+  // changing this turn; it now simply mirrors `wotTier`.
+  const effectiveWotTier: WotTier = wotTier;
 
   // Deprecated boolean view of the tier — see the interface docstring.
   // Kept for any out-of-tree consumer; in-tree consumers should read


### PR DESCRIPTION
## Why

Two related WoT fixes; landing them together because removing one obviates the need for partially fixing the other.

### 1. Secret-mode WoT clamp removed

`GroupsContext.effectiveWotTier` used to coerce `'all'` → `'friends'` whenever secret-mode was off, as a parental-control hard-lock added in #547. That predates the post-#630 `'all'`-by-default era. The clamp now produces two visible-yet-disagreeing values for the same setting — Messages chip says **Friends**, the WoT bottom sheet says **All** — which is the exact mismatch Copilot flagged on PR #630 (round 5).

`effectiveWotTier` is now a straight pass-through to `wotTier`. The field is retained on the context so the wide audience of readers (MessagesScreen, GroupsScreen filters, the dev-only test-id hooks, the deprecated `followingOnly` derivation) don't all have to be migrated in the same PR — it just mirrors the global tier going forward. Secret mode still controls its other UI-affordance reveals (delete-group, dev build hash, etc.); only the WoT-clamp piece is gone.

User intent for this change: *"Remove the limitation on WoT via SecretMode."* The WoT picker should be the single source of truth — what the user sees in the bottom sheet is what every surface, including Messages, actually applies.

### 2. `WebOfTrustBottomSheet` accepts a `currentTier` prop

The sheet previously read `wotTier` from `useTrustGraph()` directly and rendered that as the active row. Future per-rail overrides (#636) need to surface a derived tier in their chip; without a way to inject that into the sheet, the active state would always reflect the global value regardless of which chip the user just tapped.

New optional `currentTier?: WotTier` prop. When provided, the sheet renders it as active. When omitted, falls back to the global tier — every existing caller's behaviour is unchanged.

## What this is **not** doing

- Does not remove the `effectiveWotTier` field from the context. The wide migration to read `wotTier` directly can land later in a docs-only refactor PR.
- Does not yet wire per-rail callers (#636 will). This PR is the prerequisite.
- Does not touch secret-mode's other behaviour. AboutScreen's display label, GroupsScreen's affordance reveals, dev build hash etc. all continue to gate on `secretMode` exactly as before.

## Test plan

- Cold install, default secret-mode off, leave WoT tier at the post-#630 default `'all'` → Messages tab now actually shows All (was being clamped to Friends).
- Open the WoT bottom sheet from the Messages chip → All is the active row, matching the chip.
- Switch to Friends from the sheet → Messages re-filters to follows; chip flips to Friends.
- Enable secret mode via the About triple-tap → no visible change to WoT state (the clamp wasn't there to release).
- `npx tsc --noEmit` / `npx eslint` / `npx prettier --check` clean on touched files.

## Related

- Round-5 Copilot blocker on PR #630 (#640).
- #636 per-rail WoT chip — depends on `currentTier` landing here.
- #547 — original migration that introduced the clamp; #640 is the post-`'all'`-default reversal of that part.

Closes #640