### PR TITLE
fix(hunt): derive edit LP-ness from the published event, not just the local stub

### DIFF
--- a/src/screens/HuntCreateScreen.tsx
+++ b/src/screens/HuntCreateScreen.tsx
@@ -359,7 +359,8 @@ const HuntCreateScreen: React.FC<Props> = ({ navigation, route }) => {
       // local *stub* (blank `lnurlw`, and `isLpPiggy` unset on an old
       // record or saved `false` by a prior reward-dropping edit) would
       // otherwise read as non-LP and wrongly lock the fields even though
-      // the listing carries the LP label on relays (Hawthorn case, #681).
+      // the listing carries the LP label on relays (Hawthorn case, #692;
+      // follows the #681 edit-Piglet work).
       setIsLpPiggyEdit(
         (piggy.isLpPiggy ?? Boolean(piggy.lnurlw)) || (fallbackCache?.isLpPiggy ?? false),
       );

--- a/src/screens/HuntCreateScreen.tsx
+++ b/src/screens/HuntCreateScreen.tsx
@@ -353,12 +353,16 @@ const HuntCreateScreen: React.FC<Props> = ({ navigation, route }) => {
       piggyIdRef.current = piggy.id;
       setLnurl(piggy.lnurlw);
       setIsPublic(piggy.isPublic);
-      // LP-ness from the local record so the prize/cooldown/uses
-      // affordances stay enabled even for a local LP *stub* — a record
-      // left by a prior cross-device save has `isLpPiggy: true` but a
-      // blank `lnurlw`, so the lnurl-presence check alone would wrongly
-      // hide them (#681 review).
-      setIsLpPiggyEdit(piggy.isLpPiggy ?? Boolean(piggy.lnurlw));
+      // LP-ness for the prize/cooldown/uses affordances. Take it from the
+      // local record OR the published event (fallbackCache) — whichever
+      // says LP, since the published event is the source of truth. A stale
+      // local *stub* (blank `lnurlw`, and `isLpPiggy` unset on an old
+      // record or saved `false` by a prior reward-dropping edit) would
+      // otherwise read as non-LP and wrongly lock the fields even though
+      // the listing carries the LP label on relays (Hawthorn case, #681).
+      setIsLpPiggyEdit(
+        (piggy.isLpPiggy ?? Boolean(piggy.lnurlw)) || (fallbackCache?.isLpPiggy ?? false),
+      );
       // Re-hydrate the post-write PIN row so the hider returning via Edit
       // can recover the PIN they wrote earlier. The NFC lock is local-only
       // (never on the event), so it always comes from the local record —


### PR DESCRIPTION
## Problem
Editing an LP Piglet whose **local record is a stub** (blank `lnurlw` + `isLpPiggy` unset/false) locked the **Sats / Cooldown / Total uses** fields — `isLpPiggyEdit` resolved false, so `listingIsLpInEdit` was false and the fields went read-only. Hit on-device with **The Hawthorn Hideaway!**, whose published listing *does* carry the LP label (confirmed on relay: LP label + `wait=1200` + `uses=100`, `amount` dropped by an earlier edit).

## Fix
`setIsLpPiggyEdit((piggy.isLpPiggy ?? Boolean(piggy.lnurlw)) || (fallbackCache?.isLpPiggy ?? false))` — LP-ness now comes from the local record **OR the published event** (the event is the source of truth; the detail screen already passes `fallbackCache` on every edit). A stale stub no longer wrongly locks the prize fields.

## Test plan
- tsc / ESLint / Prettier clean.
- On-device: open Hawthorn (LP listing, stub local record) → Sats/Cooldown/Uses are now editable; type a sats amount to re-add the prize.

Closes #692