### PR TITLE
fix(hunt): show a pin marker at the hidden location on the edit map

### DIFF
--- a/src/components/LibreMiniMap.tsx
+++ b/src/components/LibreMiniMap.tsx
@@ -116,6 +116,11 @@ interface Props {
   // LocationPickerSheet where the user picks the geocache coordinate
   // by panning the map until the crosshair sits where they want it.
   crosshair?: boolean;
+  // Optional single marker rendered at an explicit coordinate, on top of
+  // any `caches`. Used by the Hide/Edit-a-Piglet location step to show a
+  // piggy/pin glyph at the spot the hider pinned (the map centres there
+  // but otherwise has no marker). `isLpPiggy` picks the glyph + colour.
+  pinMarker?: { lat: number; lon: number; isLpPiggy?: boolean } | null;
   // Marker-tap callbacks. Optional — when unset the pin is decorative
   // (mini-map use case). MapScreen wires these to open MerchantDetail-
   // Sheet / CacheDetailSheet.
@@ -195,6 +200,7 @@ const LibreMiniMapInner: React.FC<Props> = ({
   fill = false,
   onBoundsChange,
   crosshair = false,
+  pinMarker,
   onSelectMerchant,
   onSelectCache,
   onSelectEvent,
@@ -525,6 +531,20 @@ const LibreMiniMapInner: React.FC<Props> = ({
             </Marker>
           );
         })}
+        {/* Explicit pin marker (Hide/Edit-a-Piglet location step) — drawn
+            at the hider's chosen coordinate so the centred map shows where
+            the Piglet is, not just an empty map. */}
+        {pinMarker ? (
+          <Marker id="pin-marker" lngLat={[pinMarker.lon, pinMarker.lat]}>
+            <View style={[styles.pin, pinMarker.isLpPiggy ? styles.pinPiglet : styles.pinCache]}>
+              {pinMarker.isLpPiggy ? (
+                <PiggyBank size={12} color="#fff" strokeWidth={2.5} />
+              ) : (
+                <MapPin size={12} color="#fff" strokeWidth={2.5} />
+              )}
+            </View>
+          </Marker>
+        ) : null}
         {/* Events: Calendar glyph in deep-purple. */}
         {eventPoints.map((e) => {
           const original = eventByCoord.get(e.id);

--- a/src/components/LibreMiniMap.tsx
+++ b/src/components/LibreMiniMap.tsx
@@ -846,6 +846,16 @@ const arePropsEqual = (prev: Props, next: Props): boolean => {
   if (prev.fill !== next.fill) return false;
   if (prev.crosshair !== next.crosshair) return false;
   if (prev.testID !== next.testID) return false;
+  // pinMarker is an object — compare its fields (and null↔object) so a
+  // changed/toggled pin (e.g. isLpPiggy flips, or the coordinate moves)
+  // actually re-renders the marker (#683 review).
+  if (
+    (prev.pinMarker == null) !== (next.pinMarker == null) ||
+    prev.pinMarker?.lat !== next.pinMarker?.lat ||
+    prev.pinMarker?.lon !== next.pinMarker?.lon ||
+    prev.pinMarker?.isLpPiggy !== next.pinMarker?.isLpPiggy
+  )
+    return false;
   // Handlers — host screens should `useCallback` these but fall back
   // gracefully on reference identity if not.
   if (prev.onTapMap !== next.onTapMap) return false;

--- a/src/screens/HuntCreateScreen.tsx
+++ b/src/screens/HuntCreateScreen.tsx
@@ -1611,6 +1611,7 @@ const HuntCreateScreen: React.FC<Props> = ({ navigation, route }) => {
                       merchants={[]}
                       caches={[]}
                       events={[]}
+                      pinMarker={{ lat: pin.lat, lon: pin.lon, isLpPiggy: listingIsLpInEdit }}
                       onTapMap={() => setLocationPickerVisible(true)}
                     />
                   </View>


### PR DESCRIPTION
## What
The Edit/Hide-a-Piglet **location step** centred the preview map on the pinned coordinate but rendered **no marker** there (`caches={[]}`), so the hidden spot looked like an empty map — reported as "no piglet icon in the middle of the map".

## Fix
- `LibreMiniMap` gains an optional `pinMarker={{ lat, lon, isLpPiggy }}` prop that draws one marker at an explicit coordinate — `PiggyBank` (pink) for an LP Piglet, `MapPin` (purple) otherwise — reusing the existing cache-pin chassis.
- The step-3 preview map passes the hider's pinned location, so a piggy/pin glyph now sits dead-centre on the hidden spot, with the user's own dot still shown.

Follow-up to #681 (which fixed the picker crash + centring); this adds the missing on-map marker.

## Test plan
- `tsc --noEmit` clean; ESLint 0 errors; Prettier clean.
- On-device: edit a Piglet → Location step → the map shows a piggy marker at the hidden coordinate (was empty before).

Closes #685