### PR TITLE
chore(storage): one-time DM-store migration logic (relays→DB, verified delete) (#710)

### DIFF
--- a/src/services/dmStoreMigration.test.ts
+++ b/src/services/dmStoreMigration.test.ts
@@ -1,0 +1,89 @@
+import { migrateDmStore, type MigrationDeps } from './dmStoreMigration';
+
+// A deps harness with sane defaults + call tracking, overridable per test.
+const makeDeps = (over: Partial<MigrationDeps> = {}) => {
+  const calls: string[] = [];
+  let migrated = false;
+  const deps: MigrationDeps = {
+    isMigrated: jest.fn(async () => migrated),
+    setMigrated: jest.fn(async () => {
+      migrated = true;
+      calls.push('setMigrated');
+    }),
+    populateFromRelays: jest.fn(async () => {
+      calls.push('populate');
+      return { completed: true };
+    }),
+    deletePlaintextCaches: jest.fn(async () => {
+      calls.push('delete');
+    }),
+    verifyPlaintextGone: jest.fn(async () => true),
+    warn: jest.fn(),
+    ...over,
+  };
+  return {
+    deps,
+    calls,
+    get migrated() {
+      return migrated;
+    },
+  };
+};
+
+describe('dmStoreMigration', () => {
+  it('short-circuits when already migrated (no populate, no delete)', async () => {
+    const { deps } = makeDeps({ isMigrated: jest.fn(async () => true) });
+    const res = await migrateDmStore(deps);
+    expect(res).toEqual({ ok: true, status: 'already-migrated' });
+    expect(deps.populateFromRelays).not.toHaveBeenCalled();
+    expect(deps.deletePlaintextCaches).not.toHaveBeenCalled();
+  });
+
+  it('happy path: populate → delete → setMigrated, strictly ordered', async () => {
+    const { deps, calls } = makeDeps();
+    const res = await migrateDmStore(deps);
+    expect(res).toEqual({ ok: true, status: 'migrated' });
+    expect(calls).toEqual(['populate', 'delete', 'setMigrated']); // ordering is the safety invariant
+  });
+
+  it('does NOT delete plaintext or set the flag when populate is incomplete', async () => {
+    const { deps } = makeDeps({
+      populateFromRelays: jest.fn(async () => ({ completed: false })),
+    });
+    const res = await migrateDmStore(deps);
+    expect(res).toEqual({ ok: false, reason: 'populate-incomplete' });
+    expect(deps.deletePlaintextCaches).not.toHaveBeenCalled(); // never delete on a partial DB
+    expect(deps.setMigrated).not.toHaveBeenCalled();
+  });
+
+  it('M2: does NOT set the migrated flag if plaintext survives the delete', async () => {
+    const { deps } = makeDeps({
+      verifyPlaintextGone: jest.fn(async () => false),
+    });
+    const res = await migrateDmStore(deps);
+    expect(res).toEqual({ ok: false, reason: 'delete-unverified' });
+    expect(deps.deletePlaintextCaches).toHaveBeenCalled(); // it tried
+    expect(deps.setMigrated).not.toHaveBeenCalled(); // but didn't mark done → retries
+  });
+
+  it('is idempotent: a second run after success short-circuits', async () => {
+    const h = makeDeps();
+    await migrateDmStore(h.deps);
+    expect(h.migrated).toBe(true);
+    const second = await migrateDmStore(h.deps);
+    expect(second).toEqual({ ok: true, status: 'already-migrated' });
+    expect(h.deps.populateFromRelays).toHaveBeenCalledTimes(1); // not re-run
+  });
+
+  it('retries cleanly: a failed run leaves the flag unset so the next run proceeds', async () => {
+    let plaintextGone = false; // first delete "fails" verification, then succeeds
+    const deps = makeDeps({
+      verifyPlaintextGone: jest.fn(async () => plaintextGone),
+    }).deps;
+    const first = await migrateDmStore(deps);
+    expect(first.ok).toBe(false);
+    plaintextGone = true; // environment recovered
+    const second = await migrateDmStore(deps);
+    expect(second).toEqual({ ok: true, status: 'migrated' });
+  });
+});

--- a/src/services/dmStoreMigration.ts
+++ b/src/services/dmStoreMigration.ts
@@ -1,0 +1,73 @@
+// One-time migration from the old plaintext DM caches to the encrypted DB
+// (#695 / #710 M1+M2). The encrypted store is populated from the *canonical*
+// source — relays — not by importing the old plaintext (which only ever
+// memoised decryption); then the old plaintext caches are deleted, closing the
+// at-rest gap (#690).
+//
+// Strict ordering is the whole safety story:
+//   1. populate the encrypted DB from relays (decrypt-once → rows)
+//   2. only if that completed, delete the old plaintext caches
+//   3. only if the plaintext is VERIFIED gone, set the migrated flag
+// Never delete plaintext before the DB is populated; never mark migrated until
+// the plaintext is confirmed deleted. Because the DB is re-fetchable from
+// relays, deletion is safe even in the worst case (a bad run just re-migrates
+// next launch — the flag stays unset). Idempotent + interruption-safe.
+
+export interface MigrationDeps {
+  /** Has migration already completed for this account? */
+  isMigrated: () => Promise<boolean>;
+  /** Persist the migrated flag — called LAST, only after a verified wipe. */
+  setMigrated: () => Promise<void>;
+  /**
+   * Re-fetch the wraps from relays and decrypt-once into the encrypted DB.
+   * Returns whether it ran to completion (false = aborted/errored → do NOT
+   * delete plaintext, since the DB may be incomplete). An empty inbox still
+   * counts as completed.
+   */
+  populateFromRelays: () => Promise<{ completed: boolean }>;
+  /** Delete the old plaintext caches (file wrap cache + AsyncStorage blobs). */
+  deletePlaintextCaches: () => Promise<void>;
+  /** M2: confirm the plaintext caches are actually gone after deletion. */
+  verifyPlaintextGone: () => Promise<boolean>;
+  /** Dev breadcrumb for a non-fatal migration hiccup (so a stuck retry is visible). */
+  warn?: (msg: string) => void;
+}
+
+export type MigrationResult =
+  | { ok: true; status: 'migrated' | 'already-migrated' }
+  | { ok: false; reason: 'populate-incomplete' | 'delete-unverified' };
+
+/**
+ * Run the one-time DM-store migration. Safe to call on every login/app-start:
+ * short-circuits once migrated, and a failed run leaves the flag unset so it
+ * retries (the decrypt-once gate makes re-populating cheap).
+ */
+export async function migrateDmStore(deps: MigrationDeps): Promise<MigrationResult> {
+  if (await deps.isMigrated()) return { ok: true, status: 'already-migrated' };
+
+  // 1. Populate the encrypted DB from relays. If it didn't complete, bail
+  //    WITHOUT touching the plaintext — the DB may be partial.
+  const populate = await deps.populateFromRelays();
+  if (!populate.completed) {
+    deps.warn?.(
+      'DM migration: populate did not complete; leaving plaintext + flag intact, will retry',
+    );
+    return { ok: false, reason: 'populate-incomplete' };
+  }
+
+  // 2. DB is now the source of truth → delete the old plaintext caches.
+  await deps.deletePlaintextCaches();
+
+  // 3. M2: verify the plaintext is actually gone. If not, DO NOT mark migrated
+  //    — otherwise plaintext would persist while the user believes it's gone.
+  if (!(await deps.verifyPlaintextGone())) {
+    deps.warn?.(
+      'DM migration: plaintext caches still present after delete; not marking migrated, will retry',
+    );
+    return { ok: false, reason: 'delete-unverified' };
+  }
+
+  // 4. Flag LAST — so a crash anywhere above just retries next launch.
+  await deps.setMigrated();
+  return { ok: true, status: 'migrated' };
+}


### PR DESCRIPTION
The migration orchestration for #695 3b-ii, implementing the **M1/M2** security-review findings (#710). **Pure logic, fully unit-tested, not yet wired** into the live path (that's the 3b-ii rewire, which needs on-device before/after).

## What

`migrateDmStore(deps)` — the one-time move from the old plaintext DM caches to the encrypted DB, **strictly ordered** (the safety invariant):
1. **populate** the encrypted DB from relays (the canonical source — *not* by importing the old plaintext, which only memoised decryption)
2. only if that **completed**, **delete** the old plaintext caches
3. only if the plaintext is **verified gone** (M2), set the migrated flag — **last**

- **M1** — the deletion of the old plaintext caches (file wrap cache + AsyncStorage inbox/conversation blobs) is part of the migration, gated on a populated DB.
- **M2** — deletion is **verified, not fire-and-forget**: if plaintext survives, the migrated flag stays unset → retries next launch (don't let a silent failed-delete leave plaintext while the user believes it's encrypted).
- **Idempotent + interruption-safe** — flag set last; a crash anywhere just retries; re-populate is cheap via the decrypt-once gate. Safe because the DB is re-fetchable from relays.

## Deferred to the 3b-ii live rewire
NostrContext supplies the real deps (relay-fetch+`ingestWraps`, the cache-delete, the flag) and calls `migrateDmStore` on login; `refreshDmInbox`/`fetchConversation` switch to reading the DB; logout calls `wipeLocalDmStore` (#712). That PR carries the **on-device before/after** (52s → ?) — gated on a healthy emulator.

## Test plan
- [x] `npx jest src/services/dmStoreMigration.test.ts` — 6 tests: ordering, populate-incomplete guard, M2 unverified-delete guard, idempotency, clean retry. tsc/eslint/prettier/file-size green.
- [ ] End-to-end migration exercised on-device when wired in 3b-ii.

Part of #695 / #710 (M1/M2). #710 stays open for H1-wiring + this wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)