### PR TITLE
feat(friends): bigger, easier-to-tap alphabet bar

### DIFF
--- a/src/components/AlphabetBar.tsx
+++ b/src/components/AlphabetBar.tsx
@@ -205,8 +205,10 @@ const createStyles = (colors: Palette) =>
       alignItems: 'center',
       paddingTop: 8,
       paddingBottom: 8,
-      width: 22,
-      marginLeft: 2,
+      // Wider + nudged in from the screen edge so the letters are easier to
+      // tap (were tight against the left bezel at width 22 / marginLeft 2).
+      width: 26,
+      marginLeft: 6,
     },
     alphabetLetterTouch: {
       // `flex: 1` distributes the 27 letter buckets proportionally
@@ -218,7 +220,7 @@ const createStyles = (colors: Palette) =>
       flex: 1,
       paddingHorizontal: 2,
       borderRadius: 8,
-      width: 18,
+      width: 24,
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -231,8 +233,8 @@ const createStyles = (colors: Palette) =>
       // remain visible in constrained layouts such as
       // FriendPickerSheet, reducing the chance that trailing letters
       // get clipped on smaller screens.
-      fontSize: 9,
-      lineHeight: 11,
+      fontSize: 11,
+      lineHeight: 13,
       fontWeight: '700',
       color: colors.textSupplementary,
       textAlign: 'center',


### PR DESCRIPTION
Closes #672.

## What

The A-Z index bar on Friends / FriendPicker had small (9px) letters tight against the left bezel, making them fiddly to tap.

- Letter font **9 → 11px** (lineHeight 11 → 13)
- Bar width **22 → 26**, per-letter touch target **18 → 24**
- Nudged in from the edge: **marginLeft 2 → 6**

## Test plan
- `npx tsc --noEmit` — clean; ESLint + Prettier — clean
- Manual: the alphabet index reads larger and is easier to tap; full A–Z still fits without clipping trailing letters (the constraint the original 9px guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)