### PR TITLE
fix(send): don't show "Payment failed" on a connection error (#648)

### DIFF
--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -25,7 +25,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
-import { Check, X } from 'lucide-react-native';
+import { Check, X, WifiOff } from 'lucide-react-native';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { lightPalette, type Palette } from '../styles/palettes';
 
@@ -33,6 +33,10 @@ export type PaymentProgressState =
   | 'sending'
   | 'in-flight-extended'
   | 'success'
+  // Relay/transport connectivity failure — outcome UNKNOWN, not a
+  // confirmed failure (#648). Distinct from 'error' so we never imply the
+  // payment failed when it may have settled.
+  | 'connection-lost'
   | 'error'
   | 'hidden';
 export type PaymentDirection = 'send' | 'receive';
@@ -369,6 +373,14 @@ export default function PaymentProgressOverlay({
         withTiming(0, { duration: 0 }),
         withSpring(1, { damping: 10, stiffness: 220 }),
       );
+    } else if (state === 'connection-lost') {
+      // Not a failure — keep the neutral palette (no red morph) but pop
+      // the icon in so the "couldn't confirm" card reads as resolved.
+      colorProgress.value = 0;
+      iconScale.value = withSequence(
+        withTiming(0, { duration: 0 }),
+        withSpring(1, { damping: 10, stiffness: 220 }),
+      );
     } else if (state === 'sending' || state === 'in-flight-extended') {
       colorProgress.value = 0;
       iconScale.value = 0;
@@ -411,6 +423,10 @@ export default function PaymentProgressOverlay({
           ? `from ${recipientName}`
           : `to ${recipientName}`
         : undefined;
+  } else if (state === 'connection-lost') {
+    title = 'Connection lost';
+    subtitle =
+      "We couldn't reach your wallet to confirm. Your payment may still have gone through — check your balance before trying again.";
   } else if (state === 'error') {
     title = 'Payment failed';
     subtitle = humanizedError.message;
@@ -480,6 +496,11 @@ export default function PaymentProgressOverlay({
           {state === 'error' && (
             <Animated.View style={[styles.iconSlot, styles.errorCircle, iconAnimatedStyle]}>
               <X size={44} color={colors.white} strokeWidth={3.5} />
+            </Animated.View>
+          )}
+          {state === 'connection-lost' && (
+            <Animated.View style={[styles.iconSlot, styles.connectionCircle, iconAnimatedStyle]}>
+              <WifiOff size={40} color={colors.white} strokeWidth={3} />
             </Animated.View>
           )}
 
@@ -606,6 +627,12 @@ const createStyles = (colors: Palette) =>
     errorCircle: {
       borderRadius: 36,
       backgroundColor: colors.red,
+    },
+    // Amber, not red: a connection loss is "couldn't confirm", not a
+    // confirmed failure (#648).
+    connectionCircle: {
+      borderRadius: 36,
+      backgroundColor: colors.zapYellow,
     },
     title: {
       fontSize: 20,

--- a/src/components/PaymentProgressOverlay.tsx
+++ b/src/components/PaymentProgressOverlay.tsx
@@ -500,7 +500,7 @@ export default function PaymentProgressOverlay({
           )}
           {state === 'connection-lost' && (
             <Animated.View style={[styles.iconSlot, styles.connectionCircle, iconAnimatedStyle]}>
-              <WifiOff size={40} color={colors.white} strokeWidth={3} />
+              <WifiOff size={40} color={colors.zapYellowInk} strokeWidth={3} />
             </Animated.View>
           )}
 

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -38,7 +38,7 @@ import * as swapRecoveryService from '../services/swapRecoveryService';
 import * as SecureStore from 'expo-secure-store';
 import { npubEncode } from '../services/nostrService';
 import { recordOutgoing as recordOutgoingCounterparty } from '../services/zapCounterpartyStorage';
-import { isReplyTimeoutError } from '../services/nwcService';
+import { isReplyTimeoutError, isConnectionError } from '../services/nwcService';
 import PaymentProgressOverlay, { PaymentProgressState } from './PaymentProgressOverlay';
 import AmountEntryScreen from './AmountEntryScreen';
 import { perfLog } from '../utils/perfLog';
@@ -673,6 +673,16 @@ const SendSheet: React.FC<Props> = ({
         if (dismissedInFlightRef.current) return;
         setProgressError(undefined);
         setProgressState('in-flight-extended');
+        return;
+      }
+      // A relay/transport connectivity failure (relay unreachable, publish
+      // never completed) is an UNKNOWN outcome, not a confirmed failure —
+      // the payment may have settled. Surface "Connection lost" with a
+      // check-before-retry warning instead of "Payment failed" (#648).
+      if (isConnectionError(error)) {
+        if (dismissedInFlightRef.current) return;
+        setProgressError(undefined);
+        setProgressState('connection-lost');
         return;
       }
       if (dismissedInFlightRef.current) return;

--- a/src/services/nwcService.test.ts
+++ b/src/services/nwcService.test.ts
@@ -110,6 +110,7 @@ describe('isConnectionError (#648 — connection-lost vs confirmed failure)', ()
     'Failed to connect to wss://relay.coinos.io',
     'failed to connect to any relay',
     'publish timed out',
+    "Couldn't reach your wallet: relay publish timed out",
     '[NWC] Relay publish failed',
     'Network request failed',
     'WebSocket connection closed',

--- a/src/services/nwcService.test.ts
+++ b/src/services/nwcService.test.ts
@@ -28,7 +28,7 @@ jest.mock('@getalby/sdk', () => ({
   })),
 }));
 
-import { connect, getBalance } from './nwcService';
+import { connect, getBalance, isConnectionError, isReplyTimeoutError } from './nwcService';
 
 const VALID_NWC_URL =
   'nostr+walletconnect://' +
@@ -102,5 +102,32 @@ describe('nwcService.getBalance with replyTimeoutMs', () => {
     const balance = await getBalance(WALLET_ID);
     expect(balance).toBe(999);
     expect(calls).toBe(2);
+  });
+});
+
+describe('isConnectionError (#648 — connection-lost vs confirmed failure)', () => {
+  it.each([
+    'Failed to connect to wss://relay.coinos.io',
+    'failed to connect to any relay',
+    'publish timed out',
+    '[NWC] Relay publish failed',
+    'Network request failed',
+    'WebSocket connection closed',
+    'connection lost',
+  ])('treats %j as a connectivity (unknown-outcome) error', (msg) => {
+    expect(isConnectionError(new Error(msg))).toBe(true);
+  });
+
+  it.each(['Insufficient funds', 'invoice expired', 'no route', 'payment failed'])(
+    'does NOT treat %j (a confirmed wallet error) as a connection error',
+    (msg) => {
+      expect(isConnectionError(new Error(msg))).toBe(false);
+    },
+  );
+
+  it('a connection error is distinct from a reply-timeout', () => {
+    const connErr = new Error('Failed to connect to wss://relay.coinos.io');
+    expect(isConnectionError(connErr)).toBe(true);
+    expect(isReplyTimeoutError(connErr)).toBe(false);
   });
 });

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -64,6 +64,28 @@ export function isReplyTimeoutError(error: unknown): boolean {
   return (error as Error)?.name === REPLY_TIMEOUT_ERROR_NAME;
 }
 
+// True when the failure is a relay/transport connectivity problem rather
+// than a confirmed payment outcome — e.g. the relay was unreachable
+// ("Failed to connect to wss://…", NWC code OTHER) or a publish never
+// completed. Like a reply-timeout, the payment status is UNKNOWN: it may
+// well have settled. Callers must NOT present these as "Payment failed"
+// (#648) — a user who trusts that may re-send and double-pay.
+export function isConnectionError(error: unknown): boolean {
+  const msg = (
+    (error as { message?: string } | undefined)?.message ?? String(error ?? '')
+  ).toLowerCase();
+  return (
+    msg.includes('failed to connect') ||
+    msg.includes('publish timed out') ||
+    msg.includes('publish failed') ||
+    msg.includes('could not connect') ||
+    msg.includes('network request failed') ||
+    msg.includes('websocket') ||
+    msg.includes('connection closed') ||
+    msg.includes('connection lost')
+  );
+}
+
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw createAbortError();
 }


### PR DESCRIPTION
Closes #648

## Problem
A send that fails because the wallet's relay was **unreachable** (or a publish never completed) is an **unknown** outcome — the payment may well have settled — yet the UI showed a definitive **"Payment failed"**. That's misleading and **risks a re-send / double-pay**.

**Observed (real device, poor connection):** sent 1,000 sats (Pixel, LNbits NWC) → Pixel showed "Payment failed" with a *connection*-error body — but the 1,000 sats **actually arrived** (Coin OS balance 11 → 1,011, verified via NWC `lookup_invoice`/`get_balance`).

The reply-timeout case was already handled (→ "Still in flight"), but a **connection-lost** error (NWC code `OTHER`, `Failed to connect to wss://…`) fell through to the generic `'error'` state → "Payment failed".

## Change
- **`nwcService.isConnectionError()`** — classifies relay/transport failures (failed-to-connect, publish timeout/failed, websocket/connection-closed) as *unknown outcome*, distinct from a confirmed wallet decline.
- **`SendSheet`** — routes those to a new **`'connection-lost'`** state instead of `'error'`. The reply-timeout → `'in-flight-extended'` path is untouched.
- **`PaymentProgressOverlay`** — `'connection-lost'` shows an **amber "Connection lost"** card (not the red failure morph): *"We couldn't reach your wallet to confirm. Your payment may still have gone through — check your balance before trying again."*
- Unit tests for the classifier (connectivity errors vs confirmed declines like "Insufficient funds" / "payment failed").

`tsc`, Prettier, ESLint all clean; nwcService tests pass (17).

## Test plan
1. **Unit** — `npx jest nwcService` → `isConnectionError()` cases pass: connectivity errors (failed-to-connect, publish timeout, websocket-closed) classify as unknown-outcome, while confirmed declines ("Insufficient funds", "payment failed") still classify as failures. 17 tests green.
2. **Manual — connection-lost path** — with the wallet relay unreachable (toggle airplane mode mid-send, or point at a dead relay URL), send 1–2 sats from the Send sheet → the overlay shows the **amber "Connection lost"** card ("We couldn't reach your wallet to confirm…"), **not** the red "Payment failed" morph.
3. **Regression — confirmed decline** — send with insufficient funds → still shows the red "Payment failed" state.
4. **Regression — reply timeout** — slow-but-reachable relay → still shows "Still in flight" (`in-flight-extended`), unchanged.

> On-device screenshots of the amber card are still to come (see below).

## Still to do before "ready"
- **On-device screenshots** of the new "Connection lost" card (blocked right now by a flaky dev-machine connection; will add once stable).
- **Follow-up (optional, noted in #648):** best-effort `lookup_invoice` by payment hash to *confirm* settled/declined before showing either outcome — the receive side already does this (#481). Could fold in here or as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
