### PR TITLE
perf(dm): decrypt voice notes once — reuse cache across remounts (#730)

### DIFF
--- a/src/components/VoiceNotePlayer.tsx
+++ b/src/components/VoiceNotePlayer.tsx
@@ -12,7 +12,18 @@ import { decryptFile } from '../services/encryptedFile';
 // url → decrypted-clip file:// uri. Module-scoped so a voice note decrypted
 // once is reused across re-renders, remounts and the session — no re-fetch /
 // re-decrypt on every play after a scroll-away (#730). Mirrors DecryptedImage.
+// Capped (insertion-order eviction) so a long session with many notes can't
+// grow it unbounded, matching the bounded module caches elsewhere (#732 review).
+const VOICE_CACHE_CAP = 64;
 const decryptedVoiceCache = new Map<string, string>();
+function rememberVoiceUri(url: string, uri: string): void {
+  decryptedVoiceCache.set(url, uri);
+  while (decryptedVoiceCache.size > VOICE_CACHE_CAP) {
+    const oldest = decryptedVoiceCache.keys().next().value;
+    if (oldest === undefined) break;
+    decryptedVoiceCache.delete(oldest);
+  }
+}
 
 const BARS = 40;
 
@@ -96,10 +107,11 @@ const VoiceNotePlayer: React.FC<Props> = ({
   const bars = useMemo(() => pseudoWave(url, BARS), [url]);
 
   // Decrypted clip is written to a cache file on first play; for plain notes
-  // we stream the URL directly.
-  const [localUri, setLocalUri] = useState<string | null>(
-    encrypted ? (decryptedVoiceCache.get(url) ?? null) : null,
-  );
+  // we stream the URL directly. NOT seeded from the cache Map directly: the OS
+  // can evict cacheDirectory, so a Map hit isn't proof the file still exists —
+  // ensureLocal verifies existence (and re-decrypts on a miss) before it sets
+  // localUri (#732 review).
+  const [localUri, setLocalUri] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
   const wantPlayRef = useRef(false);
@@ -118,11 +130,16 @@ const VoiceNotePlayer: React.FC<Props> = ({
   const ensureLocal = useCallback(async (): Promise<string | null> => {
     if (!encrypted) return url;
     if (localUri) return localUri;
-    // Decrypted earlier this session → reuse the cache file, no work (#730).
+    // Decrypted earlier this session → reuse it, but verify the file still
+    // exists first: the OS can evict cacheDirectory, and a stale entry would
+    // otherwise pin localUri to a dead path with no retry (#732 review).
     const memo = decryptedVoiceCache.get(url);
     if (memo) {
-      setLocalUri(memo);
-      return memo;
+      if ((await getInfoAsync(memo)).exists) {
+        setLocalUri(memo);
+        return memo;
+      }
+      decryptedVoiceCache.delete(url); // evicted from disk → fall through to re-decrypt
     }
     if (!keyHex || !nonceHex) {
       setFailed(true);
@@ -148,7 +165,7 @@ const VoiceNotePlayer: React.FC<Props> = ({
           encoding: 'base64',
         });
       }
-      decryptedVoiceCache.set(url, uri);
+      rememberVoiceUri(url, uri);
       setLocalUri(uri);
       return uri;
     } catch (e) {

--- a/src/components/VoiceNotePlayer.tsx
+++ b/src/components/VoiceNotePlayer.tsx
@@ -2,12 +2,17 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
 import { Play, Pause, AlertCircle } from 'lucide-react-native';
 import { useAudioPlayer, useAudioPlayerStatus, setAudioModeAsync } from 'expo-audio';
-import { writeAsStringAsync, cacheDirectory } from 'expo-file-system/legacy';
+import { writeAsStringAsync, getInfoAsync, cacheDirectory } from 'expo-file-system/legacy';
 import { Buffer } from 'buffer';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 import { formatTime } from '../utils/messageContent';
 import { decryptFile } from '../services/encryptedFile';
+
+// url → decrypted-clip file:// uri. Module-scoped so a voice note decrypted
+// once is reused across re-renders, remounts and the session — no re-fetch /
+// re-decrypt on every play after a scroll-away (#730). Mirrors DecryptedImage.
+const decryptedVoiceCache = new Map<string, string>();
 
 const BARS = 40;
 
@@ -92,7 +97,9 @@ const VoiceNotePlayer: React.FC<Props> = ({
 
   // Decrypted clip is written to a cache file on first play; for plain notes
   // we stream the URL directly.
-  const [localUri, setLocalUri] = useState<string | null>(null);
+  const [localUri, setLocalUri] = useState<string | null>(
+    encrypted ? (decryptedVoiceCache.get(url) ?? null) : null,
+  );
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
   const wantPlayRef = useRef(false);
@@ -111,25 +118,37 @@ const VoiceNotePlayer: React.FC<Props> = ({
   const ensureLocal = useCallback(async (): Promise<string | null> => {
     if (!encrypted) return url;
     if (localUri) return localUri;
+    // Decrypted earlier this session → reuse the cache file, no work (#730).
+    const memo = decryptedVoiceCache.get(url);
+    if (memo) {
+      setLocalUri(memo);
+      return memo;
+    }
     if (!keyHex || !nonceHex) {
       setFailed(true);
       return null;
     }
     setBusy(true);
     try {
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-      const cipher = new Uint8Array(await res.arrayBuffer());
-      const plain = decryptFile(cipher, keyHex, nonceHex);
       // `||` not `??`: a trailing-slash URL makes `.pop()` return '' (not
       // null), which would yield `lp-voice-.m4a` and collide across notes.
       const safe = (url.split('/').pop() || 'note').replace(/[^a-zA-Z0-9._-]/g, '');
       if (!cacheDirectory) throw new Error('No cache directory available for decrypted audio');
       const base = cacheDirectory.endsWith('/') ? cacheDirectory : `${cacheDirectory}/`;
       const uri = `${base}lp-voice-${safe}.${extFromMime(mime)}`;
-      await writeAsStringAsync(uri, Buffer.from(plain).toString('base64'), {
-        encoding: 'base64',
-      });
+      // Reuse a clip decrypted on a previous mount if it's still on disk —
+      // decrypt once, even across remounts (#730).
+      const info = await getInfoAsync(uri);
+      if (!info.exists) {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+        const cipher = new Uint8Array(await res.arrayBuffer());
+        const plain = decryptFile(cipher, keyHex, nonceHex);
+        await writeAsStringAsync(uri, Buffer.from(plain).toString('base64'), {
+          encoding: 'base64',
+        });
+      }
+      decryptedVoiceCache.set(url, uri);
       setLocalUri(uri);
       return uri;
     } catch (e) {


### PR DESCRIPTION
## What
Makes encrypted voice notes **decrypt-once**, matching the image work in #729.

Closes #730

## Why
`VoiceNotePlayer` cached the decrypted clip only in **component state** (`localUri`), so after a note scrolled off-screen and back (remount) the next tap of play re-fetched the ciphertext from Blossom, re-decrypted, and re-wrote the cache file — even though the decrypted clip was already on disk.

## How
Mirrors `DecryptedImage` (#688/#729): `ensureLocal` now checks (1) a module-level `Map<url, file://uri>`, then (2) the on-disk cache file via `getInfoAsync`, and only fetches+decrypts on a true miss. The clip is decrypted **once** and reused across re-renders, remounts and the session; the player source seeds from the cache on mount. Blossom URLs are content-addressed (sha256 of ciphertext), so the URL is a safe cache key (same as the image side).

## Test plan
- Static: `npx tsc --noEmit`, ESLint, Prettier, and `scripts/check-file-size.sh` all pass. `VoiceNotePlayer.tsx` is 314 lines (well under the cap). No behaviour-changing logic outside the cache lookup.
- Component-internal change (components are out of unit-test coverage scope per CLAUDE.md); mirrors the reviewed `DecryptedImage` caching.
- Manual (device): play an encrypted voice note, scroll it off-screen and back, play again → it plays immediately with **no** `[Blossom]` re-fetch in the logs (previously each remount re-downloaded + re-decrypted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
