### PR TITLE
fix(release): poll for the finished Android build before attaching the APK (#674)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,9 +277,16 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Pick the most recent FINISHED Android production build (the one we just submitted).
-          # Filter by the git commit of the Release tag so we don't accidentally grab an
-          # unrelated older build.
+          # Pick the FINISHED Android production build for THIS commit, filtering
+          # by gitCommitHash so we never grab an unrelated older build.
+          #
+          # This job runs right after build-and-submit, and there's a brief
+          # window where the just-finished build hasn't yet surfaced as
+          # "finished" in `eas build:list` (eventual consistency). A single-shot
+          # query raced here on v1.2.0 and produced a spurious "No Android build
+          # artifact" failure (#674). So POLL: treat both a failed call and an
+          # empty/lagging result as "retry", and only error out once the poll
+          # is exhausted.
 
           fetch() {
             local out_file="$1" err_file="$2"
@@ -291,44 +298,39 @@ jobs:
 
           OUT=$(mktemp)
           ERR=$(mktemp)
-          if ! fetch "$OUT" "$ERR"; then
-            echo "::warning title=eas build:list failed once — retrying in 8 s::Transient EAS API hiccup; see grouped logs below if the retry also fails."
-            sleep 8
-            if ! fetch "$OUT" "$ERR"; then
-              echo "::error title=eas build:list failed twice::See grouped logs below for stderr and stdout."
-              echo "::group::eas build:list stderr"
-              cat "$ERR"
-              echo "::endgroup::"
-              echo "::group::eas build:list stdout"
-              cat "$OUT"
-              echo "::endgroup::"
-              exit 1
-            fi
-          fi
-
-          # Strip any non-JSON prefix lines (deprecation banners, error noise
-          # written to stdout) — find the first `[` line and keep everything
-          # from there.
           CLEAN=$(mktemp)
-          sed -n '/^\[/,$p' "$OUT" > "$CLEAN"
+          url=""
+          attempts=12
+          for i in $(seq 1 "$attempts"); do
+            if ! fetch "$OUT" "$ERR"; then
+              echo "::warning title=eas build:list call failed (attempt $i/$attempts)::Transient EAS API hiccup; retrying in 20 s."
+              sleep 20
+              continue
+            fi
 
-          if ! url=$(jq -r --arg sha "${{ github.sha }}" \
-                       '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty' \
-                       "$CLEAN" 2>/dev/null); then
-            echo "::error title=jq parse failed on eas build:list output::See grouped logs below for raw stdout and the stripped JSON we tried to parse."
-            echo "::group::raw stdout"
-            cat "$OUT"
-            echo "::endgroup::"
-            echo "::group::stripped JSON (post sed)"
-            cat "$CLEAN"
-            echo "::endgroup::"
-            exit 1
-          fi
+            # Strip any non-JSON prefix lines (deprecation banners / progress
+            # noise written to stdout) — keep from the first `[` line onward.
+            sed -n '/^\[/,$p' "$OUT" > "$CLEAN"
+
+            url=$(jq -r --arg sha "${{ github.sha }}" \
+                    '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty' \
+                    "$CLEAN" 2>/dev/null || true)
+            if [ -n "$url" ] && [ "$url" != "null" ]; then
+              echo "Resolved Android APK URL on attempt $i/$attempts."
+              break
+            fi
+
+            echo "::warning title=Finished Android build not surfaced yet (attempt $i/$attempts)::eas build:list has no finished build for ${{ github.sha }} yet; retrying in 20 s."
+            sleep 20
+          done
 
           if [ -z "$url" ] || [ "$url" = "null" ]; then
-            echo "::error title=No Android build artifact for commit ${{ github.sha }}::EAS build may still be running, or failed. Recent builds dumped in the grouped log below."
+            echo "::error title=No Android build artifact for commit ${{ github.sha }} after $attempts attempts::EAS build may have failed, or build:list never surfaced it. Recent builds + last stderr dumped below."
             echo "::group::recent builds (cleaned)"
             cat "$CLEAN"
+            echo "::endgroup::"
+            echo "::group::last eas build:list stderr"
+            cat "$ERR"
             echo "::endgroup::"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,12 +299,13 @@ jobs:
           OUT=$(mktemp)
           ERR=$(mktemp)
           CLEAN=$(mktemp)
+          JQERR=$(mktemp)
           url=""
           attempts=12
           for i in $(seq 1 "$attempts"); do
             if ! fetch "$OUT" "$ERR"; then
               echo "::warning title=eas build:list call failed (attempt $i/$attempts)::Transient EAS API hiccup; retrying in 20 s."
-              sleep 20
+              [ "$i" -lt "$attempts" ] && sleep 20
               continue
             fi
 
@@ -312,16 +313,27 @@ jobs:
             # noise written to stdout) — keep from the first `[` line onward.
             sed -n '/^\[/,$p' "$OUT" > "$CLEAN"
 
-            url=$(jq -r --arg sha "${{ github.sha }}" \
-                    '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty' \
-                    "$CLEAN" 2>/dev/null || true)
+            # Fail fast on a genuine jq parse error (malformed JSON / an EAS
+            # CLI output-format change) instead of mistaking it for an
+            # eventual-consistency empty result — otherwise a real format
+            # break burns the whole poll window then fails with a misleading
+            # "not surfaced yet" message.
+            if ! url=$(jq -r --arg sha "${{ github.sha }}" \
+                         '[.[] | select(.gitCommitHash == $sha)][0].artifacts.buildUrl // empty' \
+                         "$CLEAN" 2>"$JQERR"); then
+              echo "::error title=jq failed to parse eas build:list output::Likely an EAS CLI / JSON format change — logs below."
+              echo "::group::jq stderr"; cat "$JQERR"; echo "::endgroup::"
+              echo "::group::raw stdout"; cat "$OUT"; echo "::endgroup::"
+              echo "::group::cleaned JSON"; cat "$CLEAN"; echo "::endgroup::"
+              exit 1
+            fi
             if [ -n "$url" ] && [ "$url" != "null" ]; then
               echo "Resolved Android APK URL on attempt $i/$attempts."
               break
             fi
 
             echo "::warning title=Finished Android build not surfaced yet (attempt $i/$attempts)::eas build:list has no finished build for ${{ github.sha }} yet; retrying in 20 s."
-            sleep 20
+            [ "$i" -lt "$attempts" ] && sleep 20
           done
 
           if [ -z "$url" ] || [ "$url" = "null" ]; then


### PR DESCRIPTION
## Why

On the **v1.2.0** release, `Attach Android APK to Release` failed with a spurious *"No Android build artifact for commit f19ed1d"* even though the Android production build finished fine and had a valid artifact URL. The APK had to be attached by hand afterwards, and `sync-release-identifiers` skipped (it `needs` attach), so the Release title also missed its build-number suffix.

Root cause: the resolve step did a **single-shot** `eas build:list --status finished` + `gitCommitHash` filter. Running immediately after `build-and-submit`, it hit the brief eventual-consistency window where the just-finished build isn't yet surfaced as `finished`. The pre-existing retry only covered the *call failing*, not the call succeeding with an empty result.

## What changes

`.github/workflows/release.yml` → the "Resolve latest finished Android APK URL" step now **polls** instead of failing on the first empty result:

- bounded loop, **12 attempts × 20 s** (~4 min headroom for the lag);
- treats *both* a failed `eas build:list` call *and* an empty/lagging match as "retry";
- only `exit 1`s once the poll is exhausted, with the recent-builds + last-stderr dumps for diagnosis.

No behavioural change on the happy path (resolves on attempt 1).

A more thorough follow-up (noted in #674): thread the Android build ID out of `build-and-submit` as a job output and `eas build:view <id>` it directly, removing the commit-filter query entirely.

## Test plan

- Workflow-only change; exercised for real on the next release.
- Verified the bash logic locally (loop breaks on a non-empty `url`, falls through to the error after `attempts` with empty results).
- YAML structure unchanged apart from the one `run:` block.

Closes #674