### PR TITLE
fix(hunt): apply dev-leftover denylist on cache storage hydrate + save (#699)

### DIFF
--- a/src/services/nostrPlacesStorage.test.ts
+++ b/src/services/nostrPlacesStorage.test.ts
@@ -111,4 +111,24 @@ describe('nostrPlacesStorage denylist enforcement (#699)', () => {
     await seedAndRehydrate(CACHES_STORAGE_KEY, [cache(CLEAN, 'A'), cache(CLEAN, 'B')]);
     expect((await loadCachedCaches()).length).toBe(2);
   });
+
+  it('rewrites the sanitized blob to disk when hydrate drops entries (no re-filter every start)', async () => {
+    await seedAndRehydrate(CACHES_STORAGE_KEY, [
+      cache(DENYLISTED, 'Geo-Cache 1'),
+      cache(CLEAN, 'Keeper'),
+    ]);
+    await loadCachedCaches();
+    // The on-disk blob itself should now be clean, not just the in-memory mirror.
+    const raw = await AsyncStorage.getItem(CACHES_STORAGE_KEY);
+    expect(raw).not.toContain(DENYLISTED);
+  });
+
+  it('does not rewrite the blob when nothing is dropped', async () => {
+    await seedAndRehydrate(CACHES_STORAGE_KEY, [cache(CLEAN, 'A')]);
+    const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+    setSpy.mockClear(); // drop the seed write's history (shared mock fn) so we only see hydrate
+    await loadCachedCaches();
+    expect(setSpy).not.toHaveBeenCalled();
+    setSpy.mockRestore();
+  });
 });

--- a/src/services/nostrPlacesStorage.test.ts
+++ b/src/services/nostrPlacesStorage.test.ts
@@ -1,0 +1,114 @@
+// The dev-leftover denylist is enforced at relay ingestion, but blobs
+// persisted before a signer was denylisted still carry it. These guard
+// that nostrPlacesStorage re-applies the denylist on both read (hydrate)
+// and write (saveCaches/saveEvents) so orphaned "Geo-Cache 1" stashes
+// stop painting from disk (#699).
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { ParsedCache, ParsedEvent } from './nostrPlacesService';
+import {
+  clearCacheStorage,
+  loadCachedCaches,
+  loadCachedEvents,
+  peekCachedCachesSync,
+  peekCachedEventsSync,
+  saveCaches,
+  saveEvents,
+} from './nostrPlacesStorage';
+
+const CACHES_STORAGE_KEY = '@lp:nostr-caches-v1';
+const EVENTS_STORAGE_KEY = '@lp:nostr-events-v1';
+
+// One of the four disposable signers of d=big-piggy-geo-cache-1 in
+// devEventDenylist.ts ("Geo-Cache 1").
+const DENYLISTED = 'b8d38e654adff224418002ae752155a84a86dab6fa94b4bc9e81ca9e25dce9e7';
+const CLEAN = 'feed'.repeat(16);
+
+const cache = (hiderPubkey: string, name: string): ParsedCache => ({
+  coord: `37516:${hiderPubkey}:${name}`,
+  hiderPubkey,
+  d: name,
+  name,
+  description: '',
+  geohash: null,
+  difficulty: null,
+  terrain: null,
+  size: null,
+  cacheType: null,
+  hint: null,
+  imageUrl: null,
+  isLpPiggy: false,
+  waitSeconds: null,
+  uses: null,
+  payoutSats: null,
+  createdAt: 1_000,
+  expiresAt: null,
+});
+
+const event = (organiserPubkey: string, title: string): ParsedEvent => ({
+  coord: `31923:${organiserPubkey}:${title}`,
+  organiserPubkey,
+  d: title,
+  title,
+  description: '',
+  startsAt: 1_000,
+  endsAt: null,
+  location: null,
+  geohash: null,
+  imageUrl: null,
+  hashtags: [],
+});
+
+// clearCacheStorage resets the module's hydrate gate so a later
+// loadCached* re-reads whatever we seeded.
+const seedAndRehydrate = async (key: string, items: unknown[]) => {
+  await clearCacheStorage();
+  await AsyncStorage.setItem(key, JSON.stringify({ fetchedAt: Date.now(), items }));
+};
+
+describe('nostrPlacesStorage denylist enforcement (#699)', () => {
+  beforeEach(async () => {
+    await clearCacheStorage();
+    await AsyncStorage.clear();
+  });
+
+  it('drops a denylisted cache persisted in the on-disk blob on hydrate', async () => {
+    await seedAndRehydrate(CACHES_STORAGE_KEY, [
+      cache(DENYLISTED, 'Geo-Cache 1'),
+      cache(CLEAN, 'The Hawthorn Hideaway!'),
+    ]);
+    const loaded = await loadCachedCaches();
+    expect(loaded.map((c) => c.name)).toEqual(['The Hawthorn Hideaway!']);
+  });
+
+  it('drops a denylisted event persisted in the on-disk blob on hydrate', async () => {
+    await seedAndRehydrate(EVENTS_STORAGE_KEY, [
+      event(DENYLISTED, 'Junk'),
+      event(CLEAN, 'Real Meetup'),
+    ]);
+    const loaded = await loadCachedEvents();
+    expect(loaded.map((e) => e.title)).toEqual(['Real Meetup']);
+  });
+
+  it('never persists a denylisted cache via saveCaches', async () => {
+    saveCaches([cache(DENYLISTED, 'Geo-Cache 1'), cache(CLEAN, 'Keeper')]);
+    expect(peekCachedCachesSync().map((c) => c.name)).toEqual(['Keeper']);
+    const raw = await AsyncStorage.getItem(CACHES_STORAGE_KEY);
+    expect(raw).not.toContain(DENYLISTED);
+  });
+
+  it('never persists a denylisted event via saveEvents', async () => {
+    saveEvents([event(DENYLISTED, 'Junk'), event(CLEAN, 'Keeper')]);
+    expect(peekCachedEventsSync().map((e) => e.title)).toEqual(['Keeper']);
+    const raw = await AsyncStorage.getItem(EVENTS_STORAGE_KEY);
+    expect(raw).not.toContain(DENYLISTED);
+  });
+
+  it('keeps clean entries untouched on hydrate', async () => {
+    await seedAndRehydrate(CACHES_STORAGE_KEY, [cache(CLEAN, 'A'), cache(CLEAN, 'B')]);
+    expect((await loadCachedCaches()).length).toBe(2);
+  });
+});

