### PR TITLE
docs(storage): Mermaid DB schema + storage-map diagrams (#695)

### DIFF
--- a/docs/DATA_STORAGE.adoc
+++ b/docs/DATA_STORAGE.adoc
@@ -177,7 +177,7 @@ erDiagram
         TEXT content
     }
     transactions {
-        TEXT id PK
+        TEXT id PK "payment_hash | txid"
         TEXT wallet_id
         TEXT direction
         INTEGER amount_sats
@@ -217,8 +217,8 @@ erDiagram
     }
     profiles ||--o{ dm_messages : "sender"
     profiles ||--o{ group_messages : "sender"
-    profiles ||--o{ caches : "hider"
-    profiles ||--o{ events : "organiser"
+    profiles ||--o{ caches : "hider_pubkey"
+    profiles ||--o{ events : "organiser_pubkey"
 ....
 
 `dm_messages` ships first (#695); the rest migrate in later slices (DMs cause

--- a/docs/DATA_STORAGE.adoc
+++ b/docs/DATA_STORAGE.adoc
@@ -101,16 +101,24 @@ The target — matching how 0xchat / Damus persist Nostr data — is a single
 |===
 | Data | Row keyed by | Encrypted?
 | DM wraps / messages (NIP-17) | `event_id` (+ `conversation`, `created_at`) | *Yes* — private content
+| Transactions (Lightning / on-chain) | `payment_hash` / txid (+ `wallet_id`, `created_at`) | *Yes* — private financial
+| Boltz swaps | swap id (+ `status`, `timeout_block`) | *Yes* — private + recovery-critical
 | Geo-caches (NIP-GC 37516) | `coord` (+ `geohash`, `author`) | Harmless (public); encrypted anyway since one DB
 | NIP-52 events (31923) | `coord` (+ `geohash`, `starts_at`) | Harmless (public)
-| BTC Map places | place id (+ lat/lon) | Harmless (public)
 |===
 
-Geo-caches, events, and places are *public* and don't require encryption, but
-folding them into the same SQLCipher DB is simpler than maintaining a second
-plain DB, and the encryption overhead is negligible. *Sequencing:* DMs first
-(they cause the freeze and need encryption); caches/events/places migrate into
-the same DB afterwards (they're smaller, public, not on fire).
+DMs, transactions, and swaps are *private* and the reason the DB is encrypted.
+Geo-caches and events are *public* but folding them into the same SQLCipher DB
+is simpler than a second plain DB, and the overhead is negligible.
+
+*BTC Map places are the deliberate exception* — public *external bulk* data,
+identical for every user and refreshed wholesale, so they stay in their own
+*plain* cache (`btcmap-last-result.json`), **not** the encrypted DB. That keeps
+the encrypted DB strictly *your* data, so logout = a clean, complete wipe (see
+the storage map under <<Diagrams>>).
+
+*Sequencing:* DMs first (they cause the freeze and need encryption);
+transactions/swaps next (financial); the public Nostr tables after.
 
 [[keys]]
 == Keystore key management (for the encrypted DB)
@@ -138,9 +146,10 @@ key off the device yields nothing usable.
 
 == Diagrams
 
-NOTE: These are https://mermaid.js.org[Mermaid] blocks. They render in the
-asciidoctor-diagram / PDF pipeline and on Mermaid-aware viewers; GitHub's raw
-`.adoc` preview shows them as source.
+NOTE: These are https://mermaid.js.org[Mermaid] blocks. They render to images
+in the PDF build (`generate-docs.sh` wires `asciidoctor-diagram` +
+`puppeteer-mermaid.json`) and on Mermaid-aware viewers; GitHub's raw `.adoc`
+preview shows them as source.
 
 === Encrypted DB schema (target)
 
@@ -246,7 +255,7 @@ that isn't yours to wipe.
 
 The encrypted DB is populated from the *canonical sources*, not by importing the
 old caches. Relays are already the source of truth for messages — the old wrap
-cache only memoised decryption — so we re-fetch wraps and decrypt-once into the
+cache only memoized decryption — so we re-fetch wraps and decrypt-once into the
 DB, then *delete* the old plaintext caches (closing the at-rest gap, #690). The
 old blob/file caches are never read as a migration source.
 
@@ -256,5 +265,5 @@ flowchart LR
     R["Relays<br/>(kind 1059 wraps)"] -->|"fetch + decrypt-once"| DB[("Encrypted DB")]
     W["Wallet backend<br/>(NWC / on-chain)"] -->|"sync"| DB
     BM["BTC Map API"] -->|"refresh"| PC["Plain places cache"]
-    OLD["Old plaintext caches<br/>(wrap cache, AsyncStorage blobs)"] -.->|"deleted, not imported"| X["🗑"]
+    OLD["Old plaintext caches<br/>(wrap cache, AsyncStorage blobs)"] -.->|"deleted, not imported"| X["discarded"]
 ....

--- a/docs/DATA_STORAGE.adoc
+++ b/docs/DATA_STORAGE.adoc
@@ -135,3 +135,126 @@ deliberately not DM-specific:
 
 The hardware keystore wraps the key, so raw extraction of the DB file *or* the
 key off the device yields nothing usable.
+
+== Diagrams
+
+NOTE: These are https://mermaid.js.org[Mermaid] blocks. They render in the
+asciidoctor-diagram / PDF pipeline and on Mermaid-aware viewers; GitHub's raw
+`.adoc` preview shows them as source.
+
+=== Encrypted DB schema (target)
+
+One SQLCipher database, one row per item, indexed for slice reads. Tables hold
+*your* data — private (DMs, transactions, swaps) and public-but-you-touched
+(profiles, caches, events). Public *external bulk* data (BTC Map places) is
+deliberately NOT here — see the storage map below. Relationships are *soft*:
+the pubkey columns reference Nostr identities, not enforced foreign keys.
+
+[mermaid]
+....
+erDiagram
+    dm_messages {
+        TEXT event_id PK
+        TEXT conversation
+        INTEGER created_at
+        TEXT sender
+        TEXT content
+    }
+    group_messages {
+        TEXT event_id PK
+        TEXT group_id
+        INTEGER created_at
+        TEXT sender
+        TEXT content
+    }
+    transactions {
+        TEXT id PK
+        TEXT wallet_id
+        TEXT direction
+        INTEGER amount_sats
+        TEXT status
+        INTEGER created_at
+        TEXT memo
+    }
+    swaps {
+        TEXT id PK
+        TEXT status
+        INTEGER amount_sats
+        TEXT preimage
+        TEXT refund_address
+        INTEGER timeout_block
+        INTEGER claimed
+        INTEGER created_at
+    }
+    profiles {
+        TEXT pubkey PK
+        TEXT name
+        TEXT picture
+        TEXT lud16
+        INTEGER updated_at
+    }
+    caches {
+        TEXT coord PK
+        TEXT hider_pubkey
+        TEXT geohash
+        INTEGER is_lp_piggy
+        INTEGER created_at
+    }
+    events {
+        TEXT coord PK
+        TEXT organiser_pubkey
+        TEXT geohash
+        INTEGER starts_at
+    }
+    profiles ||--o{ dm_messages : "sender"
+    profiles ||--o{ group_messages : "sender"
+    profiles ||--o{ caches : "hider"
+    profiles ||--o{ events : "organiser"
+....
+
+`dm_messages` ships first (#695); the rest migrate in later slices (DMs cause
+the freeze, so they go first; transactions/swaps next as they're financial;
+public Nostr tables after).
+
+=== Storage map — where each kind of data lives
+
+The decision rule. Three durable homes plus a throwaway cache; the axis is
+"secret?", "sensitive/growing collection?", "scalar setting?", or "public
+external bulk dataset?".
+
+[mermaid]
+....
+flowchart TD
+    Q{"What is the data?"}
+    Q -->|"secret / credential"| KS["Keystore<br/>expo-secure-store"]
+    Q -->|"sensitive or growing<br/>collection (your data)"| DB[("Encrypted DB<br/>op-sqlite + SQLCipher")]
+    Q -->|"small scalar setting"| AS["AsyncStorage"]
+    Q -->|"public external<br/>bulk dataset"| PC["Plain cache<br/>file / unencrypted"]
+
+    KS --> KSi["nsec · mnemonics · xpubs<br/>NWC URLs · LNURL bearers<br/>NFC PINs · local_db_key"]
+    DB --> DBi["dm_messages · group_messages<br/>transactions · swaps<br/>profiles · caches · events"]
+    AS --> ASi["theme · WoT tier · cursors<br/>send threshold · feature flags"]
+    PC --> PCi["BTC Map places<br/>btcmap-last-result.json"]
+....
+
+Logout / account wipe deletes the **Keystore** secrets and the **Encrypted DB**
+(+ its key) — a clean, complete user-data wipe. **AsyncStorage** scalars and the
+**Plain cache** survive: they're either non-identifying settings or public data
+that isn't yours to wipe.
+
+=== Migration (old store → new): re-fetch, don't import
+
+The encrypted DB is populated from the *canonical sources*, not by importing the
+old caches. Relays are already the source of truth for messages — the old wrap
+cache only memoised decryption — so we re-fetch wraps and decrypt-once into the
+DB, then *delete* the old plaintext caches (closing the at-rest gap, #690). The
+old blob/file caches are never read as a migration source.
+
+[mermaid]
+....
+flowchart LR
+    R["Relays<br/>(kind 1059 wraps)"] -->|"fetch + decrypt-once"| DB[("Encrypted DB")]
+    W["Wallet backend<br/>(NWC / on-chain)"] -->|"sync"| DB
+    BM["BTC Map API"] -->|"refresh"| PC["Plain places cache"]
+    OLD["Old plaintext caches<br/>(wrap cache, AsyncStorage blobs)"] -.->|"deleted, not imported"| X["🗑"]
+....

--- a/docs/TECHNICAL_SOLUTION_DOCUMENT.adoc
+++ b/docs/TECHNICAL_SOLUTION_DOCUMENT.adoc
@@ -49,6 +49,8 @@ include::DEPLOYMENT.adoc[]
 
 include::SECURITY.adoc[]
 
+include::DATA_STORAGE.adoc[]
+
 include::TESTING.adoc[]
 
 <<<

--- a/docs/generate-docs.sh
+++ b/docs/generate-docs.sh
@@ -14,6 +14,20 @@ if ! command -v asciidoctor-pdf &> /dev/null; then
     exit 1
 fi
 
+# Rendering DATA_STORAGE.adoc's [mermaid] diagrams needs the asciidoctor-diagram
+# extension plus the mermaid CLI (mmdc). Check both up front so a missing dep
+# fails with an actionable message instead of an unrendered / aborted PDF.
+if ! gem list -i asciidoctor-diagram &> /dev/null; then
+    echo "Error: asciidoctor-diagram gem is not installed (needed to render [mermaid] blocks)"
+    echo "Please install it with: sudo gem install asciidoctor-diagram"
+    exit 1
+fi
+if ! command -v mmdc &> /dev/null; then
+    echo "Error: mermaid CLI (mmdc) is not installed (needed to render [mermaid] blocks)"
+    echo "Please install it with: npm install -g @mermaid-js/mermaid-cli"
+    exit 1
+fi
+
 # Change to docs directory
 cd "$(dirname "$0")"
 

--- a/docs/generate-docs.sh
+++ b/docs/generate-docs.sh
@@ -19,7 +19,12 @@ cd "$(dirname "$0")"
 
 # Generate Technical Solution Document
 echo "Generating Technical Solution Document..."
+# -r asciidoctor-diagram renders [mermaid] blocks (e.g. DATA_STORAGE.adoc's
+# schema/storage diagrams) via mmdc. mermaid-puppeteer-config points mmdc's
+# headless Chrome at --no-sandbox so it launches in CI/containers.
 asciidoctor-pdf \
+    -r asciidoctor-diagram \
+    -a mermaid-puppeteer-config=puppeteer-mermaid.json \
     -a pdf-theme=lightning-piggy \
     -a pdf-themesdir=themes \
     -a pdf-fontsdir=themes \

--- a/docs/puppeteer-mermaid.json
+++ b/docs/puppeteer-mermaid.json
@@ -1,0 +1,1 @@
+{ "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"] }


### PR DESCRIPTION
Adds three Mermaid diagrams to `docs/DATA_STORAGE.adoc`, capturing the schema design worked out in discussion:

1. **Encrypted DB schema** (`erDiagram`) — target tables: `dm_messages`, `group_messages`, `transactions`, `swaps`, `profiles`, `caches`, `events`, with soft pubkey relationships (Nostr identities, not enforced FKs).
2. **Storage map** (`flowchart`) — the decision rule: secret → Keystore · sensitive/growing collection → encrypted DB · scalar setting → AsyncStorage · public external bulk dataset → plain cache.
3. **Migration** (`flowchart`) — populate the encrypted DB from canonical sources (relays / wallet / BTC Map) and **delete** the old plaintext caches rather than import them.

Records the decisions made while designing #695:
- transactions + Boltz **swaps** are sensitive → their own tables in the encrypted DB (swaps are recovery-critical).
- BTC Map **places** are public external bulk data → deliberately a **plain cache**, not in the encrypted user DB (keeps logout = clean user-data wipe).
- migration is **relays → decrypt-once → DB**, not old-store → new-store.

## Test plan

N/A — docs only. Mermaid blocks are valid (eyeballed; `mmdc` render needs a browser unavailable in CI). They render in the asciidoctor-diagram/PDF pipeline and Mermaid-aware viewers; GitHub's raw `.adoc` preview shows them as source (noted inline).

Part of #695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)