### PR TITLE
chore: rule + CI gate — no source file over 1,000 lines (#703)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run format:check
+
+  file-size:
+    name: File size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-file-size.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,16 @@
 - Use the branded `Alert` from `src/components/BrandedAlert.tsx`, not React Native's native `Alert.alert` — the branded one matches the app's theme (pink/blue) and is testable via `id: 'branded-alert-button-N'` in Maestro flows. ESLint enforces this via `no-restricted-imports`.
 - Use the branded `Toast` from `src/components/BrandedToast.tsx`, not `react-native-toast-message` directly — matches the app's pink/blue theme. ESLint enforces this via `no-restricted-imports`.
 
+## File size and modularity
+
+- **Hard cap: no source file over 1,000 lines.** A file approaching or past 1,000 lines MUST be broken up into smaller, **logically-cohesive** modules — split by *concern*, not by arbitrary line count. A 4,000-line context/screen is unreviewable, conflict-prone, and hides coupling.
+- **New files** must not be created over the cap. **When you touch an existing over-cap file, leave it smaller, never larger** — extract the part you're working on into its own module rather than adding to the blob.
+- **How to split (by concern, not by slicing):**
+  - **Contexts** → extract per-responsibility hooks/services. E.g. `NostrContext` → `useDmInbox` / `useProfiles` / `useRelays` (+ the `src/services/dm*` data layer), each its own file; the context just composes them.
+  - **Screens** → lift sub-views into components, and non-UI logic into hooks/utils (`useXScreenState`, `src/utils/…`).
+  - **Services** → split by domain (`nostrService` → `nostrRelay` / `nostrDm` / `nostrProfile`).
+- **Known offenders to break up (as of 2026-05-26, when touched):** `NostrContext.tsx` (4,279), `HuntCreateScreen.tsx` (3,121), `WalletContext.tsx` (2,173), `HuntPiggyDetailScreen.tsx` (1,710), `MapScreen.tsx` (1,562), `nostrService.ts` (1,529), `ConversationScreen.tsx` (1,455), `TransferSheet.tsx` (1,418), `ExploreHomeScreen.tsx` (1,377), `nfcService.ts` (1,242), `SendSheet.tsx` (1,176), `GroupConversationScreen.tsx` (1,015), `nwcService.ts` (1,009).
+
 ## Unit tests
 
 - Coverage scope: **`src/services`, `src/utils`, `src/contexts` only.** Components are excluded — they're best covered by Maestro pixel/flow tests (mocking Reanimated + bottom-sheet + Image for unit tests is high-effort, low-payoff).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@
   - **Contexts** → extract per-responsibility hooks/services. E.g. `NostrContext` → `useDmInbox` / `useProfiles` / `useRelays` (+ the `src/services/dm*` data layer), each its own file; the context just composes them.
   - **Screens** → lift sub-views into components, and non-UI logic into hooks/utils (`useXScreenState`, `src/utils/…`).
   - **Services** → split by domain (`nostrService` → `nostrRelay` / `nostrDm` / `nostrProfile`).
-- **Known offenders to break up (as of 2026-05-26, when touched):** `NostrContext.tsx` (4,279), `HuntCreateScreen.tsx` (3,121), `WalletContext.tsx` (2,173), `HuntPiggyDetailScreen.tsx` (1,710), `MapScreen.tsx` (1,562), `nostrService.ts` (1,529), `ConversationScreen.tsx` (1,455), `TransferSheet.tsx` (1,418), `ExploreHomeScreen.tsx` (1,377), `nfcService.ts` (1,242), `SendSheet.tsx` (1,176), `GroupConversationScreen.tsx` (1,015), `nwcService.ts` (1,009).
+- **Known offenders to break up (as of 2026-05-26, when touched; counts by `wc -l`, may read ±1 vs an editor's last-line number):** `NostrContext.tsx` (4,279), `HuntCreateScreen.tsx` (3,121), `WalletContext.tsx` (2,173), `HuntPiggyDetailScreen.tsx` (1,710), `MapScreen.tsx` (1,562), `nostrService.ts` (1,529), `ConversationScreen.tsx` (1,455), `TransferSheet.tsx` (1,418), `ExploreHomeScreen.tsx` (1,377), `nfcService.ts` (1,242), `SendSheet.tsx` (1,176), `GroupConversationScreen.tsx` (1,015), `nwcService.ts` (1,009). The CI gate (`scripts/check-file-size.sh`) baselines the same `wc -l` numbers, so doc and check agree.
 
 ## Unit tests
 

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Enforce the "no source file over 1,000 lines" rule (CLAUDE.md → File size and
+# modularity). Scans tracked JS/TS source (AsciiDoc/Markdown/JSON etc. are not
+# code and are excluded by the extension filter).
+#
+# Grandfather-aware: the files already over the cap when the rule landed are
+# baselined below. They are allowed to exist BUT MUST NOT GROW — extract, don't
+# append (see issue #703). Any *new* file over the cap, or any baselined file
+# that grows past its recorded size, fails the build.
+set -euo pipefail
+
+LIMIT=1000
+
+# Baseline of pre-existing over-cap files (path → max allowed lines = the count
+# when the rule landed, 2026-05-26). Shrink these over time and lower the number
+# here; never raise it. Delete the entry once a file drops under the cap.
+declare -A BASELINE=(
+  ["src/contexts/NostrContext.tsx"]=4279
+  ["src/screens/HuntCreateScreen.tsx"]=3121
+  ["src/contexts/WalletContext.tsx"]=2173
+  ["src/screens/HuntPiggyDetailScreen.tsx"]=1710
+  ["src/screens/MapScreen.tsx"]=1562
+  ["src/services/nostrService.ts"]=1529
+  ["src/screens/ConversationScreen.tsx"]=1455
+  ["src/components/TransferSheet.tsx"]=1418
+  ["src/screens/ExploreHomeScreen.tsx"]=1377
+  ["src/services/nfcService.ts"]=1242
+  ["src/components/SendSheet.tsx"]=1176
+  ["src/screens/GroupConversationScreen.tsx"]=1015
+  ["src/services/nwcService.ts"]=1009
+)
+
+# GitHub Actions error annotation when running in CI; plain echo locally.
+emit_error() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::error file=$1::$2"; else echo "ERROR: $1 — $2"; fi
+}
+
+fail=0
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  lines=$(wc -l < "$f" | tr -d ' ')
+  base="${BASELINE[$f]:-}"
+  if [ -n "$base" ]; then
+    if [ "$lines" -gt "$base" ]; then
+      emit_error "$f" "grew to ${lines} lines (baseline ${base}). Over-cap files must shrink, not grow — extract logic into its own module, don't append. See #703 + CLAUDE.md."
+      fail=1
+    fi
+  elif [ "$lines" -gt "$LIMIT" ]; then
+    emit_error "$f" "${lines} lines exceeds the ${LIMIT}-line cap. Split it into logically-cohesive modules (CLAUDE.md → File size and modularity)."
+    fail=1
+  fi
+done < <(git ls-files | grep -E '\.(ts|tsx|js|jsx)$')
+
+if [ "$fail" -eq 0 ]; then
+  echo "✓ file-size check passed (no new files over ${LIMIT} lines; baselined files did not grow)"
+fi
+exit "$fail"


### PR DESCRIPTION
Adds the **File size and modularity** rule to `CLAUDE.md` **and a CI gate that enforces it**.

## Rule (CLAUDE.md)
- Hard 1,000-line cap on source files; split by *concern*, not arbitrary slicing.
- New files must not exceed it; when you touch an over-cap file you **leave it smaller** (extract, don't append).
- Split guidance for contexts → hooks, screens → components, services → domains.

## Enforcement (CI)
- `scripts/check-file-size.sh` + a **File size** job in `ci.yml`. Scans tracked JS/TS (`.ts/.tsx/.js/.jsx`); AsciiDoc/Markdown/JSON are excluded by extension.
- **Grandfather-aware:** the 13 pre-existing over-cap files (led by `NostrContext.tsx` at 4,279) are baselined at their current size — they may **shrink but not grow**. Any *new* file over 1,000 lines, or a baselined file that grows past its baseline, fails the build.
- This enforces the rule going forward without blocking the backlog (tracked in #703, to be broken up opportunistically — the #695 DM work already cracks `NostrContext` open).

Verified locally: passes on main; fails a new 1001-line file; fails a grown baselined file.

## Test plan
- [x] `bash scripts/check-file-size.sh` passes on the current tree.
- [x] Fails (exit 1) on a synthetic 1001-line file and on a baselined file grown past baseline.
- [ ] CI "File size" job green on this PR.

Closes #703 is **not** set — #703 stays open to track breaking up the 13 offenders; this PR just adds the rule + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