--- a/src/services/nostrPlacesStorage.ts
+++ b/src/services/nostrPlacesStorage.ts
@@ -51,19 +51,29 @@ const hydrate = async (): Promise<void> => {
       // Re-apply the dev-leftover denylist on read: the ingestion-layer
       // filter (nostrPlacesPublisher) only blocks new events, so blobs
       // persisted before a signer was denylisted still carry it and
-      // would paint on cold start otherwise (#699).
+      // would paint on cold start otherwise (#699). When we drop any, also
+      // rewrite the sanitized blob (fire-and-forget) so the on-disk copy is
+      // actually cleaned rather than re-filtered on every cold start.
       if (cachesRaw) {
         const parsed = JSON.parse(cachesRaw) as CachedShape<ParsedCache>;
         if (Array.isArray(parsed.items) && isFresh(parsed)) {
+          const before = parsed.items.length;
           parsed.items = parsed.items.filter((c) => !isDevLeftover(c.hiderPubkey));
           memCaches = parsed;
+          if (parsed.items.length < before) {
+            AsyncStorage.setItem(CACHES_STORAGE_KEY, JSON.stringify(parsed)).catch(() => {});
+          }
         }
       }
       if (eventsRaw) {
         const parsed = JSON.parse(eventsRaw) as CachedShape<ParsedEvent>;
         if (Array.isArray(parsed.items) && isFresh(parsed)) {
+          const before = parsed.items.length;
           parsed.items = parsed.items.filter((e) => !isDevLeftover(e.organiserPubkey));
           memEvents = parsed;
+          if (parsed.items.length < before) {
+            AsyncStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify(parsed)).catch(() => {});
+          }
         }
       }
     } catch {

--- a/src/services/nostrPlacesStorage.ts
+++ b/src/services/nostrPlacesStorage.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { ParsedCache, ParsedEvent } from './nostrPlacesService';
+import { isDevLeftover } from './devEventDenylist';
 
 /**
  * AsyncStorage-backed cache of resolved NIP-GC kind 37516 cache
@@ -47,13 +48,23 @@ const hydrate = async (): Promise<void> => {
         AsyncStorage.getItem(CACHES_STORAGE_KEY),
         AsyncStorage.getItem(EVENTS_STORAGE_KEY),
       ]);
+      // Re-apply the dev-leftover denylist on read: the ingestion-layer
+      // filter (nostrPlacesPublisher) only blocks new events, so blobs
+      // persisted before a signer was denylisted still carry it and
+      // would paint on cold start otherwise (#699).
       if (cachesRaw) {
         const parsed = JSON.parse(cachesRaw) as CachedShape<ParsedCache>;
-        if (Array.isArray(parsed.items) && isFresh(parsed)) memCaches = parsed;
+        if (Array.isArray(parsed.items) && isFresh(parsed)) {
+          parsed.items = parsed.items.filter((c) => !isDevLeftover(c.hiderPubkey));
+          memCaches = parsed;
+        }
       }
       if (eventsRaw) {
         const parsed = JSON.parse(eventsRaw) as CachedShape<ParsedEvent>;
-        if (Array.isArray(parsed.items) && isFresh(parsed)) memEvents = parsed;
+        if (Array.isArray(parsed.items) && isFresh(parsed)) {
+          parsed.items = parsed.items.filter((e) => !isDevLeftover(e.organiserPubkey));
+          memEvents = parsed;
+        }
       }
     } catch {
       // Best-effort hydrate — corrupted blobs are silently ignored so
@@ -93,7 +104,10 @@ void hydrate();
 // createdAt / startsAt) and persist. Write is fire-and-forget — the
 // in-memory state stays authoritative for the current session.
 export const saveCaches = (caches: ReadonlyArray<ParsedCache>): void => {
-  const sorted = [...caches].sort((a, b) => b.createdAt - a.createdAt).slice(0, MAX_ENTRIES);
+  const sorted = [...caches]
+    .filter((c) => !isDevLeftover(c.hiderPubkey))
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .slice(0, MAX_ENTRIES);
   const next: CachedShape<ParsedCache> = { fetchedAt: Date.now(), items: sorted };
   memCaches = next;
   AsyncStorage.setItem(CACHES_STORAGE_KEY, JSON.stringify(next)).catch(() => {});
@@ -103,6 +117,7 @@ export const saveEvents = (events: ReadonlyArray<ParsedEvent>): void => {
   // Events sort by start time so the newest-upcoming surface first
   // when we hydrate.
   const sorted = [...events]
+    .filter((e) => !isDevLeftover(e.organiserPubkey))
     .sort((a, b) => (b.startsAt ?? 0) - (a.startsAt ?? 0))
     .slice(0, MAX_ENTRIES);
   const next: CachedShape<ParsedEvent> = { fetchedAt: Date.now(), items: sorted };


### PR DESCRIPTION
## Problem

Three orphaned **"Geo-Cache 1"** stashes (`d=big-piggy-geo-cache-1`) still appear in the app even though their four disposable signers are all on the `devEventDenylist`.

The denylist was enforced **only at the relay-ingestion layer** (`nostrPlacesPublisher` — the `subscribeMany`/`fetchCachesByAuthor`/`fetchCache` paths). But `nostrPlacesStorage` rehydrates `ParsedCache`s straight from a persisted AsyncStorage blob with **no `isDevLeftover` check**. Events persisted *before* a signer was denylisted survive in that blob and get painted on cold start — the ingestion filter only stops *new* events reaching storage, it never purges what's already there.

Confirmed on-relay: exactly the 4 denylisted pubkeys publish `name="Geo-Cache 1"`, no missing entries — so the list is complete; the leak is the storage layer.

## Fix

Re-apply `isDevLeftover` in `nostrPlacesStorage` at both ends:
- **hydrate (read)** — filters denylisted entries out of the on-disk blob, so the stale "Geo-Cache 1" rows vanish on the next cold start.
- **saveCaches / saveEvents (write)** — never re-persist a denylisted signer.

Covers both caches (`hiderPubkey`) and events (`organiserPubkey`).

## Test plan

- `npx jest src/services/nostrPlacesStorage.test.ts` — 5 unit tests: hydrate-drop + save-drop for both caches and events, plus a clean-entries-untouched guard. All green.
- `npx tsc --noEmit` — clean.
- On device: cold-start the app and confirm the three "Geo-Cache 1" stashes (`d=big-piggy-geo-cache-1`) no longer appear in Explore / Geo-caches.

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
