### PR TITLE
chore(storage): op-sqlite + SQLCipher encrypted DB module (#695)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@gorhom/bottom-sheet": "^5.2.8",
         "@maplibre/maplibre-react-native": "^11.2.1",
         "@noble/hashes": "^2.0.1",
+        "@op-engineering/op-sqlite": "^16.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "^12.0.1",
         "@react-navigation/bottom-tabs": "^7.15.8",
@@ -2911,6 +2912,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@op-engineering/op-sqlite": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@op-engineering/op-sqlite/-/op-sqlite-16.1.1.tgz",
+      "integrity": "sha512-wmfQGwWgpefgwarR5VlhKGRkbWEp5HwQrDuX0GVBIeNuITMSKkgn0i0nfW/PMTJcA9xgtzrt/GlUzQ281SRRXQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "node"
+      ],
+      "peerDependencies": {
+        "@sqlite.org/sqlite-wasm": "*",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sqlite.org/sqlite-wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@gorhom/bottom-sheet": "^5.2.8",
     "@maplibre/maplibre-react-native": "^11.2.1",
     "@noble/hashes": "^2.0.1",
+    "@op-engineering/op-sqlite": "^16.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@react-navigation/bottom-tabs": "^7.15.8",
@@ -106,5 +107,8 @@
     "react-test-renderer": "19.2.0",
     "typescript": "~5.9.2"
   },
-  "private": true
+  "private": true,
+  "op-sqlite": {
+    "sqlcipher": true
+  }
 }

--- a/src/services/localDb.test.ts
+++ b/src/services/localDb.test.ts
@@ -68,14 +68,24 @@ describe('localDb', () => {
     expect(await freshVerify()).toBe('4.6.0');
   });
 
-  it('verifyEncryptedDb throws when SQLCipher is not active (empty cipher_version)', async () => {
+  it('refuses to open when SQLCipher is not active (empty cipher_version → plaintext guard)', async () => {
     mockExecute.mockImplementation((sql: string) =>
       sql.includes('cipher_version')
         ? Promise.resolve({ rows: [{ cipher_version: '' }] })
         : Promise.resolve({ rows: [] }),
     );
-    const { verifyEncryptedDb: freshVerify } = require('./localDb');
-    await expect(freshVerify()).rejects.toThrow('SQLCipher not active');
+    const { getLocalDb: freshGetLocalDb } = require('./localDb');
+    await expect(freshGetLocalDb()).rejects.toThrow('SQLCipher not active');
+  });
+
+  it('checks cipher_version before running the schema (open-time guard)', async () => {
+    const { getLocalDb: freshGetLocalDb } = require('./localDb');
+    await freshGetLocalDb();
+    const sqls = mockExecute.mock.calls.map((c) => c[0]);
+    const cipherIdx = sqls.findIndex((s) => s.includes('cipher_version'));
+    const schemaIdx = sqls.findIndex((s) => s.includes('CREATE TABLE'));
+    expect(cipherIdx).toBeGreaterThanOrEqual(0);
+    expect(cipherIdx).toBeLessThan(schemaIdx); // guard runs before schema
   });
 });
 

