### PR TITLE
feat(messaging): fetch + cache profiles for non-friend DM senders (#664)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -799,6 +799,8 @@ interface NostrContextType {
    */
   refreshProfile: (opts?: { force?: boolean }) => Promise<void>;
   refreshContacts: () => Promise<void>;
+  // Fetch kind-0 profiles for arbitrary pubkeys (non-followed DM senders) (#664).
+  fetchProfilesForPubkeys: (pubkeys: string[]) => Promise<Map<string, NostrProfile>>;
   signZapRequest: (
     recipientPubkey: string,
     amountSats: number,
@@ -1102,6 +1104,18 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       }
     },
     [],
+  );
+
+  // Batch-fetch kind-0 profiles for arbitrary pubkeys (e.g. non-followed DM
+  // senders, which `loadContacts`/`fetchProfiles` never fetch). Reads from the
+  // user's relays; nostrService.fetchProfiles unions PROFILE_RELAYS for
+  // coverage. Returns a pubkey→profile map; the caller owns caching (#664).
+  const fetchProfilesForPubkeys = useCallback(
+    async (pubkeys: string[]): Promise<Map<string, NostrProfile>> => {
+      if (pubkeys.length === 0) return new Map();
+      return nostrService.fetchProfiles(pubkeys, getReadRelays());
+    },
+    [getReadRelays],
   );
 
   /** Eagerly hydrate own `profile` state from the per-account cache so
@@ -4112,6 +4126,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       logout,
       refreshProfile,
       refreshContacts,
+      fetchProfilesForPubkeys,
       signZapRequest,
       publishProfile,
       followContact,
@@ -4149,6 +4164,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       logout,
       refreshProfile,
       refreshContacts,
+      fetchProfilesForPubkeys,
       signZapRequest,
       publishProfile,
       followContact,

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -301,6 +301,10 @@ const MessagesScreen: React.FC = () => {
 
   // Hydrate the per-account non-follow profile cache on mount / identity change.
   useEffect(() => {
+    // Reset per-account state first so a previous account's profiles + the
+    // attempted set don't leak across a multi-account switch (#668 review).
+    nonFollowAttempted.current = new Set();
+    setNonFollowProfiles(new Map());
     if (!pubkey) return;
     let cancelled = false;
     AsyncStorage.getItem(`nonfollow_profiles_${pubkey}`)
@@ -345,25 +349,25 @@ const MessagesScreen: React.FC = () => {
   // attempted once per session so a profile-less sender isn't re-queried (#664).
   useEffect(() => {
     if (!pubkey) return;
-    const missing: string[] = [];
+    // De-dupe — dmInbox can hold multiple entries for the same partner.
+    const missingSet = new Set<string>();
     for (const entry of dmInbox) {
       const pk = entry.partnerPubkey?.toLowerCase();
       if (!pk || contactInfoMap.has(pk) || nonFollowAttempted.current.has(pk)) continue;
-      missing.push(pk);
+      missingSet.add(pk);
     }
-    if (missing.length === 0) return;
+    if (missingSet.size === 0) return;
+    const missing = [...missingSet];
     missing.forEach((pk) => nonFollowAttempted.current.add(pk));
     let cancelled = false;
     fetchProfilesForPubkeys(missing)
       .then((fetched) => {
         if (cancelled || fetched.size === 0) return;
+        // No side effects in the updater (Strict Mode may run it twice);
+        // persistence is handled by the dedicated effect below.
         setNonFollowProfiles((prev) => {
           const next = new Map(prev);
           for (const [pk, prof] of fetched) next.set(pk.toLowerCase(), prof);
-          AsyncStorage.setItem(
-            `nonfollow_profiles_${pubkey}`,
-            JSON.stringify(Object.fromEntries(next)),
-          ).catch(() => {});
           return next;
         });
       })
@@ -372,6 +376,16 @@ const MessagesScreen: React.FC = () => {
       cancelled = true;
     };
   }, [dmInbox, contactInfoMap, pubkey, fetchProfilesForPubkeys]);
+
+  // Persist the non-follow profile cache when it changes — kept out of the
+  // state updater so Strict Mode's double-invocation can't duplicate the write.
+  useEffect(() => {
+    if (!pubkey || nonFollowProfiles.size === 0) return;
+    AsyncStorage.setItem(
+      `nonfollow_profiles_${pubkey}`,
+      JSON.stringify(Object.fromEntries(nonFollowProfiles)),
+    ).catch(() => {});
+  }, [nonFollowProfiles, pubkey]);
 
   // useDeferredValue lets React deprioritise the (O(n)) summary rebuild when an urgent update — e.g. a tab-bar tap, scroll gesture — comes in during a relay-burst flush. The user's tap renders against the previous dmInbox; the new summary lands on the next idle frame. Keeps the bottom nav snappy when 25 wraps batch-flush via the live-sub queue (queueInboxEntry / flushPendingInbox).
   const deferredDmInbox = useDeferredValue(dmInbox);

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -45,6 +45,7 @@ import {
 } from '../utils/conversationSummaries';
 import { createMessagesScreenStyles } from '../styles/MessagesScreen.styles';
 import type { MainTabParamList, RootStackParamList } from '../navigation/types';
+import type { NostrProfile } from '../types/nostr';
 
 type MessagesNavigation = CompositeNavigationProp<
   BottomTabNavigationProp<MainTabParamList, 'Messages'>,
@@ -72,6 +73,8 @@ const MessagesScreen: React.FC = () => {
     dmInbox,
     refreshDmInbox,
     armLiveDmSub,
+    fetchProfilesForPubkeys,
+    pubkey,
   } = useNostr();
   const { wallets } = useWallet();
   const { groupSummaries, effectiveWotTier } = useGroups();
@@ -289,6 +292,33 @@ const MessagesScreen: React.FC = () => {
   // handleConversationPress's picture/lightning-address fallback) now
   // all consult this map, so a 50-contact x N-row screen does O(contacts)
   // once per render instead of O(rows × contacts) per render. See #245.
+  // Non-followed DM senders aren't in `contacts`, so the contacts pipeline
+  // never fetches their kind-0 — they'd show a raw npub + blank avatar. We
+  // fetch their profiles on demand (see the effect below), cache to disk, and
+  // layer them into the resolution here + buildDmSummaries (#664).
+  const [nonFollowProfiles, setNonFollowProfiles] = useState<Map<string, NostrProfile>>(new Map());
+  const nonFollowAttempted = useRef<Set<string>>(new Set());
+
+  // Hydrate the per-account non-follow profile cache on mount / identity change.
+  useEffect(() => {
+    if (!pubkey) return;
+    let cancelled = false;
+    AsyncStorage.getItem(`nonfollow_profiles_${pubkey}`)
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        try {
+          const obj = JSON.parse(raw) as Record<string, NostrProfile>;
+          setNonFollowProfiles(new Map(Object.entries(obj)));
+        } catch {
+          // Corrupt cache — ignore; the fetch effect repopulates.
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [pubkey]);
+
   const contactInfoMap = useMemo(() => {
     const map = new Map<string, ContactInfo>();
     for (const c of contacts) {
@@ -298,8 +328,50 @@ const MessagesScreen: React.FC = () => {
         lightningAddress: c.profile?.lud16 ?? null,
       });
     }
+    // Layer in non-followed senders' fetched profiles (never override a contact).
+    for (const [pk, prof] of nonFollowProfiles) {
+      if (map.has(pk)) continue;
+      map.set(pk, {
+        picture: prof.picture ?? null,
+        name: (prof.displayName || prof.name || '').trim() || null,
+        lightningAddress: prof.lud16 ?? null,
+      });
+    }
     return map;
-  }, [contacts]);
+  }, [contacts, nonFollowProfiles]);
+
+  // Fetch kind-0 for DM partners not in contacts and not yet cached, so their
+  // name + avatar resolve in the list (esp. with WoT: All). Each pubkey is
+  // attempted once per session so a profile-less sender isn't re-queried (#664).
+  useEffect(() => {
+    if (!pubkey) return;
+    const missing: string[] = [];
+    for (const entry of dmInbox) {
+      const pk = entry.partnerPubkey?.toLowerCase();
+      if (!pk || contactInfoMap.has(pk) || nonFollowAttempted.current.has(pk)) continue;
+      missing.push(pk);
+    }
+    if (missing.length === 0) return;
+    missing.forEach((pk) => nonFollowAttempted.current.add(pk));
+    let cancelled = false;
+    fetchProfilesForPubkeys(missing)
+      .then((fetched) => {
+        if (cancelled || fetched.size === 0) return;
+        setNonFollowProfiles((prev) => {
+          const next = new Map(prev);
+          for (const [pk, prof] of fetched) next.set(pk.toLowerCase(), prof);
+          AsyncStorage.setItem(
+            `nonfollow_profiles_${pubkey}`,
+            JSON.stringify(Object.fromEntries(next)),
+          ).catch(() => {});
+          return next;
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [dmInbox, contactInfoMap, pubkey, fetchProfilesForPubkeys]);
 
   // useDeferredValue lets React deprioritise the (O(n)) summary rebuild when an urgent update — e.g. a tab-bar tap, scroll gesture — comes in during a relay-burst flush. The user's tap renders against the previous dmInbox; the new summary lands on the next idle frame. Keeps the bottom nav snappy when 25 wraps batch-flush via the live-sub queue (queueInboxEntry / flushPendingInbox).
   const deferredDmInbox = useDeferredValue(dmInbox);
@@ -318,8 +390,9 @@ const MessagesScreen: React.FC = () => {
       deferredDmInbox,
       deferredContacts,
       enforceFollowingOnly ? followPubkeys : undefined,
+      nonFollowProfiles,
     );
-  }, [deferredDmInbox, deferredContacts, enforceFollowingOnly, followPubkeys]);
+  }, [deferredDmInbox, deferredContacts, enforceFollowingOnly, followPubkeys, nonFollowProfiles]);
   // Build the zap-counterparties memo separately so that toggling
   // `showZapCounterparties` off doesn't make every wallet update churn
   // the merged summary list — when the toggle is off this memo is built

--- a/src/utils/conversationSummaries.test.ts
+++ b/src/utils/conversationSummaries.test.ts
@@ -1,5 +1,5 @@
 import { buildDmSummaries, type DmInboxEntry } from './conversationSummaries';
-import type { NostrContact } from '../types/nostr';
+import type { NostrContact, NostrProfile } from '../types/nostr';
 
 const FOLLOWED = 'a'.repeat(64);
 const UNFOLLOWED = 'b'.repeat(64);
@@ -62,5 +62,48 @@ describe('buildDmSummaries follow gate', () => {
       new Set<string>(),
     );
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('buildDmSummaries non-followed profile resolution (#664)', () => {
+  const evilProfile: NostrProfile = {
+    pubkey: UNFOLLOWED,
+    npub: '',
+    name: 'Evil Piggy',
+    displayName: null,
+    picture: 'https://example.com/evil.png',
+    banner: null,
+    about: null,
+    lud16: null,
+    nip05: null,
+  };
+
+  it('resolves a non-contact sender name + avatar from extraProfiles', () => {
+    const result = buildDmSummaries(
+      [entry(UNFOLLOWED)],
+      [], // not in the contact list
+      undefined,
+      new Map([[UNFOLLOWED.toLowerCase(), evilProfile]]),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Evil Piggy');
+    expect(result[0].picture).toBe('https://example.com/evil.png');
+  });
+
+  it('falls back to an npub-style name (not a profile) when none is known', () => {
+    const result = buildDmSummaries([entry(UNFOLLOWED)], [], undefined);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).not.toBe('Evil Piggy');
+    expect(result[0].picture).toBeNull();
+  });
+
+  it('prefers a real contact profile over extraProfiles', () => {
+    const result = buildDmSummaries(
+      [entry(FOLLOWED)],
+      [followedContact],
+      undefined,
+      new Map([[FOLLOWED.toLowerCase(), evilProfile]]),
+    );
+    expect(result[0].name).toBe('Alice');
   });
 });

--- a/src/utils/conversationSummaries.ts
+++ b/src/utils/conversationSummaries.ts
@@ -1,5 +1,5 @@
 import type { WalletState, WalletTransaction } from '../types/wallet';
-import type { NostrContact } from '../types/nostr';
+import type { NostrContact, NostrProfile } from '../types/nostr';
 
 export interface ConversationSummary {
   /**
@@ -208,6 +208,10 @@ export function buildDmSummaries(
   entries: DmInboxEntry[],
   contacts: NostrContact[],
   followPubkeys?: ReadonlySet<string>,
+  // Profiles for partners NOT in `contacts` (non-followed DM senders),
+  // fetched separately so their name + avatar resolve instead of showing a
+  // raw npub — keyed by lowercase pubkey (#664).
+  extraProfiles?: ReadonlyMap<string, NostrProfile>,
 ): ConversationSummary[] {
   const contactByPubkey = new Map<string, NostrContact>();
   for (const c of contacts) contactByPubkey.set(c.pubkey.toLowerCase(), c);
@@ -253,19 +257,23 @@ export function buildDmSummaries(
 
   const summaries: ConversationSummary[] = [];
   for (const entry of winner.values()) {
-    const contact = contactByPubkey.get(entry.partnerPubkey.toLowerCase());
+    const key = entry.partnerPubkey.toLowerCase();
+    const contact = contactByPubkey.get(key);
+    // Prefer the contact's profile; for a non-followed sender fall back to the
+    // separately-fetched profile so name + avatar still resolve (#664).
+    const prof = contact?.profile ?? extraProfiles?.get(key) ?? null;
     const name =
-      contact?.profile?.displayName?.trim() ||
-      contact?.profile?.name?.trim() ||
+      prof?.displayName?.trim() ||
+      prof?.name?.trim() ||
       contact?.petname?.trim() ||
       fallbackName(entry.partnerPubkey);
     summaries.push({
       id: entry.partnerPubkey,
       pubkey: entry.partnerPubkey,
       name,
-      picture: contact?.profile?.picture ?? null,
-      nip05: contact?.profile?.nip05 ?? null,
-      lightningAddress: contact?.profile?.lud16 ?? null,
+      picture: prof?.picture ?? null,
+      nip05: prof?.nip05 ?? null,
+      lightningAddress: prof?.lud16 ?? null,
       lastActivityAt: entry.createdAt,
       lastAmountSats: 0,
       lastDirection: entry.fromMe ? 'outgoing' : 'incoming',


### PR DESCRIPTION
Closes #664.

## Problem

A DM partner you haven't followed isn't in your `contacts`, so the contacts pipeline never fetches their kind-0 — they render as a **raw `npub1…` + blank avatar** in the conversation list (e.g. `npub1gqk34jd…`), even with **WoT: All**.

## Fix

- **`buildDmSummaries`** takes an optional `extraProfiles` map (lowercase-pubkey → kind-0) and resolves a non-contact sender's name + avatar from it; contacts still win, and an unknown sender still falls back to the npub.
- **`NostrContext.fetchProfilesForPubkeys(pubkeys)`** batch-fetches kind-0 for arbitrary pubkeys via `nostrService.fetchProfiles` (which unions `PROFILE_RELAYS`).
- **`MessagesScreen`** collects DM partners that aren't in `contacts`, fetches their profiles **once per pubkey per session**, **caches** them per-account in AsyncStorage (`nonfollow_profiles_<pk>`), hydrates that cache on mount, and layers the profiles into both `contactInfoMap` (row rendering) and `buildDmSummaries` (the summary list).

## Acceptance

With **WoT: All**, someone who messages you but isn't a follow (e.g. **Evil Piggy**) now shows their **real name + avatar**, not an npub. A sender with genuinely no kind-0 still shows the npub + default avatar.

## Test plan

- `npx tsc --noEmit` — clean
- `npx jest conversationSummaries` — 6 pass, incl. 3 new #664 cases: resolves a non-contact name+avatar from `extraProfiles`; falls back to npub when unknown; a real contact profile still wins over `extraProfiles`.
- ESLint + Prettier — clean.
- Manual (pending device): WoT: All → a non-followed DM sender resolves name + avatar.
