### PR TITLE
perf(nostr): always hydrate cached profiles on cold start, even when contacts cache is stale (#642)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -1165,9 +1165,20 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       perfLog(
         `loadContactsFromCache: blob sizes contacts=${contactsJson?.length ?? 0}B profiles=${profilesJson?.length ?? 0}B`,
       );
+      // Previously: any contacts cache older than 24h short-circuited the
+      // whole bootstrap, discarding the still-useful profile map and
+      // painting an empty Friends tab while `loadContacts` ran the relay
+      // fetch (#642). Even a stale follow list is a better first paint
+      // than nothing — the relay refresh will overwrite it in seconds via
+      // the stale-while-revalidate path in `loadContacts`. Profiles in
+      // particular are identity data that change rarely; preserving them
+      // means the per-row zap gate hydrates from cache instead of reading
+      // `lightningAddress: null` for every contact during the kind-0
+      // batch refetch.
       if (contactsTsStr && Date.now() - parseInt(contactsTsStr, 10) > CACHE_MAX_AGE_MS) {
-        perfLog('loadContactsFromCache: contacts cache expired, skipping');
-        return false;
+        perfLog(
+          'loadContactsFromCache: contacts cache stale, still hydrating from disk (relay refresh will reconcile)',
+        );
       }
       if (contactsJson) {
         const tParse = Date.now();


### PR DESCRIPTION
## Why

On cold start the `loadContactsFromCache` bootstrap used to early-return as soon as the contacts cache timestamp was older than `CACHE_MAX_AGE_MS` (24h). That discarded the still-useful **profile map** alongside the legitimately-stale contacts list, so the Friends tab painted empty during the window where `loadContacts` ran the kind-0 batch refetch (~30s).

The user-visible symptom: every friend row rendered with `lightningAddress: null` until the kind-0 batch settled — the zap chip showed a misleading **"no Lightning address"** greyed state on contacts the user had clearly zapped before. Surfaced today on the Pixel production app and reproduced on the emulator during PR #635 testing.

`loadContacts` itself has a perfectly good stale-while-revalidate path that re-hydrates both contacts and profiles, but the bootstrap was throwing the data away before that ran.

## What

Drop the early-return. Always parse + merge the cached blobs even when the timestamp is past `CACHE_MAX_AGE_MS`. The relay refresh in `loadContacts` overwrites stale entries within seconds; profiles get refreshed by the kind-0 batch as before — but the user's first paint now reflects the data we already have on disk rather than an empty list.

Diff is intentionally tiny — one early-return removed, replaced with a `perfLog` line so the regression doesn't sneak back in unnoticed.

## What this is **not** doing

- Doesn't change per-account cache scoping (`perAccountKey` still isolates one signed-in user's contacts from another's).
- Doesn't change the kind-0 batch refresh policy — still gated by `MISSING_PROFILE_RETRY_MS` / `CACHE_MAX_AGE_MS` on the profile timestamp.
- Doesn't touch the LRU + size-cap added by #543 for the DM cache; profile cache continues to grow with each contact.

## Test plan

- Reproduce the pre-fix state: install the dev client, sign in, leave the app for >24h (or manually overwrite `nostr_contacts_cache_ts:<pubkey>` in AsyncStorage to ~25h ago), reopen → Friends tab shows the cached contacts with cached profiles immediately, zap chips reflect each contact's `lud16` accurately within the first render rather than 30s later.
- Within a single fresh session (cache <24h), behaviour unchanged.
- `npx tsc --noEmit` / `npx eslint` / `npx prettier --check` clean on touched file (1 pre-existing warning elsewhere in the file, unrelated).

## Related

- PR #635 — friend-row icons always render with disabled state when not usable. This PR closes the data-loading regression that made the disabled state lie about which condition was missing.
- PR #644 — `£–` placeholder on the fiat row. Same principle (be honest about loading state) applied to the wallet card.
- PR #645 — offline banner. Same UX cluster.

Closes #642