### PR TITLE
fix(nwc): support wallets without a kind-13194 info event + back off on relay ban (#737)

### DIFF
--- a/src/services/nwcEncryption.ts
+++ b/src/services/nwcEncryption.ts
@@ -1,22 +1,53 @@
 import type { NostrWebLNProvider } from '@getalby/sdk';
 
-// Per-wallet encryption decision, cached so reconnects don't re-probe the relay.
-// Each probe is a subscription that adds load, and noisy relays (CoinOS) temp-ban
-// busy IPs — so we decide once per wallet and reuse it. (#737)
-//   'nip04'     → wallet publishes no kind-13194 info event; pin NIP-04.
-//   'negotiate' → info event present; let the SDK negotiate normally.
-const encryptionDecision = new Map<string, 'nip04' | 'negotiate'>();
+// Per-wallet "pin to NIP-04" decision, persisted across reconnects so we don't
+// re-probe noisy relays on every connect (CoinOS temp-bans busy IPs, #737). We
+// deliberately cache ONLY the negative ('nip04') outcome — caching a positive
+// 'negotiate' decision would permanently downgrade a NIP-44-capable wallet to
+// NIP-04 if its kind-13194 info event was briefly unavailable when we last
+// probed (Copilot review #738). Re-probing on each connect for the 'negotiate'
+// path is one bounded relay call and lets a wallet whose info event appears
+// later recover automatically.
+const encryptionDecision = new Map<string, 'nip04'>();
 
 type NwcInternals = {
   client?: { _encryptionType?: string; getWalletServiceInfo?: () => Promise<unknown> };
 };
 
+// Bounded wait for the info-event probe. `client.getWalletServiceInfo()` opens
+// a relay subscription that resolves on EOSE — against a slow / temp-banned
+// relay (the very scenario this probe is meant to harden), the SDK's own
+// internal timeout (or lack thereof) can stall connect() for many seconds or
+// indefinitely. We cap it ourselves and treat a timeout the same as "no info
+// event" → pin NIP-04 (Copilot review #738). The SDK's underlying subscription
+// may continue briefly until its own bound, but our connect() path is no
+// longer blocked.
+const PROBE_TIMEOUT_MS = 5_000;
+const PROBE_TIMEOUT_MARKER = 'probe-timeout';
+
+function probeWithTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(PROBE_TIMEOUT_MARKER)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
 // Some NWC wallets (notably CoinOS) never publish a kind-13194 info event yet
 // still speak NIP-47 over NIP-04. @getalby/sdk negotiates encryption from that
 // event before every command and throws "no info event (kind 13194)" when it's
-// absent — bricking invoice/claim/balance. After connecting, probe once; if the
-// event is missing, pin NIP-04 (the SDK's own baseline). The decision is cached
-// per wallet so reconnects set it straight away without another relay probe.
+// absent — bricking invoice/claim/balance. After connecting, probe once with a
+// bounded timeout; if the event is missing (or the probe times out against a
+// slow / banned relay), pin NIP-04 (the SDK's own baseline) and cache the
+// decision so reconnects skip the probe straight away.
 export async function pinNip04IfNoInfoEvent(
   provider: NostrWebLNProvider,
   walletId: string,
@@ -26,19 +57,21 @@ export async function pinNip04IfNoInfoEvent(
     return;
   }
 
-  const cached = encryptionDecision.get(walletId);
-  if (cached === 'nip04') {
+  if (encryptionDecision.get(walletId) === 'nip04') {
     client._encryptionType = 'nip04';
     return;
   }
-  if (cached === 'negotiate') return;
 
   try {
-    await client.getWalletServiceInfo();
-    encryptionDecision.set(walletId, 'negotiate');
+    await probeWithTimeout(client.getWalletServiceInfo(), PROBE_TIMEOUT_MS);
+    // Info event present → let the SDK negotiate normally. Don't cache the
+    // positive outcome — see the encryptionDecision comment above.
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    if (/no info event|kind ?13194/i.test(msg)) {
+    // "no info event" / "kind 13194 missing" → the wallet doesn't publish one.
+    // Our own probe-timeout → relay is too slow / temp-banned to answer in
+    // time; treat the same way so we don't hang connect() indefinitely.
+    if (/no info event|kind ?13194/i.test(msg) || msg === PROBE_TIMEOUT_MARKER) {
       client._encryptionType = 'nip04';
       encryptionDecision.set(walletId, 'nip04');
     }

--- a/src/services/nwcEncryption.ts
+++ b/src/services/nwcEncryption.ts
@@ -1,0 +1,52 @@
+import type { NostrWebLNProvider } from '@getalby/sdk';
+
+// Per-wallet encryption decision, cached so reconnects don't re-probe the relay.
+// Each probe is a subscription that adds load, and noisy relays (CoinOS) temp-ban
+// busy IPs — so we decide once per wallet and reuse it. (#737)
+//   'nip04'     → wallet publishes no kind-13194 info event; pin NIP-04.
+//   'negotiate' → info event present; let the SDK negotiate normally.
+const encryptionDecision = new Map<string, 'nip04' | 'negotiate'>();
+
+type NwcInternals = {
+  client?: { _encryptionType?: string; getWalletServiceInfo?: () => Promise<unknown> };
+};
+
+// Some NWC wallets (notably CoinOS) never publish a kind-13194 info event yet
+// still speak NIP-47 over NIP-04. @getalby/sdk negotiates encryption from that
+// event before every command and throws "no info event (kind 13194)" when it's
+// absent — bricking invoice/claim/balance. After connecting, probe once; if the
+// event is missing, pin NIP-04 (the SDK's own baseline). The decision is cached
+// per wallet so reconnects set it straight away without another relay probe.
+export async function pinNip04IfNoInfoEvent(
+  provider: NostrWebLNProvider,
+  walletId: string,
+): Promise<void> {
+  const client = (provider as unknown as NwcInternals).client;
+  if (!client || typeof client.getWalletServiceInfo !== 'function' || client._encryptionType) {
+    return;
+  }
+
+  const cached = encryptionDecision.get(walletId);
+  if (cached === 'nip04') {
+    client._encryptionType = 'nip04';
+    return;
+  }
+  if (cached === 'negotiate') return;
+
+  try {
+    await client.getWalletServiceInfo();
+    encryptionDecision.set(walletId, 'negotiate');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/no info event|kind ?13194/i.test(msg)) {
+      client._encryptionType = 'nip04';
+      encryptionDecision.set(walletId, 'nip04');
+    }
+  }
+}
+
+// Forget a wallet's cached decision — call when the wallet is removed so a later
+// re-add (e.g. a different NWC URL under the same id) re-probes fresh.
+export function clearEncryptionDecision(walletId: string): void {
+  encryptionDecision.delete(walletId);
+}

--- a/src/services/nwcErrors.ts
+++ b/src/services/nwcErrors.ts
@@ -46,8 +46,11 @@ export function isConnectionError(error: unknown): boolean {
     msg.includes('connection lost') ||
     // Relay rate-limit / abuse rejection (e.g. CoinOS "temp-banned <ip>"). Treat
     // as a connectivity failure so the cooldown (#656) parks the relay and we
-    // stop publishing into a ban instead of hammering it (#737).
-    msg.includes('banned') ||
+    // stop publishing into a ban instead of hammering it (#737). Match the
+    // narrow "temp-banned" anchor, not bare "banned", so a wallet-side error
+    // that happens to contain "banned" (e.g. "user account banned") still
+    // surfaces as a confirmed failure to the user (Copilot review #738).
+    msg.includes('temp-banned') ||
     msg.includes('rate-limit') ||
     msg.includes('rate limit')
   );

--- a/src/services/nwcErrors.ts
+++ b/src/services/nwcErrors.ts
@@ -1,0 +1,102 @@
+// NWC error classification + abort/cancellation primitives, shared by the NWC
+// service layer. Kept separate so nwcService stays focused on connection +
+// command logic.
+
+/** Standard DOMException-shape abort error: `name === 'AbortError'`.
+ * Callers can detect via `error.name === 'AbortError'` or by checking
+ * `signal.aborted` after await. */
+export function createAbortError(message = 'Payment cancelled'): Error {
+  const err = new Error(message);
+  err.name = 'AbortError';
+  return err;
+}
+
+export const REPLY_TIMEOUT_ERROR_NAME = 'ReplyTimeoutError';
+
+export function createReplyTimeoutError(
+  message = 'Wallet did not reply in time; payment may still be in flight',
+): Error {
+  const err = new Error(message);
+  err.name = REPLY_TIMEOUT_ERROR_NAME;
+  return err;
+}
+
+export function isReplyTimeoutError(error: unknown): boolean {
+  return (error as Error)?.name === REPLY_TIMEOUT_ERROR_NAME;
+}
+
+// True when the failure is a relay/transport connectivity problem rather
+// than a confirmed payment outcome — e.g. the relay was unreachable
+// ("Failed to connect to wss://…", NWC code OTHER) or a publish never
+// completed. Like a reply-timeout, the payment status is UNKNOWN: it may
+// well have settled. Callers must NOT present these as "Payment failed"
+// (#648) — a user who trusts that may re-send and double-pay.
+export function isConnectionError(error: unknown): boolean {
+  const msg = (
+    (error as { message?: string } | undefined)?.message ?? String(error ?? '')
+  ).toLowerCase();
+  return (
+    msg.includes('failed to connect') ||
+    msg.includes('publish timed out') ||
+    msg.includes('publish failed') ||
+    msg.includes('could not connect') ||
+    msg.includes('network request failed') ||
+    msg.includes('websocket') ||
+    msg.includes('connection closed') ||
+    msg.includes('connection lost') ||
+    // Relay rate-limit / abuse rejection (e.g. CoinOS "temp-banned <ip>"). Treat
+    // as a connectivity failure so the cooldown (#656) parks the relay and we
+    // stop publishing into a ban instead of hammering it (#737).
+    msg.includes('banned') ||
+    msg.includes('rate-limit') ||
+    msg.includes('rate limit')
+  );
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
+/** Sleep that rejects with AbortError if the signal fires, instead of
+ * resolving on schedule. Without this the 5-minute poll loop below
+ * ignores cancellation between polls. */
+export function abortableSleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(createAbortError());
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Race a non-cancellable promise against an AbortSignal so the caller
+ * can stop waiting even while the underlying SDK call keeps running.
+ * The background promise is allowed to complete; its result is just
+ * discarded if abort wins the race. */
+export function abortable<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(createAbortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}

--- a/src/services/nwcService.ts
+++ b/src/services/nwcService.ts
@@ -1,5 +1,24 @@
 import { NostrWebLNProvider } from '@getalby/sdk';
 import type { Nip47GetInfoResponse } from '@getalby/sdk';
+import { pinNip04IfNoInfoEvent, clearEncryptionDecision } from './nwcEncryption';
+import {
+  createReplyTimeoutError,
+  isConnectionError,
+  isReplyTimeoutError,
+  throwIfAborted,
+  abortableSleep,
+  abortable,
+} from './nwcErrors';
+
+// Preserve the prior public API — these were defined + exported here before
+// moving to ./nwcErrors; consumers (e.g. SendSheet) still import them from here.
+export {
+  createAbortError,
+  createReplyTimeoutError,
+  isConnectionError,
+  isReplyTimeoutError,
+  REPLY_TIMEOUT_ERROR_NAME,
+} from './nwcErrors';
 
 const providers = new Map<string, NostrWebLNProvider>();
 const nwcUrls = new Map<string, string>();
@@ -100,99 +119,6 @@ function hasRecentPublishFailure(walletId: string): boolean {
   return true;
 }
 
-/** Standard DOMException-shape abort error: `name === 'AbortError'`.
- * Callers can detect via `error.name === 'AbortError'` or by checking
- * `signal.aborted` after await. */
-export function createAbortError(message = 'Payment cancelled'): Error {
-  const err = new Error(message);
-  err.name = 'AbortError';
-  return err;
-}
-
-export const REPLY_TIMEOUT_ERROR_NAME = 'ReplyTimeoutError';
-
-export function createReplyTimeoutError(
-  message = 'Wallet did not reply in time; payment may still be in flight',
-): Error {
-  const err = new Error(message);
-  err.name = REPLY_TIMEOUT_ERROR_NAME;
-  return err;
-}
-
-export function isReplyTimeoutError(error: unknown): boolean {
-  return (error as Error)?.name === REPLY_TIMEOUT_ERROR_NAME;
-}
-
-// True when the failure is a relay/transport connectivity problem rather
-// than a confirmed payment outcome — e.g. the relay was unreachable
-// ("Failed to connect to wss://…", NWC code OTHER) or a publish never
-// completed. Like a reply-timeout, the payment status is UNKNOWN: it may
-// well have settled. Callers must NOT present these as "Payment failed"
-// (#648) — a user who trusts that may re-send and double-pay.
-export function isConnectionError(error: unknown): boolean {
-  const msg = (
-    (error as { message?: string } | undefined)?.message ?? String(error ?? '')
-  ).toLowerCase();
-  return (
-    msg.includes('failed to connect') ||
-    msg.includes('publish timed out') ||
-    msg.includes('publish failed') ||
-    msg.includes('could not connect') ||
-    msg.includes('network request failed') ||
-    msg.includes('websocket') ||
-    msg.includes('connection closed') ||
-    msg.includes('connection lost')
-  );
-}
-
-function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw createAbortError();
-}
-
-/** Sleep that rejects with AbortError if the signal fires, instead of
- * resolving on schedule. Without this the 5-minute poll loop below
- * ignores cancellation between polls. */
-function abortableSleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(createAbortError());
-      return;
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(timer);
-      reject(createAbortError());
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-/** Race a non-cancellable promise against an AbortSignal so the caller
- * can stop waiting even while the underlying SDK call keeps running.
- * The background promise is allowed to complete; its result is just
- * discarded if abort wins the race. */
-function abortable<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
-  if (!signal) return promise;
-  if (signal.aborted) return Promise.reject(createAbortError());
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      (value) => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(value);
-      },
-      (err) => {
-        signal.removeEventListener('abort', onAbort);
-        reject(err);
-      },
-    );
-  });
-}
-
 async function withRetry<T>(
   fn: () => Promise<T>,
   { attempts = 3, delayMs = 1000, label = 'operation' } = {},
@@ -260,6 +186,7 @@ export async function connect(
     patchRelayPublish(provider, walletId);
 
     await withRetry(() => provider.enable(), { label: 'connect', attempts: 3, delayMs: 2000 });
+    await pinNip04IfNoInfoEvent(provider, walletId);
 
     // Store provider immediately after enable() — the relay connection is
     // established even if getBalance fails (e.g. slow relay response).
@@ -330,6 +257,8 @@ export function disconnect(walletId: string): void {
   // wallet lifecycle (a removed wallet shouldn't keep its terminal-miss
   // entries pinned for the JS-runtime lifetime).
   clearFailedLookupCache(walletId);
+  // Forget the cached encryption decision so a re-add re-probes fresh (#737).
+  clearEncryptionDecision(walletId);
 }
 
 /**
@@ -485,6 +414,10 @@ function patchRelayPublish(provider: NostrWebLNProvider, walletId: string): void
             origPublish(event).catch((err: unknown) => {
               console.warn('[NWC] Relay publish failed (fire-and-forget):', err);
               markPublishFailure(walletId);
+              // A relay rejection (temp-ban / rate-limit / connectivity) should
+              // count toward the cooldown so we park the relay and stop
+              // publishing into a ban instead of looping on it (#737).
+              if (isConnectionError(err)) recordRelayOutcome(walletId, err);
             });
             return Promise.resolve(); // resolve immediately
           };
@@ -515,6 +448,7 @@ async function reconnect(walletId: string): Promise<NostrWebLNProvider> {
   const provider = new NostrWebLNProvider({ nostrWalletConnectUrl: url });
   patchRelayPublish(provider, walletId);
   await provider.enable();
+  await pinNip04IfNoInfoEvent(provider, walletId);
   providers.set(walletId, provider);
   return provider;
 }


### PR DESCRIPTION
## Problem
CoinOS (and any NIP-47 wallet that doesn't publish a kind-13194 info event) failed **every** operation — make invoice, claim a Hunt prize, get balance — with:

> no info event (kind 13194) returned from relay

(Originally misfiled as a transient blip in #734; it's structural and 100% reproducible.)

## Root cause
The newer `@getalby/sdk` calls `NWCClient._selectEncryptionType()` **before every command**, which fetches the kind-13194 info event to negotiate NIP-44 vs NIP-04 and throws when it's absent.

**Verified by querying `relay.coinos.io` directly:** zero kind-13194 events (any author), but a steady stream of kind-23195 NWC responses whose content is NIP-04 (`…?iv=…`). So the wallet is alive and speaking NIP-04 — we just refused to talk to it because it doesn't advertise a capabilities event.

## Fix
- **`src/services/nwcEncryption.ts`** (new) — after connecting, probe once for the info event; if it's missing, pin the client to **NIP-04** (the SDK's own default baseline). The decision is **cached per wallet** so reconnects don't re-probe (each probe is a relay subscription).
- **Back off on relay ban** — `temp-banned` / rate-limit rejections now count as connection errors, and fire-and-forget publish failures feed the cooldown, so a rate-limiting relay gets parked instead of looping publish→ban→reconnect→publish. (We saw CoinOS temp-ban the IP under load and the client kept hammering it.)
- **`src/services/nwcErrors.ts`** (new) — extracted the NWC error-classification + abort/cancellation helpers so `nwcService` drops back under the 1,000-line cap (1024 → 944). Public API preserved via re-export.

## Test plan
- [x] `npx jest nwc` — 34 tests / 2 suites green
- [x] `npx tsc --noEmit`, `eslint`, `prettier`, `check-file-size.sh` — all clean
- [x] On-device (Pixel, dev): a fresh CoinOS wallet now shows **balance** and **generates invoices** (previously both failed). Probe pins NIP-04 in ~1s.
- [ ] Re-verify end-to-end once `relay.coinos.io`'s temp-ban (from heavy testing) clears
- [x] LNbits Piggy wallets (info event present) unaffected — they negotiate normally

Closes #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
