### PR TITLE
fix(release): wire TestFlight What-to-Test to the EXPO_ASC_* secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,16 +148,21 @@ jobs:
 
       - name: Verify ASC API key is wired
         env:
-          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
-          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          # The ASC API key is stored under the EXPO_ASC_* secret names (the
+          # same key EAS uses for `eas submit`). Map them onto the ASC_* env
+          # vars the script reads. The earlier ASC_* secret names never
+          # existed, so this job silently soft-skipped and left "What to Test"
+          # blank on every release until v1.2.1.
+          ASC_API_KEY_ID: ${{ secrets.EXPO_ASC_API_KEY_ID }}
+          ASC_API_KEY_ISSUER_ID: ${{ secrets.EXPO_ASC_API_KEY_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.EXPO_ASC_API_KEY_P8 }}
         run: |
           # The same .p8 EAS uses for `eas submit` is needed here. This is a
           # one-time GH Secrets setup; see docs/DEPLOYMENT.adoc → "TestFlight
           # 'What to Test' automation". If absent, soft-skip rather than fail
           # the release — Ben can fill in "What to Test" manually for this build.
           if [ -z "$ASC_API_KEY_ID" ] || [ -z "$ASC_API_KEY_ISSUER_ID" ] || [ -z "$ASC_API_KEY_P8" ]; then
-            echo "::warning title=ASC API key not configured::Skipping auto-populate of TestFlight 'What to Test'. Add ASC_API_KEY_ID, ASC_API_KEY_ISSUER_ID, ASC_API_KEY_P8 to repo secrets to enable. See docs/DEPLOYMENT.adoc."
+            echo "::warning title=ASC API key not configured::Skipping auto-populate of TestFlight 'What to Test'. Set EXPO_ASC_API_KEY_ID, EXPO_ASC_API_KEY_ISSUER_ID, EXPO_ASC_API_KEY_P8 repo secrets to enable. See docs/DEPLOYMENT.adoc."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -201,9 +206,9 @@ jobs:
       - name: PATCH whatsNew via App Store Connect API
         if: steps.gate.outputs.skip != 'true' && steps.iosbuild.outputs.version != ''
         env:
-          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
-          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_API_KEY_ID: ${{ secrets.EXPO_ASC_API_KEY_ID }}
+          ASC_API_KEY_ISSUER_ID: ${{ secrets.EXPO_ASC_API_KEY_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.EXPO_ASC_API_KEY_P8 }}
           ASC_APP_ID: '6762218164' # matches eas.json → submit.production.ios.ascAppId
           ASC_BUILD_VERSION: ${{ steps.iosbuild.outputs.version }}
           WHATS_NEW: ${{ steps.changelog.outputs.whatsnew }}

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -364,7 +364,7 @@ eas build:list --platform android --status finished --limit 1 \
 . Choose a tag like `v1.0.1` (create on publish) targeted at `main`. **The tag is the source of truth for the user-visible version** — the workflow strips the leading `v` and writes it into `package.json` via `npm version --no-git-tag-version`. `app.config.ts` reads `version: pkg.version`, so iOS `CFBundleShortVersionString`, Android `versionName`, and the in-app version label (drawer + About screen, via `src/utils/appVersion.ts`) all flow from that single value. Pre-release suffixes (e.g. `v1.0.0-rc1`) are stripped to keep the store-facing version a strict `X.Y.Z`.
 . Write release notes, click *Publish release*.
 . Watch *Actions → Release*. When it finishes, the Release page has the APK and PDF attached; TestFlight has the iOS build (auto-distributed to the Public Beta external group via `eas.json` `submit.production.ios.groups`).
