### PR TITLE
fix(messaging): make URLs in messages tappable links (#663)

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -24,7 +24,7 @@ import {
 } from '../utils/messageContent';
 import { isSupportedImageUrl } from '../utils/imageUrl';
 import { extractUrls } from '../utils/extractUrls';
-import { linkifySegments } from '../utils/linkify';
+import { linkifySegments, hasLink } from '../utils/linkify';
 import { isBlocklisted } from '../services/linkPreviewBlocklist';
 import MessageLinkPreview from './MessageLinkPreview';
 
@@ -450,8 +450,8 @@ const MessageBubble: React.FC<Props> = ({
   }
 
   // Plain text fallback — no rich content detected. Cap link previews
-  // at 1 per message: first non-blocklisted URL wins. Any other URLs in
-  // the body remain clickable as plain text via OS link recognition.
+  // at 1 per message: first non-blocklisted URL wins. All URLs in the body
+  // are rendered as tappable link spans below (see linkifySegments).
   const previewUrl = (() => {
     const urls = extractUrls(text);
     for (const u of urls) {
@@ -465,20 +465,28 @@ const MessageBubble: React.FC<Props> = ({
       <View style={[styles.bubble, fromMe ? styles.bubbleMe : styles.bubbleThem]}>
         {SenderLabel}
         <Text style={[styles.bubbleText, fromMe && styles.bubbleTextMe]}>
-          {linkifySegments(text).map((seg, i) =>
-            seg.url ? (
-              <Text
-                key={i}
-                style={[styles.bubbleLink, fromMe && styles.bubbleLinkMe]}
-                onPress={() => Linking.openURL(seg.url as string)}
-                accessibilityRole="link"
-              >
-                {seg.text}
-              </Text>
-            ) : (
-              seg.text
-            ),
-          )}
+          {hasLink(text)
+            ? linkifySegments(text).map((seg, i) =>
+                seg.url ? (
+                  <Text
+                    key={i}
+                    style={[styles.bubbleLink, fromMe && styles.bubbleLinkMe]}
+                    onPress={() => {
+                      // openURL rejects on a malformed URL / missing handler —
+                      // swallow so a bad link can't raise an unhandled rejection.
+                      void Linking.openURL(seg.url as string).catch(() => {});
+                    }}
+                    accessibilityRole="link"
+                    accessibilityLabel={`Open link ${seg.url}`}
+                    testID={`${testIdPrefix}-link-${id}-${i}`}
+                  >
+                    {seg.text}
+                  </Text>
+                ) : (
+                  seg.text
+                ),
+              )
+            : text}
         </Text>
         {previewUrl ? <MessageLinkPreview url={previewUrl} eventId={id} fromMe={fromMe} /> : null}
         <Text style={[styles.bubbleTime, fromMe && styles.bubbleTimeMe]}>

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, Image, StyleSheet, Linking } from 'react-native';
 import { Image as ExpoImage } from 'expo-image';
 import { Zap, MapPin, UserRound } from 'lucide-react-native';
 import { useThemeColors } from '../contexts/ThemeContext';
@@ -24,6 +24,7 @@ import {
 } from '../utils/messageContent';
 import { isSupportedImageUrl } from '../utils/imageUrl';
 import { extractUrls } from '../utils/extractUrls';
+import { linkifySegments } from '../utils/linkify';
 import { isBlocklisted } from '../services/linkPreviewBlocklist';
 import MessageLinkPreview from './MessageLinkPreview';
 
@@ -463,7 +464,22 @@ const MessageBubble: React.FC<Props> = ({
     <View style={[styles.bubbleRow, fromMe ? styles.bubbleRowRight : styles.bubbleRowLeft]}>
       <View style={[styles.bubble, fromMe ? styles.bubbleMe : styles.bubbleThem]}>
         {SenderLabel}
-        <Text style={[styles.bubbleText, fromMe && styles.bubbleTextMe]}>{text}</Text>
+        <Text style={[styles.bubbleText, fromMe && styles.bubbleTextMe]}>
+          {linkifySegments(text).map((seg, i) =>
+            seg.url ? (
+              <Text
+                key={i}
+                style={[styles.bubbleLink, fromMe && styles.bubbleLinkMe]}
+                onPress={() => Linking.openURL(seg.url as string)}
+                accessibilityRole="link"
+              >
+                {seg.text}
+              </Text>
+            ) : (
+              seg.text
+            ),
+          )}
+        </Text>
         {previewUrl ? <MessageLinkPreview url={previewUrl} eventId={id} fromMe={fromMe} /> : null}
         <Text style={[styles.bubbleTime, fromMe && styles.bubbleTimeMe]}>
           {formatTime(createdAt)}
@@ -511,6 +527,17 @@ const createStyles = (colors: Palette) =>
     },
     bubbleTextMe: {
       color: colors.white,
+    },
+    // Tappable URL span inside a received bubble (surface bg) — brand accent.
+    bubbleLink: {
+      color: colors.brandPink,
+      textDecorationLine: 'underline',
+    },
+    // …and inside a sent bubble (pink bg) — white so it stays legible.
+    bubbleLinkMe: {
+      color: colors.white,
+      textDecorationLine: 'underline',
+      fontWeight: '600',
     },
     bubbleTime: {
       fontSize: 10,

--- a/src/utils/linkify.test.ts
+++ b/src/utils/linkify.test.ts
@@ -1,0 +1,67 @@
+import { linkifySegments, hasLink } from './linkify';
+
+describe('linkifySegments (#663 — tappable URLs in messages)', () => {
+  it('returns a single plain segment for text with no URL', () => {
+    expect(linkifySegments('hello there')).toEqual([{ text: 'hello there' }]);
+  });
+
+  it('linkifies a bare URL', () => {
+    expect(linkifySegments('https://x.com/foo')).toEqual([
+      { text: 'https://x.com/foo', url: 'https://x.com/foo' },
+    ]);
+  });
+
+  it('keeps surrounding text plain and only links the URL', () => {
+    expect(linkifySegments('check this https://x.com/foo cheers')).toEqual([
+      { text: 'check this ' },
+      { text: 'https://x.com/foo', url: 'https://x.com/foo' },
+      { text: ' cheers' },
+    ]);
+  });
+
+  it('peels a sentence-ending period off the URL', () => {
+    expect(linkifySegments('see https://x.com/foo.')).toEqual([
+      { text: 'see ' },
+      { text: 'https://x.com/foo', url: 'https://x.com/foo' },
+      { text: '.' },
+    ]);
+  });
+
+  it('peels a trailing close-paren', () => {
+    expect(linkifySegments('(https://x.com/foo)')).toEqual([
+      { text: '(' },
+      { text: 'https://x.com/foo', url: 'https://x.com/foo' },
+      { text: ')' },
+    ]);
+  });
+
+  it('handles multiple URLs in one message', () => {
+    expect(linkifySegments('a https://one.com b http://two.org c')).toEqual([
+      { text: 'a ' },
+      { text: 'https://one.com', url: 'https://one.com' },
+      { text: ' b ' },
+      { text: 'http://two.org', url: 'http://two.org' },
+      { text: ' c' },
+    ]);
+  });
+
+  it('does NOT link a bare domain without a scheme', () => {
+    expect(linkifySegments('go to x.com now')).toEqual([{ text: 'go to x.com now' }]);
+  });
+
+  it('links http as well as https', () => {
+    expect(linkifySegments('http://example.com')).toEqual([
+      { text: 'http://example.com', url: 'http://example.com' },
+    ]);
+  });
+});
+
+describe('hasLink', () => {
+  it('detects a URL', () => {
+    expect(hasLink('see https://x.com/foo')).toBe(true);
+  });
+  it('is false without a scheme URL', () => {
+    expect(hasLink('see x.com')).toBe(false);
+    expect(hasLink('plain text')).toBe(false);
+  });
+});

--- a/src/utils/linkify.ts
+++ b/src/utils/linkify.ts
@@ -1,0 +1,51 @@
+// Split message text into plain + URL segments so a chat bubble can render
+// http(s) links as tappable spans while leaving the surrounding text plain
+// (#663). Kept as a pure helper under src/utils so it's unit-testable.
+
+export interface LinkSegment {
+  text: string;
+  // Present iff this segment is a tappable URL. `text` is what to display
+  // (identical to the URL), `url` is what to open.
+  url?: string;
+}
+
+// http(s) URLs, greedy up to the next whitespace. Trailing punctuation is
+// peeled off separately below so a sentence-ending ")"/"." isn't swallowed.
+const URL_RE = /https?:\/\/[^\s]+/gi;
+
+// Punctuation that's almost always sentence/markup rather than part of the URL
+// when it sits at the very end of the match.
+const TRAILING_PUNCT = /[.,;:!?)\]}'"»]+$/;
+
+export function linkifySegments(input: string): LinkSegment[] {
+  const segments: LinkSegment[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  while ((m = URL_RE.exec(input)) !== null) {
+    let url = m[0];
+    let trailing = '';
+    const tm = url.match(TRAILING_PUNCT);
+    if (tm) {
+      trailing = tm[0];
+      url = url.slice(0, url.length - trailing.length);
+    }
+    // Degenerate match that was ALL punctuation after the scheme — skip.
+    if (url.length <= 'https://'.length) continue;
+    if (m.index > last) segments.push({ text: input.slice(last, m.index) });
+    segments.push({ text: url, url });
+    if (trailing) segments.push({ text: trailing });
+    last = m.index + m[0].length;
+  }
+  if (last < input.length) segments.push({ text: input.slice(last) });
+  // Always return at least one segment so callers can map unconditionally.
+  if (segments.length === 0) segments.push({ text: input });
+  return segments;
+}
+
+// True when the text contains at least one linkable URL — lets callers skip
+// the segment map entirely for the common no-URL message.
+export function hasLink(input: string): boolean {
+  URL_RE.lastIndex = 0;
+  return URL_RE.test(input);
+}


### PR DESCRIPTION
Closes #663.

## What & why

URLs in received messages rendered as **plain, inert text** — e.g. a `https://x.com/…` link from "BitTasker" couldn't be tapped. `MessageBubble` had no `Linking` / URL handling.

## Changes
- New `src/utils/linkify.ts` — `linkifySegments(text)` splits a message into plain + `http(s)` URL segments, peeling trailing punctuation (`.`, `)`, …) so a sentence-ending mark isn't swallowed into the link. Pure + unit-tested (10 cases).
- `MessageBubble` renders the body as those segments; URL spans are tappable `<Text onPress={() => Linking.openURL(url)}>` (`accessibilityRole="link"`). Surrounding text stays plain; multiple URLs per message work.
- Link styling: brand-pink + underline on received bubbles, white + underline on sent (pink) bubbles so it stays legible on both backgrounds.

## Out of scope
- `nostr:` / `npub` / `lightning:` linkification — `http(s)` only for this PR (noted in #663).

## Test plan
- `npx tsc --noEmit` — clean
- `npx jest linkify` — 10 pass (bare URL, embedded-in-text, trailing `.`/`)`, multiple URLs, http+https, no-scheme domain stays plain)
- ESLint + Prettier — clean
- Manual: a message "see https://x.com/foo" shows the URL as a tappable link that opens the browser; surrounding text stays plain.
