### PR TITLE
chore(storage): DM data-access layer on the encrypted DB (#695)

### DIFF
--- a/src/services/dmDb.test.ts
+++ b/src/services/dmDb.test.ts
@@ -1,0 +1,121 @@
+// DAL over the encrypted dm_messages table. getLocalDb is mocked with a fake
+// op-sqlite DB (execute + transaction) so these cover the SQL/params/mapping
+// without the native module — the encrypted open itself is verified on-device
+// (localDb / #700).
+const mockExecute = jest.fn();
+const mockTransaction = jest.fn(
+  async (fn: (tx: { execute: typeof mockExecute }) => Promise<void>) => {
+    await fn({ execute: mockExecute });
+  },
+);
+jest.mock('./localDb', () => ({
+  getLocalDb: jest.fn(() =>
+    Promise.resolve({ execute: mockExecute, transaction: mockTransaction }),
+  ),
+}));
+
+import {
+  selectKnownEventIds,
+  upsertDmMessages,
+  getConversationMessages,
+  getInboxLatest,
+  type DmMessageRow,
+} from './dmDb';
+
+const row = (over: Partial<DmMessageRow> = {}): DmMessageRow => ({
+  eventId: 'e1',
+  conversation: 'convA',
+  createdAt: 100,
+  sender: 's1',
+  content: 'hi',
+  ...over,
+});
+
+// op-sqlite shape: { rows: Array<Record<string, Scalar>> }
+const rowsResult = (rows: Record<string, unknown>[]) => ({ rows });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExecute.mockResolvedValue(rowsResult([]));
+});
+
+describe('dmDb', () => {
+  describe('selectKnownEventIds', () => {
+    it('returns empty set (no query) for an empty input', async () => {
+      expect((await selectKnownEventIds([])).size).toBe(0);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns the set of ids already stored', async () => {
+      mockExecute.mockResolvedValueOnce(rowsResult([{ event_id: 'a' }, { event_id: 'c' }]));
+      const known = await selectKnownEventIds(['a', 'b', 'c']);
+      expect([...known].sort()).toEqual(['a', 'c']);
+      const [sql, params] = mockExecute.mock.calls[0];
+      expect(sql).toContain('WHERE event_id IN (?,?,?)');
+      expect(params).toEqual(['a', 'b', 'c']);
+    });
+
+    it('chunks large id lists under the SQLite variable limit', async () => {
+      const ids = Array.from({ length: 1200 }, (_, i) => `id${i}`);
+      await selectKnownEventIds(ids);
+      // 1200 / 500 → 3 chunked queries
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('upsertDmMessages', () => {
+    it('no-ops on empty input', async () => {
+      await upsertDmMessages([]);
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('upserts each row in a single transaction with INSERT OR REPLACE', async () => {
+      await upsertDmMessages([row({ eventId: 'e1' }), row({ eventId: 'e2' })]);
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+      const [sql, params] = mockExecute.mock.calls[0];
+      expect(sql).toContain('INSERT OR REPLACE INTO dm_messages');
+      expect(params).toEqual(['e1', 'convA', 100, 's1', 'hi']);
+    });
+  });
+
+  describe('getConversationMessages', () => {
+    it('reads newest-first with a default limit, mapping rows', async () => {
+      mockExecute.mockResolvedValueOnce(
+        rowsResult([
+          { event_id: 'e2', conversation: 'convA', created_at: 200, sender: 's', content: 'b' },
+        ]),
+      );
+      const out = await getConversationMessages('convA');
+      expect(out).toEqual([
+        { eventId: 'e2', conversation: 'convA', createdAt: 200, sender: 's', content: 'b' },
+      ]);
+      const [sql, params] = mockExecute.mock.calls[0];
+      expect(sql).toContain('WHERE conversation = ?');
+      expect(sql).toContain('ORDER BY created_at DESC');
+      expect(params).toEqual(['convA', 50]);
+    });
+
+    it('pages backwards with beforeCreatedAt', async () => {
+      await getConversationMessages('convA', { limit: 20, beforeCreatedAt: 150 });
+      const [sql, params] = mockExecute.mock.calls[0];
+      expect(sql).toContain('created_at < ?');
+      expect(params).toEqual(['convA', 150, 20]);
+    });
+  });
+
+  describe('getInboxLatest', () => {
+    it('selects the latest row per conversation (MAX(created_at) join)', async () => {
+      mockExecute.mockResolvedValueOnce(
+        rowsResult([
+          { event_id: 'e9', conversation: 'convB', created_at: 900, sender: 's', content: 'z' },
+        ]),
+      );
+      const out = await getInboxLatest();
+      expect(out[0].conversation).toBe('convB');
+      const [sql] = mockExecute.mock.calls[0];
+      expect(sql).toContain('MAX(created_at)');
+      expect(sql).toContain('GROUP BY conversation');
+    });
+  });
+});

--- a/src/services/dmDb.ts
+++ b/src/services/dmDb.ts
@@ -1,0 +1,107 @@
+import { getLocalDb } from './localDb';
+
+// Data-access layer for the `dm_messages` table in the encrypted local DB
+// (#695). One row per decrypted NIP-17 message, keyed by event_id. Replaces
+// the single-blob wrap cache whose whole-blob parse + re-decrypt froze the
+// Messages tab for ~52s (see docs/DATA_STORAGE.adoc). All reads are indexed
+// slice reads — never "load the whole inbox into JS".
+
+export interface DmMessageRow {
+  eventId: string;
+  conversation: string;
+  createdAt: number;
+  sender: string;
+  content: string;
+}
+
+// SQLite caps bound variables per statement (historically 999). Chunk IN()
+// lists well under that.
+const VAR_CHUNK = 500;
+
+const toRow = (r: Record<string, unknown>): DmMessageRow => ({
+  eventId: String(r.event_id),
+  conversation: String(r.conversation),
+  createdAt: Number(r.created_at),
+  sender: String(r.sender),
+  content: String(r.content),
+});
+
+/**
+ * Of the given event ids, which are already stored. This is the decrypt-once
+ * gate: ingest checks this first and only decrypts wraps we haven't seen,
+ * instead of re-decrypting the whole inbox on every refresh.
+ */
+export async function selectKnownEventIds(eventIds: string[]): Promise<Set<string>> {
+  const known = new Set<string>();
+  if (eventIds.length === 0) return known;
+  const db = await getLocalDb();
+  for (let i = 0; i < eventIds.length; i += VAR_CHUNK) {
+    const slice = eventIds.slice(i, i + VAR_CHUNK);
+    const placeholders = slice.map(() => '?').join(',');
+    const res = await db.execute(
+      `SELECT event_id FROM dm_messages WHERE event_id IN (${placeholders});`,
+      slice,
+    );
+    for (const r of res.rows ?? []) known.add(String(r.event_id));
+  }
+  return known;
+}
+
+/**
+ * Upsert decrypted messages. Idempotent by event_id (INSERT OR REPLACE) and
+ * batched in one transaction so a large first-sync is a single commit, not N.
+ */
+export async function upsertDmMessages(rows: readonly DmMessageRow[]): Promise<void> {
+  if (rows.length === 0) return;
+  const db = await getLocalDb();
+  await db.transaction(async (tx) => {
+    for (const m of rows) {
+      await tx.execute(
+        `INSERT OR REPLACE INTO dm_messages (event_id, conversation, created_at, sender, content)
+         VALUES (?, ?, ?, ?, ?);`,
+        [m.eventId, m.conversation, m.createdAt, m.sender, m.content],
+      );
+    }
+  });
+}
+
+/**
+ * One conversation's messages, newest-first, paginated. `beforeCreatedAt`
+ * pages backwards (load-older). Uses the (conversation, created_at) index —
+ * O(result), no whole-table scan, no whole-blob parse.
+ */
+export async function getConversationMessages(
+  conversation: string,
+  opts: { limit?: number; beforeCreatedAt?: number } = {},
+): Promise<DmMessageRow[]> {
+  const db = await getLocalDb();
+  const limit = opts.limit ?? 50;
+  const params: (string | number)[] = [conversation];
+  let sql = `SELECT * FROM dm_messages WHERE conversation = ?`;
+  if (opts.beforeCreatedAt != null) {
+    sql += ` AND created_at < ?`;
+    params.push(opts.beforeCreatedAt);
+  }
+  sql += ` ORDER BY created_at DESC LIMIT ?;`;
+  params.push(limit);
+  const res = await db.execute(sql, params);
+  return (res.rows ?? []).map(toRow);
+}
+
+/**
+ * The latest message in each conversation, newest-first — the inbox list.
+ * This is the read that replaces the whole-inbox blob parse: the DB does the
+ * per-conversation MAX in one indexed query instead of JS walking everything.
+ */
+export async function getInboxLatest(): Promise<DmMessageRow[]> {
+  const db = await getLocalDb();
+  const res = await db.execute(
+    `SELECT m.* FROM dm_messages m
+       JOIN (
+         SELECT conversation, MAX(created_at) AS mx
+         FROM dm_messages GROUP BY conversation
+       ) g ON m.conversation = g.conversation AND m.created_at = g.mx
+     ORDER BY m.created_at DESC;`,
+  );
+  return (res.rows ?? []).map(toRow);
+}


### PR DESCRIPTION
**Stacked on #700** (needs `localDb.ts`). Review/merge #700 first; this retargets to `main` automatically once #700 lands.

## What

#695 step 2: the indexed data-access layer over `dm_messages`, replacing the single-blob wrap cache.

- `selectKnownEventIds(ids)` — the **decrypt-once gate**: which event ids are already stored, so ingest only decrypts wraps we haven't seen (not the whole inbox every refresh). Chunked under SQLite's variable limit.
- `upsertDmMessages(rows)` — idempotent `INSERT OR REPLACE`, batched in one transaction.
- `getConversationMessages(conversation, {limit, beforeCreatedAt})` — newest-first, paginated; uses the `(conversation, created_at)` index. O(result), no whole-blob parse.
- `getInboxLatest()` — latest message per conversation (MAX join) for the inbox list — **the read that replaces the O(whole-inbox) blob parse that froze the Messages tab for 52s.**

## Why

See `docs/DATA_STORAGE.adoc` and the 2026-05-26 on-device measurement (52s `refreshDmInbox`, 49s frozen). This is the layer the freeze-killing ingest sits on.

## Test plan

- [x] `npx jest src/services/dmDb.test.ts` — 8 tests: empty-input no-op, known-id set, chunking, transactional upsert, paginated/backwards reads, inbox MAX-join. Mocks `getLocalDb` (the native open is verified in #700). `tsc`/eslint/prettier clean.
- [ ] Exercised on-device once the **ingest rewrite** (next PR) wires `refreshDmInbox`/`fetchConversation` onto it.

Part of #695 (2 of ~5). Next: decrypt-once ingest + NostrContext wiring (the PR that actually removes the freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)