### PR TITLE
chore(storage): decrypt-once DM ingest + inbox read layer (#695)

### DIFF
--- a/src/services/dmDb.test.ts
+++ b/src/services/dmDb.test.ts
@@ -28,6 +28,8 @@ const row = (over: Partial<DmMessageRow> = {}): DmMessageRow => ({
   createdAt: 100,
   sender: 's1',
   content: 'hi',
+  fromMe: false,
+  wireKind: 14,
   ...over,
 });
 
@@ -75,7 +77,7 @@ describe('dmDb', () => {
       expect(mockExecute).toHaveBeenCalledTimes(2);
       const [sql, params] = mockExecute.mock.calls[0];
       expect(sql).toContain('INSERT OR REPLACE INTO dm_messages');
-      expect(params).toEqual(['e1', 'convA', 100, 's1', 'hi']);
+      expect(params).toEqual(['e1', 'convA', 100, 's1', 'hi', 0, 14]);
     });
   });
 
@@ -83,12 +85,28 @@ describe('dmDb', () => {
     it('reads newest-first with a default limit, mapping rows', async () => {
       mockExecute.mockResolvedValueOnce(
         rowsResult([
-          { event_id: 'e2', conversation: 'convA', created_at: 200, sender: 's', content: 'b' },
+          {
+            event_id: 'e2',
+            conversation: 'convA',
+            created_at: 200,
+            sender: 's',
+            content: 'b',
+            from_me: 1,
+            wire_kind: 14,
+          },
         ]),
       );
       const out = await getConversationMessages('convA');
       expect(out).toEqual([
-        { eventId: 'e2', conversation: 'convA', createdAt: 200, sender: 's', content: 'b' },
+        {
+          eventId: 'e2',
+          conversation: 'convA',
+          createdAt: 200,
+          sender: 's',
+          content: 'b',
+          fromMe: true,
+          wireKind: 14,
+        },
       ]);
       const [sql, params] = mockExecute.mock.calls[0];
       expect(sql).toContain('WHERE conversation = ?');

--- a/src/services/dmDb.ts
+++ b/src/services/dmDb.ts
@@ -12,6 +12,12 @@ export interface DmMessageRow {
   createdAt: number;
   sender: string;
   content: string;
+  /** True when we authored the message (sender === our pubkey). Stored rather
+   * than derived so reads don't need our pubkey threaded through. */
+  fromMe: boolean;
+  /** The inner rumor / event kind (NIP-17 text = 14, file = 15, legacy NIP-04
+   * = 4). Load-bearing: the inbox NIP-04/NIP-17 dedup keys on it. */
+  wireKind: number;
 }
 
 // SQLite caps bound variables per statement (historically 999). Chunk IN()
@@ -24,6 +30,8 @@ const toRow = (r: Record<string, unknown>): DmMessageRow => ({
   createdAt: Number(r.created_at),
   sender: String(r.sender),
   content: String(r.content),
+  fromMe: Number(r.from_me) === 1,
+  wireKind: Number(r.wire_kind),
 });
 
 /**
@@ -57,9 +65,10 @@ export async function upsertDmMessages(rows: readonly DmMessageRow[]): Promise<v
   await db.transaction(async (tx) => {
     for (const m of rows) {
       await tx.execute(
-        `INSERT OR REPLACE INTO dm_messages (event_id, conversation, created_at, sender, content)
-         VALUES (?, ?, ?, ?, ?);`,
-        [m.eventId, m.conversation, m.createdAt, m.sender, m.content],
+        `INSERT OR REPLACE INTO dm_messages
+           (event_id, conversation, created_at, sender, content, from_me, wire_kind)
+         VALUES (?, ?, ?, ?, ?, ?, ?);`,
+        [m.eventId, m.conversation, m.createdAt, m.sender, m.content, m.fromMe ? 1 : 0, m.wireKind],
       );
     }
   });

--- a/src/services/dmInbox.test.ts
+++ b/src/services/dmInbox.test.ts
@@ -1,0 +1,82 @@
+const mockGetInboxLatest = jest.fn();
+const mockGetConversation = jest.fn();
+jest.mock('./dmDb', () => ({
+  getInboxLatest: () => mockGetInboxLatest(),
+  getConversationMessages: (...args: unknown[]) => mockGetConversation(...args),
+}));
+
+import { rowsToInboxEntries, loadInboxEntries, loadConversationEntries } from './dmInbox';
+import type { DmMessageRow } from './dmDb';
+
+const row = (over: Partial<DmMessageRow> = {}): DmMessageRow => ({
+  eventId: 'evt1',
+  conversation: 'partnerPk',
+  createdAt: 100,
+  sender: 'partnerPk',
+  content: 'hello',
+  fromMe: false,
+  wireKind: 14,
+  ...over,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('dmInbox', () => {
+  it('maps a stored row to a DmInboxEntry 1:1 (no pubkey/kind guessing)', () => {
+    const [entry] = rowsToInboxEntries([
+      row({
+        eventId: 'w1',
+        conversation: 'bob',
+        createdAt: 42,
+        content: 'hi',
+        fromMe: true,
+        wireKind: 15,
+      }),
+    ]);
+    expect(entry).toEqual({
+      id: 'w1',
+      partnerPubkey: 'bob',
+      fromMe: true,
+      createdAt: 42,
+      text: 'hi',
+      wireKind: 15,
+    });
+  });
+
+  it('preserves fromMe + wireKind straight off the row (the reason we store them)', () => {
+    const entries = rowsToInboxEntries([
+      row({ eventId: 'a', fromMe: true, wireKind: 14 }),
+      row({ eventId: 'b', fromMe: false, wireKind: 4 }),
+    ]);
+    expect(entries.map((e) => [e.fromMe, e.wireKind])).toEqual([
+      [true, 14],
+      [false, 4],
+    ]);
+  });
+
+  it('loadInboxEntries projects getInboxLatest rows', async () => {
+    mockGetInboxLatest.mockResolvedValue([row({ eventId: 'x', conversation: 'carol' })]);
+    const out = await loadInboxEntries();
+    expect(mockGetInboxLatest).toHaveBeenCalledTimes(1);
+    expect(out).toEqual([
+      {
+        id: 'x',
+        partnerPubkey: 'carol',
+        fromMe: false,
+        createdAt: 100,
+        text: 'hello',
+        wireKind: 14,
+      },
+    ]);
+  });
+
+  it('loadConversationEntries forwards pagination opts and projects rows', async () => {
+    mockGetConversation.mockResolvedValue([row({ eventId: 'm1' })]);
+    const out = await loadConversationEntries('partnerPk', { limit: 20, beforeCreatedAt: 50 });
+    expect(mockGetConversation).toHaveBeenCalledWith('partnerPk', {
+      limit: 20,
+      beforeCreatedAt: 50,
+    });
+    expect(out[0].id).toBe('m1');
+  });
+});

--- a/src/services/dmInbox.ts
+++ b/src/services/dmInbox.ts
@@ -1,0 +1,41 @@
+import { getInboxLatest, getConversationMessages, type DmMessageRow } from './dmDb';
+import type { DmInboxEntry } from '../utils/conversationSummaries';
+
+// The read seam between the encrypted DM store (dmDb) and the Messages UI
+// (#695 step 3b). NostrContext delegates here instead of walking a giant
+// in-memory blob: loadInboxEntries() is the indexed per-conversation latest
+// read that replaces the O(whole-inbox) parse that froze the Messages tab,
+// and loadConversationEntries() is the paginated thread read.
+//
+// Mapping is 1:1 now that dmDb stores from_me + wire_kind — the row carries
+// everything DmInboxEntry needs, so no pubkey threading or kind assumptions.
+// Follow-gating is NOT applied here: it belongs at ingest (the decryptor) or
+// as a future read filter, so the "include non-follows" toggle can work
+// without re-fetching. Keep this layer a pure projection.
+
+const rowToInboxEntry = (r: DmMessageRow): DmInboxEntry => ({
+  id: r.eventId,
+  partnerPubkey: r.conversation,
+  fromMe: r.fromMe,
+  createdAt: r.createdAt,
+  text: r.content,
+  wireKind: r.wireKind,
+});
+
+/** Pure projection of stored rows → inbox entries. */
+export function rowsToInboxEntries(rows: readonly DmMessageRow[]): DmInboxEntry[] {
+  return rows.map(rowToInboxEntry);
+}
+
+/** The inbox list: latest message per conversation, newest-first. */
+export async function loadInboxEntries(): Promise<DmInboxEntry[]> {
+  return rowsToInboxEntries(await getInboxLatest());
+}
+
+/** One conversation's messages, newest-first, paginated (load-older via opts). */
+export async function loadConversationEntries(
+  partnerPubkey: string,
+  opts?: { limit?: number; beforeCreatedAt?: number },
+): Promise<DmInboxEntry[]> {
+  return rowsToInboxEntries(await getConversationMessages(partnerPubkey, opts));
+}

--- a/src/services/dmIngest.test.ts
+++ b/src/services/dmIngest.test.ts
@@ -1,0 +1,90 @@
+const mockSelectKnown = jest.fn();
+const mockUpsert = jest.fn();
+jest.mock('./dmDb', () => ({
+  selectKnownEventIds: (...args: unknown[]) => mockSelectKnown(...args),
+  upsertDmMessages: (...args: unknown[]) => mockUpsert(...args),
+}));
+
+import { ingestWraps, type IngestableWrap } from './dmIngest';
+import type { DmMessageRow } from './dmDb';
+
+const wrap = (id: string): IngestableWrap => ({ id });
+const rowFor = (id: string): DmMessageRow => ({
+  eventId: id,
+  conversation: 'conv',
+  createdAt: 1,
+  sender: 's',
+  content: 'c',
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSelectKnown.mockResolvedValue(new Set<string>());
+  mockUpsert.mockResolvedValue(undefined);
+});
+
+describe('dmIngest.ingestWraps', () => {
+  it('no-ops on empty input (no DB calls)', async () => {
+    const decrypt = jest.fn();
+    const res = await ingestWraps([], decrypt);
+    expect(res).toEqual({ ingested: 0, alreadyKnown: 0, undecryptable: 0 });
+    expect(mockSelectKnown).not.toHaveBeenCalled();
+    expect(decrypt).not.toHaveBeenCalled();
+  });
+
+  it('decrypts only wraps not already stored (the decrypt-once gate)', async () => {
+    mockSelectKnown.mockResolvedValue(new Set(['a', 'c'])); // a + c already stored
+    const decrypt = jest.fn(async (w: IngestableWrap) => rowFor(w.id));
+    const res = await ingestWraps([wrap('a'), wrap('b'), wrap('c'), wrap('d')], decrypt);
+    // only b + d get decrypted
+    expect(decrypt.mock.calls.map((c) => c[0].id)).toEqual(['b', 'd']);
+    expect(res).toEqual({ ingested: 2, alreadyKnown: 2, undecryptable: 0 });
+  });
+
+  it('upserts exactly the freshly decrypted rows', async () => {
+    const decrypt = jest.fn(async (w: IngestableWrap) => rowFor(w.id));
+    await ingestWraps([wrap('x'), wrap('y')], decrypt);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockUpsert.mock.calls[0][0].map((r: DmMessageRow) => r.eventId)).toEqual(['x', 'y']);
+  });
+
+  it('counts undecryptable wraps (decryptor returns null) and does not store them', async () => {
+    const decrypt = jest.fn(async (w: IngestableWrap) => (w.id === 'bad' ? null : rowFor(w.id)));
+    const res = await ingestWraps([wrap('ok'), wrap('bad')], decrypt);
+    expect(res).toEqual({ ingested: 1, alreadyKnown: 0, undecryptable: 1 });
+    expect(mockUpsert.mock.calls[0][0].map((r: DmMessageRow) => r.eventId)).toEqual(['ok']);
+  });
+
+  it('does not call upsert when nothing is fresh (all already known)', async () => {
+    mockSelectKnown.mockResolvedValue(new Set(['a', 'b']));
+    const decrypt = jest.fn();
+    const res = await ingestWraps([wrap('a'), wrap('b')], decrypt);
+    expect(decrypt).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(res.alreadyKnown).toBe(2);
+  });
+
+  it('yields to the event loop every N fresh decrypts and reports progress', async () => {
+    const ids = Array.from({ length: 5 }, (_, i) => wrap(`w${i}`));
+    const decrypt = jest.fn(async (w: IngestableWrap) => rowFor(w.id));
+    const onProgress = jest.fn();
+    await ingestWraps(ids, decrypt, { yieldEvery: 2, onProgress });
+    // 5 fresh decrypts, yield after #2 and #4 → 2 progress callbacks
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(4, 5);
+  });
+
+  it('stops early when the signal is aborted (no upsert of partial work after abort)', async () => {
+    const decrypt = jest.fn(async (w: IngestableWrap) => rowFor(w.id));
+    const signal = { aborted: false };
+    // abort after the first decrypt
+    decrypt.mockImplementationOnce(async (w: IngestableWrap) => {
+      signal.aborted = true;
+      return rowFor(w.id);
+    });
+    const res = await ingestWraps([wrap('a'), wrap('b'), wrap('c')], decrypt, { signal });
+    expect(decrypt).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).not.toHaveBeenCalled(); // aborted → don't persist partial
+    expect(res.ingested).toBe(0);
+  });
+});

--- a/src/services/dmIngest.test.ts
+++ b/src/services/dmIngest.test.ts
@@ -57,6 +57,17 @@ describe('dmIngest.ingestWraps', () => {
     expect(mockUpsert.mock.calls[0][0].map((r: DmMessageRow) => r.eventId)).toEqual(['ok']);
   });
 
+  it('treats a throwing decryptor as undecryptable and keeps going (no whole-sync abort)', async () => {
+    const decrypt = jest.fn(async (w: IngestableWrap) => {
+      if (w.id === 'boom') throw new Error('unwrap failed');
+      return rowFor(w.id);
+    });
+    const res = await ingestWraps([wrap('ok1'), wrap('boom'), wrap('ok2')], decrypt);
+    expect(decrypt).toHaveBeenCalledTimes(3); // didn't abort after the throw
+    expect(res).toEqual({ ingested: 2, alreadyKnown: 0, undecryptable: 1 });
+    expect(mockUpsert.mock.calls[0][0].map((r: DmMessageRow) => r.eventId)).toEqual(['ok1', 'ok2']);
+  });
+
   it('does not call upsert when nothing is fresh (all already known)', async () => {
     mockSelectKnown.mockResolvedValue(new Set(['a', 'b']));
     const decrypt = jest.fn();

--- a/src/services/dmIngest.test.ts
+++ b/src/services/dmIngest.test.ts
@@ -15,6 +15,8 @@ const rowFor = (id: string): DmMessageRow => ({
   createdAt: 1,
   sender: 's',
   content: 'c',
+  fromMe: false,
+  wireKind: 14,
 });
 
 beforeEach(() => {

--- a/src/services/dmIngest.ts
+++ b/src/services/dmIngest.ts
@@ -1,0 +1,96 @@
+import { selectKnownEventIds, upsertDmMessages, type DmMessageRow } from './dmDb';
+
+// Decrypt-once ingest for NIP-17 gift wraps (#695). This is the heart of the
+// Messages-tab freeze fix: instead of re-walking and re-decrypting the whole
+// inbox on every refresh (52s / 49s JS-thread block, measured 2026-05-26), we
+// decrypt ONLY wraps whose id isn't already in the encrypted DB, persist them,
+// and let the UI read indexed rows via dmDb.
+//
+// The caller (NostrContext) supplies the unwrap function — nsec or Amber/NIP-44
+// — that turns one wrap into a storable row; this module owns the dedup gate,
+// the batched upsert, and the cooperative yield so a big first-sync never
+// blocks the JS thread in one unbroken span.
+
+/** Minimal shape we need off a fetched kind-1059 wrap: just its event id. */
+export interface IngestableWrap {
+  id: string;
+}
+
+/**
+ * Decrypt one wrap into a row to persist, or null to skip it (undecryptable,
+ * not-for-us, filtered). Throwing is treated as a skip by the caller's own
+ * onSkip handling — keep that contract in the supplied function.
+ */
+export type WrapDecryptor<W extends IngestableWrap> = (wrap: W) => Promise<DmMessageRow | null>;
+
+export interface IngestResult {
+  /** Wraps newly decrypted + stored this run. */
+  ingested: number;
+  /** Wraps skipped because their id was already stored (the decrypt-once win). */
+  alreadyKnown: number;
+  /** Wraps the decryptor returned null for (undecryptable / not-for-us). */
+  undecryptable: number;
+}
+
+export interface IngestOptions {
+  /**
+   * Yield to the JS thread (via a 0ms timer) after every N *fresh* decrypts so
+   * a large first-sync stays interactive instead of freezing in one block.
+   * Cache-hit wraps are skipped cheaply and don't count toward the gap.
+   */
+  yieldEvery?: number;
+  /** Progress callback after each yield — for a "setting up messages…" hint. */
+  onProgress?: (decrypted: number, freshTotal: number) => void;
+  /** Abort cooperatively (e.g. signer/identity changed mid-refresh). */
+  signal?: { aborted: boolean };
+}
+
+const DEFAULT_YIELD_EVERY = 25;
+const yieldToEventLoop = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Ingest fetched wraps decrypt-once. Returns counts; the decrypted rows are
+ * persisted to the encrypted DB (read them back via dmDb's indexed queries).
+ */
+export async function ingestWraps<W extends IngestableWrap>(
+  wraps: readonly W[],
+  decrypt: WrapDecryptor<W>,
+  options: IngestOptions = {},
+): Promise<IngestResult> {
+  const result: IngestResult = { ingested: 0, alreadyKnown: 0, undecryptable: 0 };
+  if (wraps.length === 0) return result;
+
+  // The decrypt-once gate: one indexed query tells us which wrap ids we've
+  // already stored, so we never re-run the expensive unwrap for them.
+  const known = await selectKnownEventIds(wraps.map((w) => w.id));
+
+  const yieldEvery = options.yieldEvery ?? DEFAULT_YIELD_EVERY;
+  const freshTotal = wraps.length - known.size;
+  const fresh: DmMessageRow[] = [];
+  let freshAttempts = 0; // wraps we actually ran the decryptor on (hit or null)
+  for (const wrap of wraps) {
+    if (options.signal?.aborted) break;
+    if (known.has(wrap.id)) {
+      result.alreadyKnown++;
+      continue;
+    }
+    const row = await decrypt(wrap);
+    if (row) fresh.push(row);
+    else result.undecryptable++;
+    freshAttempts++;
+    // Yield only on fresh decrypts — that's where the CPU goes; cache-hit
+    // wraps above are a cheap Set lookup and shouldn't pace the loop.
+    if (yieldEvery > 0 && freshAttempts % yieldEvery === 0) {
+      await yieldToEventLoop();
+      options.onProgress?.(fresh.length, freshTotal);
+    }
+  }
+
+  // Only count + report as ingested what we actually persist. An aborted run
+  // skips the upsert, so its partial decrypts don't show as stored.
+  if (fresh.length > 0 && !options.signal?.aborted) {
+    await upsertDmMessages(fresh);
+    result.ingested = fresh.length;
+  }
+  return result;
+}

--- a/src/services/dmIngest.ts
+++ b/src/services/dmIngest.ts
@@ -74,7 +74,14 @@ export async function ingestWraps<W extends IngestableWrap>(
       result.alreadyKnown++;
       continue;
     }
-    const row = await decrypt(wrap);
+    // A throwing decryptor is treated as a skip (per WrapDecryptor's contract)
+    // so one undecryptable wrap can't abort the whole sync mid-way.
+    let row: DmMessageRow | null = null;
+    try {
+      row = await decrypt(wrap);
+    } catch {
+      row = null;
+    }
     if (row) fresh.push(row);
     else result.undecryptable++;
     freshAttempts++;

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -19,7 +19,9 @@ const SCHEMA: string[] = [
      conversation TEXT NOT NULL,
      created_at   INTEGER NOT NULL,
      sender       TEXT NOT NULL,
-     content      TEXT NOT NULL
+     content      TEXT NOT NULL,
+     from_me      INTEGER NOT NULL DEFAULT 0,
+     wire_kind    INTEGER NOT NULL DEFAULT 14
    );`,
   `CREATE INDEX IF NOT EXISTS idx_dm_conversation_created
      ON dm_messages (conversation, created_at DESC);`,

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -44,7 +44,23 @@ async function openLocalDb(): Promise<DB> {
     );
   }
   for (const stmt of SCHEMA) await db.execute(stmt);
+  await migrateDmMessagesColumns(db);
   return db;
+}
+
+// `CREATE TABLE IF NOT EXISTS` won't add columns to a dm_messages table created
+// by an earlier schema version (e.g. a dev build before from_me/wire_kind), so
+// add any missing ones explicitly. The table is a rebuildable relay cache, but
+// ALTER preserves rows already synced. Idempotent via the table_info check.
+async function migrateDmMessagesColumns(db: DB): Promise<void> {
+  const info = await db.execute('PRAGMA table_info(dm_messages);');
+  const have = new Set((info.rows ?? []).map((c) => String(c.name)));
+  if (!have.has('from_me')) {
+    await db.execute('ALTER TABLE dm_messages ADD COLUMN from_me INTEGER NOT NULL DEFAULT 0;');
+  }
+  if (!have.has('wire_kind')) {
+    await db.execute('ALTER TABLE dm_messages ADD COLUMN wire_kind INTEGER NOT NULL DEFAULT 14;');
+  }
 }
 
 /**


### PR DESCRIPTION
#695 steps 3a + 3b-i — the decrypt-once ingest and the inbox read seam that `NostrContext` will delegate to. **Pure + fully unit-tested; not yet wired into the live path** (that's 3b-ii, with on-device before/after).

## What

- **`dmIngest.ts`** — `ingestWraps(wraps, decrypt)`: checks `selectKnownEventIds` (one indexed query) and decrypts **only** wraps not already stored, batched-upserts the fresh rows, and **yields to the JS thread every N fresh decrypts** so a large first-sync stays interactive instead of freezing in one ~49s block. Cooperative abort + progress callback.
- **`dmInbox.ts`** — `loadInboxEntries()` (latest-per-conversation, the indexed read that replaces the whole-blob parse) + `loadConversationEntries()` (paginated) + the pure `rowsToInboxEntries` projection.
- **Schema:** `dm_messages` gains `from_me` + `wire_kind`. Extracting the inbox mapping surfaced that `DmInboxEntry` needs `fromMe` + `wireKind` (the latter is load-bearing for the NIP-04/NIP-17 dedup in `buildDmSummaries`); storing them keeps reads pure (no pubkey threading / kind assumption).

## Why

The Messages-tab freeze is `refreshDmInbox` re-walking + re-decrypting the whole inbox synchronously (52s / 49s frozen, measured on-device). This layer makes the inbox an indexed, decrypt-once, off-thread read. See `docs/DATA_STORAGE.adoc`.

## Test plan

- [x] 26 unit tests across `dmDb` / `dmIngest` / `dmInbox` / `localDb` (decrypt-once gate, yield/abort, projection, schema round-trip). `tsc`/eslint/prettier clean; file-size gate green.
- [ ] **3b-ii (next):** wire `NostrContext.refreshDmInbox`/`fetchConversation` onto `ingestWraps` + `loadInboxEntries`/`loadConversationEntries`, delete the old plaintext wrap cache, and verify on emulator: `perf-messages-tab-open` + `perf-dm-refresh-explore-mount` before/after, plus `test-nip17-send-1on1` / `test-dm-send-amber-373` / `test-multi-account-cold-start-isolation`.

Part of #695. The live rewire (3b-ii) lands separately so the high-stakes DM-path diff gets focused review + measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)