### PR TITLE
chore(storage): logout-wipe primitives for the encrypted DM store (#710)

### DIFF
--- a/src/services/localDb.test.ts
+++ b/src/services/localDb.test.ts
@@ -91,23 +91,21 @@ describe('localDb', () => {
     expect(cipherIdx).toBeLessThan(schemaIdx); // guard runs before schema
   });
 
-  it('clearLocalDb deletes the encrypted DB file (open handle case)', async () => {
-    const { getLocalDb: g, clearLocalDb } = require('./localDb');
-    await g(); // open it this session
-    await clearLocalDb();
-    expect(mockDelete).toHaveBeenCalled();
-  });
-
-  it('clearLocalDb opens a bare handle to delete when not opened this session', async () => {
-    const { clearLocalDb } = require('./localDb');
-    await clearLocalDb(); // never opened
-    expect(mockOpen).toHaveBeenCalledWith(expect.objectContaining({ name: 'lightningpiggy.db' }));
-    expect(mockDelete).toHaveBeenCalled();
-  });
-
-  it('wipeLocalDmStore deletes the DB AND clears the keystore key (#710 H1)', async () => {
-    const { wipeLocalDmStore } = require('./localDb');
+  // clearLocalDb is module-private (the only safe public wipe is
+  // wipeLocalDmStore, which also clears the key) — so its delete paths are
+  // exercised through wipeLocalDmStore.
+  it('wipeLocalDmStore deletes the DB AND clears the keystore key (open-handle case, #710 H1)', async () => {
+    const { getLocalDb: g, wipeLocalDmStore } = require('./localDb');
+    await g(); // opened this session
     await wipeLocalDmStore();
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockClearKey).toHaveBeenCalled();
+  });
+
+  it('wipeLocalDmStore opens a bare handle to delete when DB not opened this session', async () => {
+    const { wipeLocalDmStore } = require('./localDb');
+    await wipeLocalDmStore(); // never opened this session
+    expect(mockOpen).toHaveBeenCalledWith(expect.objectContaining({ name: 'lightningpiggy.db' }));
     expect(mockDelete).toHaveBeenCalled();
     expect(mockClearKey).toHaveBeenCalled();
   });

--- a/src/services/localDb.test.ts
+++ b/src/services/localDb.test.ts
@@ -2,11 +2,14 @@
 // schema orchestration and the verify smoke-check. The real encrypted open is
 // validated by an on-device dev build (#695 spike), not here.
 const mockExecute = jest.fn();
-const mockDb = { execute: mockExecute };
+const mockDelete = jest.fn();
+const mockDb = { execute: mockExecute, delete: mockDelete };
 const mockOpen = jest.fn(() => mockDb);
+const mockClearKey = jest.fn(() => Promise.resolve());
 jest.mock('@op-engineering/op-sqlite', () => ({ open: mockOpen }));
 jest.mock('./localDbKey', () => ({
   getOrCreateLocalDbKey: jest.fn(() => Promise.resolve('a'.repeat(64))),
+  clearLocalDbKey: mockClearKey,
 }));
 
 import { getLocalDb, verifyEncryptedDb } from './localDb';
@@ -86,6 +89,27 @@ describe('localDb', () => {
     const schemaIdx = sqls.findIndex((s) => s.includes('CREATE TABLE'));
     expect(cipherIdx).toBeGreaterThanOrEqual(0);
     expect(cipherIdx).toBeLessThan(schemaIdx); // guard runs before schema
+  });
+
+  it('clearLocalDb deletes the encrypted DB file (open handle case)', async () => {
+    const { getLocalDb: g, clearLocalDb } = require('./localDb');
+    await g(); // open it this session
+    await clearLocalDb();
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it('clearLocalDb opens a bare handle to delete when not opened this session', async () => {
+    const { clearLocalDb } = require('./localDb');
+    await clearLocalDb(); // never opened
+    expect(mockOpen).toHaveBeenCalledWith(expect.objectContaining({ name: 'lightningpiggy.db' }));
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it('wipeLocalDmStore deletes the DB AND clears the keystore key (#710 H1)', async () => {
+    const { wipeLocalDmStore } = require('./localDb');
+    await wipeLocalDmStore();
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockClearKey).toHaveBeenCalled();
   });
 });
 

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -79,13 +79,17 @@ export function getLocalDb(): Promise<DB> {
 }
 
 /**
- * Close + delete the encrypted DB file and reset the open handle. Used on
- * logout / account-wipe so no encrypted DM data lingers on disk. Best-effort:
- * a delete failure is swallowed (the file is unreadable without the key, which
- * clearLocalDbKey removes anyway). If the DB wasn't opened this session, a bare
- * handle is opened solely to delete the on-disk file.
+ * Close + delete the encrypted DB file and reset the open handle. If the DB
+ * wasn't opened this session, a bare handle is opened solely to delete the
+ * on-disk file.
+ *
+ * Module-private on purpose: deleting the file WITHOUT also clearing the key is
+ * not a complete wipe (a delete failure would leave a still-readable encrypted
+ * DB on disk). The only safe public entry point is `wipeLocalDmStore`, which
+ * pairs this with `clearLocalDbKey`. A delete failure is logged in dev as a
+ * breadcrumb rather than thrown, so it can't wedge the logout flow.
  */
-export async function clearLocalDb(): Promise<void> {
+async function clearLocalDb(): Promise<void> {
   let db: DB | null = null;
   if (dbPromise) {
     db = await dbPromise.catch(() => null);
@@ -100,8 +104,8 @@ export async function clearLocalDb(): Promise<void> {
   }
   try {
     db?.delete();
-  } catch {
-    // best-effort — see doc comment
+  } catch (e) {
+    if (__DEV__) console.warn(`[localDb] DB file delete failed: ${(e as Error)?.message ?? e}`);
   }
 }
 

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -1,5 +1,5 @@
 import { open, type DB } from '@op-engineering/op-sqlite';
-import { getOrCreateLocalDbKey } from './localDbKey';
+import { getOrCreateLocalDbKey, clearLocalDbKey } from './localDbKey';
 
 // The single encrypted local database (#695). SQLCipher is enabled as the
 // op-sqlite compile target (package.json "op-sqlite": { "sqlcipher": true }),
@@ -76,6 +76,45 @@ export function getLocalDb(): Promise<DB> {
     });
   }
   return dbPromise;
+}
+
+/**
+ * Close + delete the encrypted DB file and reset the open handle. Used on
+ * logout / account-wipe so no encrypted DM data lingers on disk. Best-effort:
+ * a delete failure is swallowed (the file is unreadable without the key, which
+ * clearLocalDbKey removes anyway). If the DB wasn't opened this session, a bare
+ * handle is opened solely to delete the on-disk file.
+ */
+export async function clearLocalDb(): Promise<void> {
+  let db: DB | null = null;
+  if (dbPromise) {
+    db = await dbPromise.catch(() => null);
+    dbPromise = null;
+  }
+  if (!db) {
+    try {
+      db = open({ name: DB_NAME });
+    } catch {
+      db = null;
+    }
+  }
+  try {
+    db?.delete();
+  } catch {
+    // best-effort — see doc comment
+  }
+}
+
+/**
+ * Full wipe of the local DM store on logout / account-wipe: delete the
+ * encrypted DB file AND its keystore key. A lone key or a lone ciphertext file
+ * is useless, but leave neither behind (#690 / #710 H1). Wire this into the
+ * logout path alongside the DM-store rewire (#709) that first writes real rows;
+ * safe to call earlier — both halves are no-ops when nothing has been created.
+ */
+export async function wipeLocalDmStore(): Promise<void> {
+  await clearLocalDb();
+  await clearLocalDbKey();
 }
 
 /**

--- a/src/services/localDbKey.ts
+++ b/src/services/localDbKey.ts
@@ -36,6 +36,10 @@ async function resolveKey(): Promise<string> {
   // Validate before trusting it: a corrupted / wrong-length value would
   // make SQLCipher fail to open with a cryptic error. Regenerate +
   // overwrite instead (pattern mirrors identitiesStore's hex guard).
+  // SAFETY (#710 L1): regenerating on a corrupt key is only safe while the DB
+  // holds rebuildable-from-relays *cache* data. Before recovery-critical rows
+  // (transactions / swaps, #695) land, revisit — a regenerated key would
+  // orphan data that can't be re-fetched.
   if (existing && HEX_64.test(existing)) return existing;
   const key = generateKey();
   await SecureStore.setItemAsync(LOCAL_DB_KEY_STORE_KEY, key, SECURE_OPTIONS);


### PR DESCRIPTION
Addresses the implementable parts of the #695 at-rest-encryption **security review** (#710). The review's verdict was *crypto sound, no live exposure* — these are the hardening primitives for the not-yet-wired logout path.

## What

- **H1 primitive** — `clearLocalDb()`: closes + deletes the encrypted DB file (`op-sqlite` `db.delete()`) and resets the open handle (opens a bare handle to delete the file if the DB wasn't opened this session). Plus **`wipeLocalDmStore()`** = `clearLocalDb()` + `clearLocalDbKey()`, so logout wipes the ciphertext file **and** its keystore key in one call.
- **L1 guard** — comment in `localDbKey.resolveKey` flagging that regenerate-on-corrupt is only safe while the DB holds rebuildable cache data (revisit before recovery-critical transactions/swaps).

## Deliberately deferred (to #709 / 3b-ii)
- **H1 wiring** — calling `wipeLocalDmStore()` from `wipeAccountCaches`/logout. Lands *in lockstep with the first real DM write* (the review's explicit guidance) — and `NostrContext.tsx` is at its file-size baseline (2,031), so the gate won't let me grow it here anyway.
- **M1/M2** — the migration's plaintext-cache deletion + verify-not-silent. The migration doesn't exist until the rewire.

So today both halves are no-ops (nothing's been written to the DB) — this just makes #709's wiring a one-liner and the guarantee correct from the moment ingest lands.

## Test plan

- [x] `npx jest src/services/localDb.test.ts` — 10 tests incl. clearLocalDb (open + bare-handle cases) and wipeLocalDmStore (deletes DB + clears key). tsc/eslint/prettier/file-size green.
- [ ] On-device `db.delete()` behaviour covered when logout wiring lands in #709.

Part of #710. Keeps #710 open for H1-wiring + M1/M2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)