--- a/src/services/localDb.test.ts
+++ b/src/services/localDb.test.ts
@@ -1,0 +1,85 @@
+// op-sqlite is a native module jest can't load; mock it to cover the open +
+// schema orchestration and the verify smoke-check. The real encrypted open is
+// validated by an on-device dev build (#695 spike), not here.
+const mockExecute = jest.fn();
+const mockDb = { execute: mockExecute };
+const mockOpen = jest.fn(() => mockDb);
+jest.mock('@op-engineering/op-sqlite', () => ({ open: mockOpen }));
+jest.mock('./localDbKey', () => ({
+  getOrCreateLocalDbKey: jest.fn(() => Promise.resolve('a'.repeat(64))),
+}));
+
+import { getLocalDb, verifyEncryptedDb } from './localDb';
+
+// Route execute() return values by SQL so verifyEncryptedDb's round-trip works.
+const wireExecute = () =>
+  mockExecute.mockImplementation((sql: string) => {
+    if (sql.includes('cipher_version')) {
+      return Promise.resolve({ rows: [{ cipher_version: '4.6.0' }] });
+    }
+    if (sql.startsWith('SELECT content')) {
+      return Promise.resolve({ rows: [{ content: 'ok' }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  wireExecute();
+  jest.resetModules();
+});
+
+describe('localDb', () => {
+  it('opens the DB with the keystore encryption key', async () => {
+    const { getLocalDb: freshGetLocalDb } = require('./localDb');
+    await freshGetLocalDb();
+    expect(mockOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'lightningpiggy.db', encryptionKey: 'a'.repeat(64) }),
+    );
+  });
+
+  it('runs the schema (dm_messages table + conversation index) on open', async () => {
+    const { getLocalDb: freshGetLocalDb } = require('./localDb');
+    await freshGetLocalDb();
+    const ddl = mockExecute.mock.calls.map((c) => c[0]).join('\n');
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS dm_messages');
+    expect(ddl).toContain('idx_dm_conversation_created');
+  });
+
+  it('is single-flight — a second getLocalDb does not reopen', async () => {
+    const { getLocalDb: freshGetLocalDb } = require('./localDb');
+    await freshGetLocalDb();
+    await freshGetLocalDb();
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the cached open on failure so a later call can retry', async () => {
+    mockOpen.mockImplementationOnce(() => {
+      throw new Error('locked');
+    });
+    const { getLocalDb: freshGetLocalDb } = require('./localDb');
+    await expect(freshGetLocalDb()).rejects.toThrow('locked');
+    const db = await freshGetLocalDb();
+    expect(db).toBe(mockDb);
+  });
+
+  it('verifyEncryptedDb returns the cipher version on a clean encrypted round-trip', async () => {
+    const { verifyEncryptedDb: freshVerify } = require('./localDb');
+    expect(await freshVerify()).toBe('4.6.0');
+  });
+
+  it('verifyEncryptedDb throws when SQLCipher is not active (empty cipher_version)', async () => {
+    mockExecute.mockImplementation((sql: string) =>
+      sql.includes('cipher_version')
+        ? Promise.resolve({ rows: [{ cipher_version: '' }] })
+        : Promise.resolve({ rows: [] }),
+    );
+    const { verifyEncryptedDb: freshVerify } = require('./localDb');
+    await expect(freshVerify()).rejects.toThrow('SQLCipher not active');
+  });
+});
+
+// reference so the static imports aren't flagged unused (we re-require per
+// test to reset the module-level single-flight cache).
+void getLocalDb;
+void verifyEncryptedDb;

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -30,6 +30,17 @@ let dbPromise: Promise<DB> | null = null;
 async function openLocalDb(): Promise<DB> {
   const encryptionKey = await getOrCreateLocalDbKey();
   const db = open({ name: DB_NAME, encryptionKey });
+  // Fail loud if SQLCipher isn't actually compiled in: op-sqlite silently
+  // ignores `encryptionKey` on a plain-SQLite build, which would write our
+  // private DM / transaction rows to disk in cleartext. cipher_version is
+  // empty on plain SQLite and non-empty (e.g. "4.14.0 community") under
+  // SQLCipher — an empty value means the build regressed, so refuse to open.
+  const cipher = await db.execute('PRAGMA cipher_version;');
+  if (!String(cipher.rows?.[0]?.cipher_version ?? '')) {
+    throw new Error(
+      'SQLCipher not active — refusing to open a plaintext DB (cipher_version empty)',
+    );
+  }
   for (const stmt of SCHEMA) await db.execute(stmt);
   return db;
 }
@@ -50,26 +61,30 @@ export function getLocalDb(): Promise<DB> {
 }
 
 /**
- * Spike smoke-check (#695 step 0): proves op-sqlite opens an *encrypted* DB
- * cleanly in the dev-client build and round-trips a row. Returns the active
- * SQLCipher cipher version (non-empty string) on success; throws if the
- * native module or SQLCipher target isn't wired up. Call once from a dev
- * build and check the log — not part of normal app flow.
+ * Dev-only smoke-check (#695 spike): round-trips a row through the opened DB
+ * and returns the active SQLCipher cipher version for logging. The
+ * SQLCipher-active assertion lives in `openLocalDb` now (every open is
+ * guarded); this just exercises an encrypted write/read end-to-end. Guarded
+ * to `__DEV__` so it can't be called from production code, and the smoke row
+ * is always cleaned up in `finally`.
  */
 export async function verifyEncryptedDb(): Promise<string> {
-  const db = await getLocalDb();
+  if (!__DEV__) throw new Error('verifyEncryptedDb is a dev-only diagnostic');
+  const db = await getLocalDb(); // openLocalDb already asserted SQLCipher is active
   const res = await db.execute('PRAGMA cipher_version;');
   const cipher = String(res.rows?.[0]?.cipher_version ?? '');
-  if (!cipher) throw new Error('SQLCipher not active — cipher_version empty (plain SQLite build?)');
-  await db.execute(
-    `INSERT OR REPLACE INTO dm_messages (event_id, conversation, created_at, sender, content)
-     VALUES (?, ?, ?, ?, ?);`,
-    ['__smoke__', '__smoke__', 0, '__smoke__', 'ok'],
-  );
-  const back = await db.execute('SELECT content FROM dm_messages WHERE event_id = ?;', [
-    '__smoke__',
-  ]);
-  await db.execute('DELETE FROM dm_messages WHERE event_id = ?;', ['__smoke__']);
-  if (back.rows?.[0]?.content !== 'ok') throw new Error('encrypted round-trip failed');
-  return cipher;
+  try {
+    await db.execute(
+      `INSERT OR REPLACE INTO dm_messages (event_id, conversation, created_at, sender, content)
+       VALUES (?, ?, ?, ?, ?);`,
+      ['__smoke__', '__smoke__', 0, '__smoke__', 'ok'],
+    );
+    const back = await db.execute('SELECT content FROM dm_messages WHERE event_id = ?;', [
+      '__smoke__',
+    ]);
+    if (back.rows?.[0]?.content !== 'ok') throw new Error('encrypted round-trip failed');
+    return cipher;
+  } finally {
+    await db.execute('DELETE FROM dm_messages WHERE event_id = ?;', ['__smoke__']).catch(() => {});
+  }
 }

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -1,0 +1,75 @@
+import { open, type DB } from '@op-engineering/op-sqlite';
+import { getOrCreateLocalDbKey } from './localDbKey';
+
+// The single encrypted local database (#695). SQLCipher is enabled as the
+// op-sqlite compile target (package.json "op-sqlite": { "sqlcipher": true }),
+// so passing `encryptionKey` to open() transparently encrypts the whole file
+// — content and metadata — with the Keystore-held key (see localDbKey.ts).
+// One DB, indexed rows: DM messages (private) plus public cached events.
+const DB_NAME = 'lightningpiggy.db';
+
+// Schema v1. One row per event keyed by event_id (unique → dedupe), indexed
+// by (conversation, created_at) for paginated slice reads — the whole point
+// of moving off the single-blob cache that froze the Messages tab (#695).
+// Public cache tables (caches/events/places) land in a later slice; DMs first
+// since they cause the freeze and need the encryption.
+const SCHEMA: string[] = [
+  `CREATE TABLE IF NOT EXISTS dm_messages (
+     event_id     TEXT PRIMARY KEY,
+     conversation TEXT NOT NULL,
+     created_at   INTEGER NOT NULL,
+     sender       TEXT NOT NULL,
+     content      TEXT NOT NULL
+   );`,
+  `CREATE INDEX IF NOT EXISTS idx_dm_conversation_created
+     ON dm_messages (conversation, created_at DESC);`,
+];
+
+let dbPromise: Promise<DB> | null = null;
+
+async function openLocalDb(): Promise<DB> {
+  const encryptionKey = await getOrCreateLocalDbKey();
+  const db = open({ name: DB_NAME, encryptionKey });
+  for (const stmt of SCHEMA) await db.execute(stmt);
+  return db;
+}
+
+/**
+ * The opened, schema-migrated encrypted DB. Single-flight so concurrent
+ * callers share one open; cleared on failure so a transient open error
+ * (bad key, locked file) can be retried rather than wedging every call.
+ */
+export function getLocalDb(): Promise<DB> {
+  if (!dbPromise) {
+    dbPromise = openLocalDb().catch((e) => {
+      dbPromise = null;
+      throw e;
+    });
+  }
+  return dbPromise;
+}
+
+/**
+ * Spike smoke-check (#695 step 0): proves op-sqlite opens an *encrypted* DB
+ * cleanly in the dev-client build and round-trips a row. Returns the active
+ * SQLCipher cipher version (non-empty string) on success; throws if the
+ * native module or SQLCipher target isn't wired up. Call once from a dev
+ * build and check the log — not part of normal app flow.
+ */
+export async function verifyEncryptedDb(): Promise<string> {
+  const db = await getLocalDb();
+  const res = await db.execute('PRAGMA cipher_version;');
+  const cipher = String(res.rows?.[0]?.cipher_version ?? '');
+  if (!cipher) throw new Error('SQLCipher not active — cipher_version empty (plain SQLite build?)');
+  await db.execute(
+    `INSERT OR REPLACE INTO dm_messages (event_id, conversation, created_at, sender, content)
+     VALUES (?, ?, ?, ?, ?);`,
+    ['__smoke__', '__smoke__', 0, '__smoke__', 'ok'],
+  );
+  const back = await db.execute('SELECT content FROM dm_messages WHERE event_id = ?;', [
+    '__smoke__',
+  ]);
+  await db.execute('DELETE FROM dm_messages WHERE event_id = ?;', ['__smoke__']);
+  if (back.rows?.[0]?.content !== 'ok') throw new Error('encrypted round-trip failed');
+  return cipher;
+}


### PR DESCRIPTION
## What

#695 step 1: the encrypted local database that the freeze-killing data-access layer will sit on.

- Adds `@op-engineering/op-sqlite` (16.1.1) with **SQLCipher** enabled as the compile target (`package.json` → `"op-sqlite": { "sqlcipher": true }`).
- `src/services/localDb.ts` — opens the single encrypted DB with the Keystore key from `localDbKey.ts` (#697), migrates **schema v1** (`dm_messages`, indexed by `(conversation, created_at)` for the paginated slice reads that replace the blob cache), single-flight + retry-on-failure.
- `verifyEncryptedDb()` — the #695 step-0 **spike smoke-check**: confirms `PRAGMA cipher_version` is non-empty and an encrypted row round-trips.

## Why

The Messages-tab freeze is `refreshDmInbox` doing O(whole-inbox) decrypt synchronously on the JS thread (measured **52s / 49s frozen** on-device, 2026-05-26). Indexed encrypted rows + decrypt-once is the fix; this PR lays the encrypted store. Architecture: `docs/DATA_STORAGE.adoc`.

## Test plan

- [x] `npx jest src/services/localDb.test.ts` — 6 tests (open-with-key, schema, single-flight, retry, verify pass/fail) against a **mocked** native module. `tsc`/eslint/prettier clean.
- [x] **Native rebuild verified on-device** (`npx expo run:android` → LP_API34 emulator): `BUILD SUCCESSFUL`, SQLCipher CMake target compiled, and a dev-only `verifyEncryptedDb()` call logged:
  ```
  [SQLCipher-spike] OK — cipher_version=4.14.0 community
  ```
  → encrypted open + schema migrate + encrypted row round-trip all succeed. The temp wiring was reverted (not in this PR).
- [x] Dev-client build boots with the new-arch native module added.

Part of #695 (1 of ~5 PRs). Next: the DM data-access layer + decrypt-once ingest that actually removes the 52s `refreshDmInbox` freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
