### PR TITLE
chore(release): bump package.json to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Why

The v1.2.0 Release was cut by publishing the GitHub Release (tag `v1.2.0`), which triggers `release.yml`. The workflow sets the user-visible version **from the tag** at build time (`npm version 1.2.0 --no-git-tag-version --allow-same-version`), so the shipped iOS/Android binaries are correctly `1.2.0`.

This PR brings `main`'s `package.json` in line with what shipped. Without it, `main` still reads `1.1.0`, so the next `npm version minor` would land on `1.2.0` again and collide with this release. Keeping the marketing version as the repo's single source of truth is exactly what #592 documented.

The protected-branch push of this bump couldn't go direct to `main`, so it goes via this PR instead.

## What changes

- `package.json` / `package-lock.json` — version `1.1.0` → `1.2.0`. No runtime code touched.

## Test plan

N/A — version-string-only change. CI (TypeScript / ESLint / Prettier / Jest gate) covers that nothing broke.