### PR TITLE
fix(wallet): back off chat invoice polling so a slow/banned NWC relay can't be hammered (#684)

### DIFF
--- a/src/hooks/usePaidInvoiceTracker.ts
+++ b/src/hooks/usePaidInvoiceTracker.ts
@@ -12,7 +12,16 @@ export interface TrackedMessage {
 }
 
 const POLL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-const POLL_INTERVAL_MS = 15_000;
+// Base cadence for the issuer-side lookupInvoice poll. A chat invoice tile
+// doesn't need sub-30 s freshness; the old 15 s fixed retry hammered our
+// own NWC relay hard enough to get the IP temp-banned (#684).
+const POLL_INTERVAL_MS = 30_000;
+// Backoff ceiling when the relay stops answering (unreachable / temp-
+// banned / slow). The delay doubles 30 s → 60 s → … → 5 min so we stop
+// hammering a relay that isn't responding — which is what kept the ban
+// alive and janked the UI — and recover to the base cadence the moment it
+// answers again.
+const POLL_BACKOFF_MAX_MS = 5 * 60 * 1000;
 
 // Tracks bolt11 settlement state across all three sources, for both
 // the issuer (`fromMe: true`) and the payer (`fromMe: false`):
@@ -89,34 +98,65 @@ export function usePaidInvoiceTracker(messages: TrackedMessage[]): {
     if (!activeWalletId || activeWallet?.walletType === 'onchain') return;
     if (outgoingOpenHashes.length === 0) return;
     let cancelled = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let running = false;
+    // Current backoff delay — grows when the relay isn't answering and
+    // resets to the base cadence as soon as it responds again (#684).
+    let delay = POLL_INTERVAL_MS;
     const poll = async () => {
+      let anyResponded = false;
       for (const hash of outgoingOpenHashes) {
         if (cancelled) return;
-        const result = await nwcService.lookupInvoice(activeWalletId, hash);
+        let result: Awaited<ReturnType<typeof nwcService.lookupInvoice>> = null;
+        try {
+          result = await nwcService.lookupInvoice(activeWalletId, hash);
+        } catch {
+          // Timeout / temp-ban / transport error — treat as "no answer"
+          // so the backoff below engages instead of a tight retry storm.
+          result = null;
+        }
         if (cancelled) return;
-        if (result?.paid) {
-          setPaidHashes((prev) => {
-            if (prev.has(hash)) return prev;
-            const next = new Set(prev);
-            next.add(hash);
-            return next;
-          });
-          bolt11SettlementCache.record(hash, true).catch(() => {});
-        } else if (result) {
-          bolt11SettlementCache.record(hash, false).catch(() => {});
+        if (result) {
+          anyResponded = true;
+          if (result.paid) {
+            setPaidHashes((prev) => {
+              if (prev.has(hash)) return prev;
+              const next = new Set(prev);
+              next.add(hash);
+              return next;
+            });
+            bolt11SettlementCache.record(hash, true).catch(() => {});
+          } else {
+            bolt11SettlementCache.record(hash, false).catch(() => {});
+          }
         }
       }
+      // Relay answered → back to base cadence; silent (unreachable / temp-
+      // banned) → double up to the ceiling so we stop hammering it.
+      delay = anyResponded ? POLL_INTERVAL_MS : Math.min(delay * 2, POLL_BACKOFF_MAX_MS);
+    };
+    const scheduleNext = () => {
+      if (cancelled || !running) return;
+      timeoutId = setTimeout(async () => {
+        await poll();
+        scheduleNext();
+      }, delay);
     };
     const start = () => {
-      if (intervalId !== null) return;
-      poll();
-      intervalId = setInterval(poll, POLL_INTERVAL_MS);
+      if (running) return;
+      running = true;
+      delay = POLL_INTERVAL_MS;
+      // Immediate first check, then self-reschedule on the (possibly
+      // backed-off) delay. setTimeout, not setInterval, so the cadence can
+      // stretch when the relay goes quiet.
+      poll().then(scheduleNext);
     };
     const stop = () => {
-      if (intervalId === null) return;
-      clearInterval(intervalId);
-      intervalId = null;
+      running = false;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
     };
     if (AppState.currentState === 'active') start();
     const sub = AppState.addEventListener('change', (next) => {

--- a/src/hooks/usePaidInvoiceTracker.ts
+++ b/src/hooks/usePaidInvoiceTracker.ts
@@ -104,20 +104,25 @@ export function usePaidInvoiceTracker(messages: TrackedMessage[]): {
     // resets to the base cadence as soon as it responds again (#684).
     let delay = POLL_INTERVAL_MS;
     const poll = async () => {
-      let anyResponded = false;
+      let gotResult = false;
       for (const hash of outgoingOpenHashes) {
         if (cancelled) return;
         let result: Awaited<ReturnType<typeof nwcService.lookupInvoice>> = null;
         try {
           result = await nwcService.lookupInvoice(activeWalletId, hash);
-        } catch {
-          // Timeout / temp-ban / transport error — treat as "no answer"
-          // so the backoff below engages instead of a tight retry storm.
+        } catch (e) {
+          // Timeout / temp-ban / transport error — including a throw
+          // before lookupInvoice's own logging (e.g. ensureConnected
+          // failing during a reconnect). Treat as "no answer" so the
+          // backoff engages instead of a tight retry storm; log in dev so
+          // an unexpected throw stays diagnosable (#686 review).
+          if (__DEV__)
+            console.log(`[invoice-poll] lookupInvoice threw: ${(e as Error)?.message ?? e}`);
           result = null;
         }
         if (cancelled) return;
         if (result) {
-          anyResponded = true;
+          gotResult = true;
           if (result.paid) {
             setPaidHashes((prev) => {
               if (prev.has(hash)) return prev;
@@ -131,9 +136,14 @@ export function usePaidInvoiceTracker(messages: TrackedMessage[]): {
           }
         }
       }
-      // Relay answered → back to base cadence; silent (unreachable / temp-
-      // banned) → double up to the ceiling so we stop hammering it.
-      delay = anyResponded ? POLL_INTERVAL_MS : Math.min(delay * 2, POLL_BACKOFF_MAX_MS);
+      // Got at least one non-null lookupInvoice result (paid or unpaid) →
+      // the relay is answering, so stay at the base cadence. Got nothing
+      // back from any hash (every call timed out / threw / returned null —
+      // i.e. unreachable or temp-banned) → double up to the ceiling so we
+      // stop hammering it. Note: a terminal NOT_FOUND that surfaces as null
+      // also counts as "no answer" here, which is fine — there's no point
+      // fast-polling a hash the relay can't find either.
+      delay = gotResult ? POLL_INTERVAL_MS : Math.min(delay * 2, POLL_BACKOFF_MAX_MS);
     };
     const scheduleNext = () => {
       if (cancelled || !running) return;


### PR DESCRIPTION
## Problem
On the Pixel (Preview build), navigating Explore → Messages → a conversation felt **locked**. Root cause: our own LNbits relay (`bank.weeksfamily.me`) **temp-banned the home IP** because the in-chat invoice poll hammered it — `usePaidInvoiceTracker` ran a **fixed 15 s `lookupInvoice` retry with no failure handling**, so against a slow/banned relay it was a relentless retry storm that kept the ban alive and janked wallet-touching screens. (The JS thread wasn't hard-frozen — gaps were ~150 ms — it was NWC timeouts making the UI feel stuck. With the ban cleared, the same navigation was smooth: 0 NWC errors, 56 ms max gap.)

## Fix
- **Base cadence 15 s → 30 s** (a chat invoice tile doesn't need faster).
- **Exponential backoff** 30 s → 60 s → … → **5 min** whenever the relay doesn't answer; **resets to base** the instant it responds. A banned/unreachable relay stops being hammered, so the ban can lapse instead of being renewed.
- `lookupInvoice` wrapped in **try/catch** — a throw no longer breaks the loop or leaks an unhandled rejection; it counts as 'no answer' for backoff.
- `setInterval` → self-rescheduling `setTimeout` so the delay can stretch.
- Unchanged (already correct): **AppState-gated + conversation-scoped** — it only polls while the conversation is open and the app is foreground.

## Out of scope / follow-up
This fixes the *chat-invoice* poll that caused the report. The broader hardening — ensuring the global `WalletContext` balance/`expectPayment` poll (the #560 freeze vector) also circuit-breaks on a banned relay — can be a follow-up if the global poll ever janks again.

## Test plan
- `tsc --noEmit` clean; ESLint 0 errors; Prettier clean.
- `src/hooks` is outside the unit-coverage scope (per CLAUDE.md); logic verified by review + tsc.
- On-device: with the relay reachable, an unpaid chat invoice still flips to Paid (now within ≤30 s); with the relay unreachable, polling backs off instead of storming (no more self-inflicted temp-ban).

Closes #684