-. *What to Test* fills itself in — the `set-testflight-whats-new` workflow job reads `docs/RELEASE_NOTES_NEXT.md`, polls App Store Connect for the just-submitted build, and PATCHes the localisation via `scripts/asc-set-whats-new.mjs` (see "TestFlight 'What to Test' notes" below). Manual pasting is only needed when the `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_API_KEY_P8` secrets aren't configured.
+. *What to Test* fills itself in — the `set-testflight-whats-new` workflow job reads `docs/RELEASE_NOTES_NEXT.md`, polls App Store Connect for the just-submitted build, and PATCHes the localisation via `scripts/asc-set-whats-new.mjs` (see "TestFlight 'What to Test' notes" below). Manual pasting is only needed when the `EXPO_ASC_API_KEY_ID` / `EXPO_ASC_API_KEY_ISSUER_ID` / `EXPO_ASC_API_KEY_P8` secrets aren't configured.
 
 NOTE: `versionCode` (Android) and `buildNumber` (iOS) are managed by EAS's remote counter (`eas.json` → `"appVersionSource": "remote"` + `"autoIncrement": true`). Don't hand-edit them for releases — cloud builds auto-increment past whatever's in `app.config.ts`. The integer in the file is only the floor for `eas build --local` and `expo run:android --variant release`, both of which are dev-test paths, not release paths.
 
@@ -515,19 +515,19 @@ If the release tagger forgot to populate the file and no qualifying commits are 
 
 ===== One-time GitHub Secrets setup
 
-The job needs the App Store Connect API key (the same `.p8` EAS uses for `eas submit` — but the `.p8` itself lives only on EAS's server, so you have to register it as a GitHub secret too). Add these three secrets at *Settings → Secrets and variables → Actions* on the repo:
+The job needs the App Store Connect API key (the same `.p8` EAS uses for `eas submit` — but the `.p8` itself lives only on EAS's server, so you have to register it as a GitHub secret too). These are the **`EXPO_ASC_*`** secrets — likely already present (EAS uses the same key), so check *Settings → Secrets and variables → Actions* before re-adding:
 
 [cols="1,3", options="header"]
 |===
 | Secret | Value
 
-| `ASC_API_KEY_ID`
+| `EXPO_ASC_API_KEY_ID`
 | The 10-character key identifier from App Store Connect → *Users and Access* → *Integrations* → *Team Keys* (e.g. `ABC1234567`). Same value as `ascApiKeyId` in the `eas.json` snippet above.
 
-| `ASC_API_KEY_ISSUER_ID`
+| `EXPO_ASC_API_KEY_ISSUER_ID`
 | The team's issuer UUID, shown above the key list on the same page (e.g. `00000000-0000-0000-0000-000000000000`). Same as `ascApiKeyIssuerId`.
 
-| `ASC_API_KEY_P8`
+| `EXPO_ASC_API_KEY_P8`
 | The full PEM contents of the `AuthKey_XXXXXXXXXX.p8` file, including the `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines. Paste the file contents verbatim into the secret value box; GitHub preserves the newlines.
 |===
 


### PR DESCRIPTION
## Why

TestFlight **"What to Test"** has been blank on every release (v1.1.0 → v1.2.1). The `set-testflight-whats-new` job gates on `secrets.ASC_API_KEY_ID` / `_ISSUER_ID` / `_P8`, but the repo secrets are actually named **`EXPO_ASC_API_KEY_ID`** / `_ISSUER_ID` / `_P8` (the same ASC key EAS uses for `eas submit`). The prefix-less names never existed → the gate saw them empty → the job **soft-skipped** (warning, no failure) → notes never set.

## What changes

`.github/workflows/release.yml` — both env blocks (the gate + the `PATCH whatsNew` step) now read the `EXPO_ASC_*` secrets; the script still consumes the `ASC_*` env vars (unchanged). Warning text updated to name the correct secrets.

## Effect

Next release auto-populates TestFlight "What to Test" from `docs/RELEASE_NOTES_NEXT.md`. (v1.2.0 / v1.2.1 are set manually this once — see PR discussion.)

## Test plan

- Workflow-only; exercised on the next release. Verified no `secrets.ASC_API_KEY*` (prefix-less) references remain.

Closes #680