### PR TITLE
feat(notifications): notify on find-logs against my geo-caches (#740)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -49,6 +49,7 @@ import {
 } from './nostrDmCache';
 import { useDmInbox } from './useDmInbox';
 import { useGroupMessaging } from './useGroupMessaging';
+import { useCacheNotifications } from './useCacheNotifications';
 import {
   CONTACTS_CACHE_KEY_BASE,
   PROFILES_CACHE_KEY_BASE,
@@ -403,6 +404,11 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     signerType,
     relays,
   });
+
+  // Find-log notifications (#740) — live kind-1111 sub against the
+  // viewer's cache coordinates. Sibling to `useDmInbox`'s live sub;
+  // fires `fireCacheNotification` per fresh arrival.
+  useCacheNotifications({ pubkey, getReadRelays });
 
   const loadProfile = useCallback(
     async (pk: string, relayUrls: string[], opts?: { force?: boolean }) => {

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -9,15 +9,17 @@
  * decryption, no follow gate, and no inbox state to mutate — the hook
  * exists purely to listen and ping.
  *
- * "My cache coordinates" is sourced from a one-shot author-listing query
- * via `fetchCachesByAuthor`, with a session-scoped re-fetch when the
- * viewer's pubkey changes or the read relays change. We deliberately do
- * NOT thread this list through NostrContext state — the screens that
- * already display the user's caches each have their own hydration
- * paths, and bolting another reactive source onto the context would
- * grow that over-cap file without a clear win. The cost is one
- * `fetchCachesByAuthor` per identity-switch; cheap (kind-37516 by one
- * pubkey is replaceable and bounded).
+ * "My cache coordinates" is sourced from `fetchCachesByAuthor` and
+ * re-fetched on a session timer (every minute) and on every AppState →
+ * active transition, so a cache the user publishes mid-session (which a
+ * one-shot snapshot would miss until full remount, Copilot review #742)
+ * is picked up by the live sub within a minute — and immediately on a
+ * background→foreground hop. We deliberately do NOT thread this list
+ * through NostrContext state — the screens that already display the
+ * user's caches each have their own hydration paths, and bolting another
+ * reactive source onto the context would grow that over-cap file without
+ * a clear win. The cost is one `fetchCachesByAuthor` per minute; cheap
+ * (kind-37516 by one pubkey is replaceable and bounded, capped at 5 s).
  *
  * Freshness gate matches the DM live sub: only events whose own
  * `created_at` ≥ `subOpenedAtSec − NOTIFY_SKEW_SEC` fire a notification,
@@ -26,6 +28,7 @@
  * relays only fires once.
  */
 import { useEffect, useRef } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
 import type { VerifiedEvent } from 'nostr-tools';
 import { subscribeCacheCommentsForCoords } from '../services/cacheNotifySubscription';
 import { fireCacheNotification } from '../services/notificationService';
@@ -39,6 +42,12 @@ const NOTIFY_SKEW_SEC = 120;
 // in heavy bursts (e.g. a treasure hunt going viral) and we don't want
 // the Set to grow unboundedly across the life of the sub.
 const SEEN_CAP = 1000;
+
+// Re-poll the viewer's cache coords once a minute so a cache published
+// mid-session is picked up by the live sub without a full app restart
+// (Copilot review #742). Bounded (5 s maxWait inside fetchCachesByAuthor)
+// and inexpensive (kind-37516 by one pubkey is replaceable + small).
+const REFETCH_COORDS_INTERVAL_MS = 60_000;
 
 export interface UseCacheNotificationsParams {
   /** Active viewer's hex pubkey. Null when logged out — sub stays closed. */
@@ -74,6 +83,9 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
 
     let cancelled = false;
     let unsubscribe: (() => void) | null = null;
+    // Coord set the sub is currently armed with. Compared against each
+    // refetch to skip tear-down + re-arm when nothing changed.
+    let currentCoords: string[] = [];
     const seen = new Set<string>();
     const subOpenedAtSec = Math.floor(Date.now() / 1000);
 
@@ -117,14 +129,29 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
       });
     };
 
-    // Resolve "my caches" with a one-shot author query, then open the
-    // sub. fetchCachesByAuthor caps internally at 5 s so a slow relay
-    // can't pin the hook on mount.
-    (async () => {
+    /**
+     * Re-fetch "my cache coords" and (re-)arm the live sub if the coord
+     * set changed. Called on mount, on a 60 s interval, and on every
+     * AppState → active transition so a cache published mid-session is
+     * picked up without a full app restart. `fetchCachesByAuthor` caps
+     * itself at 5 s so this can't pin the hook against a slow relay.
+     */
+    const refetchAndRearm = async (): Promise<void> => {
+      if (cancelled) return;
       try {
         const myCaches = await fetchCachesByAuthor(pubkey, readRelays);
         if (cancelled) return;
         const coords = myCaches.map((c) => c.coord);
+        // Set-equality (order-independent — fetchCachesByAuthor ordering is
+        // not guaranteed). Skip the tear-down + re-arm when unchanged.
+        const sameSet =
+          coords.length === currentCoords.length && coords.every((c) => currentCoords.includes(c));
+        if (sameSet) return;
+        currentCoords = coords;
+        if (unsubscribe) {
+          unsubscribe();
+          unsubscribe = null;
+        }
         if (coords.length === 0) return;
         unsubscribe = subscribeCacheCommentsForCoords({
           viewerPubkey: pubkey,
@@ -133,13 +160,24 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
           onEvent: handle,
         });
       } catch {
-        // Non-fatal — the background detect-and-ping pass still catches
-        // anything we miss here on the next wake.
+        // Non-fatal — leave the previous sub (if any) in place; the next
+        // refetch retries. The background detect-and-ping pass also
+        // catches anything we miss here.
       }
-    })();
+    };
+
+    void refetchAndRearm();
+    const interval = setInterval(() => {
+      void refetchAndRearm();
+    }, REFETCH_COORDS_INTERVAL_MS);
+    const appStateSub = AppState.addEventListener('change', (s: AppStateStatus) => {
+      if (s === 'active') void refetchAndRearm();
+    });
 
     return () => {
       cancelled = true;
+      clearInterval(interval);
+      appStateSub.remove();
       if (unsubscribe) unsubscribe();
     };
   }, [pubkey, getReadRelays]);

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -1,0 +1,146 @@
+/**
+ * useCacheNotifications — foreground live subscription that fires an OS
+ * notification when a kind-1111 find-log is published against one of the
+ * viewer's geo-caches (#740).
+ *
+ * Mirrors the shape of `useDmInbox`'s live sub (the one that opens the
+ * kind-4 + kind-1059 stream and fires `fireMessageNotification` per
+ * fresh event), but for the public find-log surface. There is no
+ * decryption, no follow gate, and no inbox state to mutate — the hook
+ * exists purely to listen and ping.
+ *
+ * "My cache coordinates" is sourced from a one-shot author-listing query
+ * via `fetchCachesByAuthor`, with a session-scoped re-fetch when the
+ * viewer's pubkey changes or the read relays change. We deliberately do
+ * NOT thread this list through NostrContext state — the screens that
+ * already display the user's caches each have their own hydration
+ * paths, and bolting another reactive source onto the context would
+ * grow that over-cap file without a clear win. The cost is one
+ * `fetchCachesByAuthor` per identity-switch; cheap (kind-37516 by one
+ * pubkey is replaceable and bounded).
+ *
+ * Freshness gate matches the DM live sub: only events whose own
+ * `created_at` ≥ `subOpenedAtSec − NOTIFY_SKEW_SEC` fire a notification,
+ * so the relay's historical replay on cold start stays silent. Per-event
+ * dedup via a session Set so the same find-log delivered by multiple
+ * relays only fires once.
+ */
+import { useEffect, useRef } from 'react';
+import type { VerifiedEvent } from 'nostr-tools';
+import { subscribeCacheCommentsForCoords } from '../services/cacheNotifySubscription';
+import { fireCacheNotification } from '../services/notificationService';
+import { fetchCachesByAuthor } from '../services/nostrPlacesPublisher';
+import { parseCacheCoord } from '../services/nostrPlacesService';
+
+// Tolerate sender/receiver clock drift — matches the DM live sub.
+const NOTIFY_SKEW_SEC = 120;
+
+// Bounded session dedup. Find-logs against a popular cache could stream
+// in heavy bursts (e.g. a treasure hunt going viral) and we don't want
+// the Set to grow unboundedly across the life of the sub.
+const SEEN_CAP = 1000;
+
+export interface UseCacheNotificationsParams {
+  /** Active viewer's hex pubkey. Null when logged out — sub stays closed. */
+  pubkey: string | null;
+  /** Stable getter returning the current read relays. Same shape as the
+   * one `useDmInbox` consumes, so callers can pass the same value. */
+  getReadRelays: () => string[];
+}
+
+/**
+ * Open the live find-log subscription for the viewer's caches. Returns
+ * nothing — the hook fires notifications as a side-effect and tears
+ * down the sub on unmount / pubkey change / relay change.
+ *
+ * Idempotent: rendering the hook with the same params is a no-op
+ * between effect runs.
+ */
+export function useCacheNotifications(params: UseCacheNotificationsParams): void {
+  const { pubkey, getReadRelays } = params;
+
+  // Snapshot the current relays once per effect run — passing
+  // `getReadRelays` itself into the dep array re-opens the sub on every
+  // identity-stable render that recomputed the getter. The actual relays
+  // are captured below and re-evaluated when `getReadRelays` reference
+  // changes (which is what the DM sub already keys on).
+  const lastRelaysRef = useRef<string[] | null>(null);
+
+  useEffect(() => {
+    if (!pubkey) return;
+    const readRelays = getReadRelays();
+    lastRelaysRef.current = readRelays;
+    if (readRelays.length === 0) return;
+
+    let cancelled = false;
+    let unsubscribe: (() => void) | null = null;
+    const seen = new Set<string>();
+    const subOpenedAtSec = Math.floor(Date.now() / 1000);
+
+    const handle = (ev: VerifiedEvent): void => {
+      if (cancelled) return;
+      if (seen.has(ev.id)) return;
+      seen.add(ev.id);
+      // Bounded dedup — drop oldest ~25% under sustained pressure (same
+      // pattern as the DM live sub's `seen` Set).
+      if (seen.size > SEEN_CAP) {
+        const drop = Math.floor(SEEN_CAP / 4);
+        const it = seen.values();
+        for (let i = 0; i < drop; i++) seen.delete(it.next().value!);
+      }
+      // Never self-ping — the hider commenting on their own cache is a
+      // maintenance note, not a find we want to surface as a notification.
+      if (ev.pubkey === pubkey) return;
+      // Freshness gate — silent on backlog the relay replays on sub open.
+      if (ev.created_at < subOpenedAtSec - NOTIFY_SKEW_SEC) return;
+
+      // The cache coord rides on the `A` (uppercase) NIP-22 root pointer.
+      // `buildComment` in nostrPlacesService writes both `A` and `a`; we
+      // read `A` because that's what the filter matched on.
+      const coordTag = ev.tags.find((t) => t[0] === 'A')?.[1];
+      if (!coordTag) return;
+      const parsed = parseCacheCoord(coordTag);
+      if (!parsed) return;
+
+      // Generic copy — the lock-screen-content toggle in
+      // notificationService substitutes a generic title/body when the
+      // user opts out of content on the lock screen. The richer
+      // "Find on <cache name> by <finder>" body could be resolved here
+      // by reading the cached ParsedCache + a profile lookup, but
+      // doing so blocks on cache-store + relay round-trips inside an
+      // event handler running on a hot stream. The follow-up is to
+      // resolve those off the hot path and pass them in.
+      void fireCacheNotification({
+        cacheCoord: coordTag,
+        title: 'New find on your cache',
+        body: 'Open Lightning Piggy to view',
+      });
+    };
+
+    // Resolve "my caches" with a one-shot author query, then open the
+    // sub. fetchCachesByAuthor caps internally at 5 s so a slow relay
+    // can't pin the hook on mount.
+    (async () => {
+      try {
+        const myCaches = await fetchCachesByAuthor(pubkey, readRelays);
+        if (cancelled) return;
+        const coords = myCaches.map((c) => c.coord);
+        if (coords.length === 0) return;
+        unsubscribe = subscribeCacheCommentsForCoords({
+          viewerPubkey: pubkey,
+          relays: readRelays,
+          cacheCoords: coords,
+          onEvent: handle,
+        });
+      } catch {
+        // Non-fatal — the background detect-and-ping pass still catches
+        // anything we miss here on the next wake.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsubscribe) unsubscribe();
+    };
+  }, [pubkey, getReadRelays]);
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -23,7 +23,7 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 import { Home, MessageCircle, Compass, Users } from 'lucide-react-native';
 import { useWallet } from '../contexts/WalletContext';
 import { useTheme } from '../contexts/ThemeContext';
-import { setActiveThread } from '../services/notificationService';
+import { setActiveThread, setActiveCache } from '../services/notificationService';
 import {
   RootStackParamList,
   ExploreStackParamList,
@@ -136,6 +136,7 @@ export const navigateFromNotification = (data: {
   conversationPubkey?: string;
   groupId?: string;
   walletId?: string;
+  cacheCoord?: string;
 }): boolean => {
   if (!navigationRef.isReady()) return false;
   if (data.conversationPubkey) {
@@ -146,6 +147,20 @@ export const navigateFromNotification = (data: {
   }
   if (data.groupId) {
     navigationRef.navigate('GroupConversation', { groupId: data.groupId });
+    return true;
+  }
+  // Find-log on one of my caches (#740) → open that cache detail. The
+  // background detect-and-ping path passes the sentinel `__background__`
+  // coord (it didn't resolve to a specific cache) — fall through to the
+  // Geo-caches list in that case instead of pushing a doomed detail.
+  if (data.kind === 'cache') {
+    if (data.cacheCoord && data.cacheCoord !== '__background__') {
+      return navigateToHuntPiggyDetail(data.cacheCoord);
+    }
+    navigationRef.navigate('Main', {
+      screen: 'MainTabs',
+      params: { screen: 'Explore', params: { screen: 'Hunt' } },
+    });
     return true;
   }
   // Generic message ping with no thread id (the background detect-and-ping
@@ -174,6 +189,15 @@ function syncActiveThreadFromNav(): void {
     setActiveThread((route.params as { groupId?: string } | undefined)?.groupId ?? null);
   } else {
     setActiveThread(null);
+  }
+  // Active-cache suppression (#740) — if the focused screen is the
+  // detail view for a specific cache, find-logs against that coord stay
+  // silent. Independent of the thread gate so a DM and a cache can't
+  // collide on the same identifier.
+  if (route?.name === 'HuntPiggyDetail') {
+    setActiveCache((route.params as { coord?: string } | undefined)?.coord ?? null);
+  } else {
+    setActiveCache(null);
   }
 }
 

--- a/src/services/backgroundSyncService.test.ts
+++ b/src/services/backgroundSyncService.test.ts
@@ -6,6 +6,8 @@ const mockQuerySync = jest.fn();
 const mockLoadIdentities = jest.fn();
 const mockGetUserRelays = jest.fn();
 const mockFireMessageNotification = jest.fn().mockResolvedValue('id');
+const mockFireCacheNotification = jest.fn().mockResolvedValue('id');
+const mockFetchCachesByAuthor = jest.fn();
 
 jest.mock('./nostrService', () => ({
   pool: { querySync: (...a: unknown[]) => mockQuerySync(...a) },
@@ -14,6 +16,10 @@ jest.mock('./identitiesStore', () => ({ loadIdentities: () => mockLoadIdentities
 jest.mock('./nostrRelayStorage', () => ({ getUserRelays: () => mockGetUserRelays() }));
 jest.mock('./notificationService', () => ({
   fireMessageNotification: (...a: unknown[]) => mockFireMessageNotification(...a),
+  fireCacheNotification: (...a: unknown[]) => mockFireCacheNotification(...a),
+}));
+jest.mock('./nostrPlacesPublisher', () => ({
+  fetchCachesByAuthor: (...a: unknown[]) => mockFetchCachesByAuthor(...a),
 }));
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -22,6 +28,8 @@ import { runBackgroundSync } from './backgroundSyncService';
 const ME = 'a'.repeat(64);
 const READ_RELAYS = [{ url: 'wss://r.example', read: true, write: true }];
 const SEEN_KEY = 'bg_sync_seen_ids_v1';
+const CACHE_SEEN_KEY = 'bg_sync_seen_cache_comment_ids_v1';
+const MY_CACHE_COORD = `37516:${ME}:my-piggy-d`;
 
 /** Put the service into the "primed" state (baseline established) with an
  * optional set of already-seen ids. Without this a run is the first-ever
@@ -30,18 +38,26 @@ async function prime(ids: string[] = []): Promise<void> {
   await AsyncStorage.setItem(SEEN_KEY, JSON.stringify(ids));
 }
 
+/** Prime the find-log seen-set baseline so the cache-comment pass isn't a
+ * first-ever silent prime. Independent key from `prime` above. */
+async function primeCacheComments(ids: string[] = []): Promise<void> {
+  await AsyncStorage.setItem(CACHE_SEEN_KEY, JSON.stringify(ids));
+}
+
 beforeEach(async () => {
   jest.clearAllMocks();
   await AsyncStorage.clear();
   mockLoadIdentities.mockResolvedValue({ identities: [], activePubkey: ME });
   mockGetUserRelays.mockResolvedValue(READ_RELAYS);
   mockQuerySync.mockResolvedValue([]);
+  // Default: user owns no caches — find-log pass short-circuits.
+  mockFetchCachesByAuthor.mockResolvedValue([]);
 });
 
 it('does nothing when logged out', async () => {
   mockLoadIdentities.mockResolvedValue({ identities: [], activePubkey: null });
   const r = await runBackgroundSync();
-  expect(r).toEqual({ pinged: false, freshCount: 0 });
+  expect(r).toEqual({ pinged: false, freshCount: 0, freshCacheCommentCount: 0 });
   expect(mockQuerySync).not.toHaveBeenCalled();
 });
 
@@ -56,7 +72,7 @@ it('first-ever run primes the baseline silently (no ping) and seeds the seen-set
   const now = Math.floor(Date.now() / 1000);
   mockQuerySync.mockResolvedValue([{ id: 'w1', kind: 1059, pubkey: 'eph', created_at: now }]);
   const r = await runBackgroundSync();
-  expect(r).toEqual({ pinged: false, freshCount: 0 });
+  expect(r).toEqual({ pinged: false, freshCount: 0, freshCacheCommentCount: 0 });
   expect(mockFireMessageNotification).not.toHaveBeenCalled();
   // The wrap we saw is now recorded so it won't ping on a later run.
   const seen = JSON.parse((await AsyncStorage.getItem(SEEN_KEY)) ?? '[]');
@@ -68,7 +84,7 @@ it('pings when a new gift-wrap arrives after the baseline is primed', async () =
   const now = Math.floor(Date.now() / 1000);
   mockQuerySync.mockResolvedValue([{ id: 'w1', kind: 1059, pubkey: 'eph', created_at: now }]);
   const r = await runBackgroundSync();
-  expect(r).toEqual({ pinged: true, freshCount: 1 });
+  expect(r).toEqual({ pinged: true, freshCount: 1, freshCacheCommentCount: 0 });
   expect(mockFireMessageNotification).toHaveBeenCalledTimes(1);
   expect(mockFireMessageNotification.mock.calls[0][0]).toMatchObject({
     kind: 'dm',
@@ -86,13 +102,16 @@ it('detects a backdated new wrap a since/created_at gate would miss (NIP-59)', a
     { id: 'wBack', kind: 1059, pubkey: 'eph', created_at: now - 24 * 60 * 60 },
   ]);
   const r = await runBackgroundSync();
-  expect(r).toEqual({ pinged: true, freshCount: 1 });
+  expect(r).toEqual({ pinged: true, freshCount: 1, freshCacheCommentCount: 0 });
 });
 
 it('queries a window wide enough to span the NIP-59 backdate (>= 2 days)', async () => {
   await prime([]);
   const now = Math.floor(Date.now() / 1000);
   await runBackgroundSync();
+  // The DM querySync call is the first one (the cache-comment pass is
+  // gated on a non-empty author-listing, which the default mock returns
+  // empty for, so it never reaches querySync).
   const sinceArg = (mockQuerySync.mock.calls[0][1] as { since: number }).since;
   expect(now - sinceArg).toBeGreaterThanOrEqual(2 * 24 * 60 * 60);
 });
@@ -121,4 +140,130 @@ it('does not ping when nothing new arrived', async () => {
   const r = await runBackgroundSync();
   expect(r.pinged).toBe(false);
   expect(mockFireMessageNotification).not.toHaveBeenCalled();
+});
+
+// --- Find-log detect-and-ping (#740) -----------------------------------
+
+describe('cache-comment detect-and-ping (#740)', () => {
+  it('short-circuits when the user owns no caches (no query, no ping)', async () => {
+    await prime(['old']);
+    await primeCacheComments(['old']);
+    mockFetchCachesByAuthor.mockResolvedValue([]);
+    const r = await runBackgroundSync();
+    expect(r.freshCacheCommentCount).toBe(0);
+    expect(mockFireCacheNotification).not.toHaveBeenCalled();
+    // The DM pass still fires its own querySync, but the cache pass is
+    // gated before reaching one. We assert no call carries the kind-1111
+    // filter, which is the only one the cache pass would emit.
+    const cacheCalls = mockQuerySync.mock.calls.filter((c) => {
+      const f = c[1] as { kinds?: number[] };
+      return Array.isArray(f.kinds) && f.kinds.includes(1111);
+    });
+    expect(cacheCalls.length).toBe(0);
+  });
+
+  it("queries kind-1111 with #A filter matching the user's cache coords", async () => {
+    await prime(['old']);
+    await primeCacheComments(['old']);
+    mockFetchCachesByAuthor.mockResolvedValue([{ coord: MY_CACHE_COORD }]);
+    // First querySync call is the DM pass; second is the cache pass.
+    mockQuerySync.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    await runBackgroundSync();
+    const cacheCall = mockQuerySync.mock.calls.find((c) => {
+      const f = c[1] as { kinds?: number[] };
+      return Array.isArray(f.kinds) && f.kinds.includes(1111);
+    });
+    expect(cacheCall).toBeDefined();
+    const filter = cacheCall![1] as { kinds: number[]; '#A': string[] };
+    expect(filter.kinds).toEqual([1111]);
+    expect(filter['#A']).toEqual([MY_CACHE_COORD]);
+  });
+
+  it('first-ever cache-comment run primes the baseline silently and seeds the seen-set', async () => {
+    await prime(['old']); // DM baseline primed
+    // No cache-comment baseline yet — first-ever run for that pass.
+    mockFetchCachesByAuthor.mockResolvedValue([{ coord: MY_CACHE_COORD }]);
+    const now = Math.floor(Date.now() / 1000);
+    mockQuerySync
+      .mockResolvedValueOnce([]) // DM pass
+      .mockResolvedValueOnce([{ id: 'c1', kind: 1111, pubkey: 'finder', created_at: now }]);
+    const r = await runBackgroundSync();
+    expect(r.freshCacheCommentCount).toBe(0);
+    expect(mockFireCacheNotification).not.toHaveBeenCalled();
+    const seen = JSON.parse((await AsyncStorage.getItem(CACHE_SEEN_KEY)) ?? '[]');
+    expect(seen).toContain('c1');
+  });
+
+  it('pings when a new find-log arrives after the baseline is primed', async () => {
+    await prime(['old']);
+    await primeCacheComments(['old']);
+    mockFetchCachesByAuthor.mockResolvedValue([{ coord: MY_CACHE_COORD }]);
+    const now = Math.floor(Date.now() / 1000);
+    mockQuerySync
+      .mockResolvedValueOnce([]) // DM pass
+      .mockResolvedValueOnce([{ id: 'c1', kind: 1111, pubkey: 'finder', created_at: now }]);
+    const r = await runBackgroundSync();
+    expect(r).toEqual({ pinged: true, freshCount: 0, freshCacheCommentCount: 1 });
+    expect(mockFireCacheNotification).toHaveBeenCalledTimes(1);
+    expect(mockFireCacheNotification.mock.calls[0][0]).toMatchObject({
+      cacheCoord: '__background__',
+    });
+  });
+
+  it('ignores my own kind-1111 echoes (hider maintenance note, not a find)', async () => {
+    await prime(['old']);
+    await primeCacheComments(['old']);
+    mockFetchCachesByAuthor.mockResolvedValue([{ coord: MY_CACHE_COORD }]);
+    const now = Math.floor(Date.now() / 1000);
+    mockQuerySync
+      .mockResolvedValueOnce([]) // DM pass
+      .mockResolvedValueOnce([{ id: 'c1', kind: 1111, pubkey: ME, created_at: now }]);
+    const r = await runBackgroundSync();
+    expect(r.freshCacheCommentCount).toBe(0);
+    expect(mockFireCacheNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not re-ping a find-log whose id is already seen', async () => {
+    await prime(['old']);
+    await primeCacheComments(['c1']);
+    mockFetchCachesByAuthor.mockResolvedValue([{ coord: MY_CACHE_COORD }]);
+    const now = Math.floor(Date.now() / 1000);
+    mockQuerySync
+      .mockResolvedValueOnce([]) // DM pass
+      .mockResolvedValueOnce([{ id: 'c1', kind: 1111, pubkey: 'finder', created_at: now }]);
+    const r = await runBackgroundSync();
+    expect(r.freshCacheCommentCount).toBe(0);
+    expect(mockFireCacheNotification).not.toHaveBeenCalled();
+  });
+
+  it('uses an independent seen-set from the DM pass (no cross-contamination)', async () => {
+    // Same id in both streams would still ping each pass once — disjoint
+    // seen-sets means the kind-1111 pass doesn't accidentally short-circuit
+    // because a kind-1059 wrap with the same id ran before it.
+    await prime(['shared']);
+    await primeCacheComments(['old']);
+    mockFetchCachesByAuthor.mockResolvedValue([{ coord: MY_CACHE_COORD }]);
+    const now = Math.floor(Date.now() / 1000);
+    mockQuerySync
+      .mockResolvedValueOnce([]) // DM pass — nothing fresh
+      .mockResolvedValueOnce([
+        // Re-using the 'shared' id intentionally.
+        { id: 'shared', kind: 1111, pubkey: 'finder', created_at: now },
+      ]);
+    const r = await runBackgroundSync();
+    expect(r.freshCacheCommentCount).toBe(1);
+    expect(mockFireCacheNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchCachesByAuthor failure does not break the DM pass', async () => {
+    await prime(['old']);
+    mockFetchCachesByAuthor.mockRejectedValue(new Error('boom'));
+    const now = Math.floor(Date.now() / 1000);
+    mockQuerySync.mockResolvedValueOnce([{ id: 'w1', kind: 1059, pubkey: 'eph', created_at: now }]);
+    const r = await runBackgroundSync();
+    expect(r.freshCount).toBe(1);
+    expect(r.freshCacheCommentCount).toBe(0);
+    expect(mockFireMessageNotification).toHaveBeenCalledTimes(1);
+    expect(mockFireCacheNotification).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/backgroundSyncService.ts
+++ b/src/services/backgroundSyncService.ts
@@ -31,13 +31,19 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { pool } from './nostrService';
 import { loadIdentities } from './identitiesStore';
 import { getUserRelays } from './nostrRelayStorage';
-import { fireMessageNotification } from './notificationService';
+import { fireMessageNotification, fireCacheNotification } from './notificationService';
+import { fetchCachesByAuthor } from './nostrPlacesPublisher';
+import { GC_COMMENT_KIND } from './nostrPlacesService';
 
 // Persisted ids we've already accounted for, so repeated wakes never
 // re-ping the same arrival. Bounded (insertion-ordered; oldest dropped
 // past the cap). Its PRESENCE also marks that the baseline has been
 // primed — see the first-run handling in runBackgroundSync.
 const BG_SEEN_IDS_KEY = 'bg_sync_seen_ids_v1';
+// Independent seen-set for kind-1111 find-logs (#740). Kept separate from the
+// DM/wrap seen-set so the two streams can't collide on event ids and so a
+// future cap change to one doesn't silently re-flood the other on next wake.
+const BG_SEEN_CACHE_COMMENT_IDS_KEY = 'bg_sync_seen_cache_comment_ids_v1';
 const SEEN_CAP = 1000;
 
 // NIP-59 tweaks a wrap's `created_at` up to 2 days into the past. Query a
@@ -47,6 +53,14 @@ const NIP59_MAX_BACKDATE_SEC = 2 * 24 * 60 * 60;
 const OVERLAP_SEC = 120;
 const LOOKBACK_SEC = NIP59_MAX_BACKDATE_SEC + OVERLAP_SEC;
 
+// Find-logs (kind-1111) are public, never gift-wrapped — their `created_at`
+// is the genuine publish time. We don't need the NIP-59 backdate cushion,
+// but background wakes are best-effort and infrequent (~15 min floor on
+// Android), so a relay that dropped one earlier still wants picking up on
+// the next pass. A 1-day window dedupes by id against the seen-set and
+// keeps the round-trip cheap.
+const CACHE_COMMENT_LOOKBACK_SEC = 24 * 60 * 60;
+
 // Cap the relay round-trip so a slow/unresponsive relay cannot keep this
 // headless task alive (battery drain + risk of the OS killing/penalising
 // it). nostr-tools closes the sub after maxWait and returns whatever
@@ -55,10 +69,12 @@ const LOOKBACK_SEC = NIP59_MAX_BACKDATE_SEC + OVERLAP_SEC;
 const QUERY_MAXWAIT_MS = 5000;
 
 export interface BackgroundSyncResult {
-  /** Whether a notification was fired this run. */
+  /** Whether a notification was fired this run (any kind). */
   pinged: boolean;
-  /** Count of fresh inbound events detected (0 when nothing new). */
+  /** Count of fresh inbound DM events detected (0 when nothing new). */
   freshCount: number;
+  /** Count of fresh kind-1111 find-logs against my caches (#740). */
+  freshCacheCommentCount: number;
 }
 
 /**
@@ -67,8 +83,10 @@ export interface BackgroundSyncResult {
  * pinging for pre-existing history. A present-but-corrupt value is treated
  * as primed (empty set) so a bad write can't trigger a cold-start flood.
  */
-async function loadSeenIds(): Promise<{ seen: Set<string>; primed: boolean }> {
-  const raw = await AsyncStorage.getItem(BG_SEEN_IDS_KEY).catch(() => null);
+async function loadSeenIds(
+  key: string = BG_SEEN_IDS_KEY,
+): Promise<{ seen: Set<string>; primed: boolean }> {
+  const raw = await AsyncStorage.getItem(key).catch(() => null);
   if (raw == null) return { seen: new Set(), primed: false };
   try {
     const arr: unknown = JSON.parse(raw);
@@ -82,10 +100,10 @@ async function loadSeenIds(): Promise<{ seen: Set<string>; primed: boolean }> {
 }
 
 /** Persist the seen-set, keeping only the most-recent SEEN_CAP ids. */
-async function persistSeenIds(seen: Set<string>): Promise<void> {
+async function persistSeenIds(seen: Set<string>, key: string = BG_SEEN_IDS_KEY): Promise<void> {
   const arr = Array.from(seen); // insertion order → tail is newest
   const bounded = arr.length > SEEN_CAP ? arr.slice(arr.length - SEEN_CAP) : arr;
-  await AsyncStorage.setItem(BG_SEEN_IDS_KEY, JSON.stringify(bounded)).catch(() => {});
+  await AsyncStorage.setItem(key, JSON.stringify(bounded)).catch(() => {});
 }
 
 /**
@@ -94,11 +112,30 @@ async function persistSeenIds(seen: Set<string>): Promise<void> {
  */
 export async function runBackgroundSync(): Promise<BackgroundSyncResult> {
   const { activePubkey } = await loadIdentities();
-  if (!activePubkey) return { pinged: false, freshCount: 0 };
+  if (!activePubkey) return { pinged: false, freshCount: 0, freshCacheCommentCount: 0 };
 
   const readRelays = (await getUserRelays()).filter((r) => r.read).map((r) => r.url);
-  if (readRelays.length === 0) return { pinged: false, freshCount: 0 };
+  if (readRelays.length === 0) return { pinged: false, freshCount: 0, freshCacheCommentCount: 0 };
 
+  // Run the two detect-and-ping passes sequentially — they touch
+  // disjoint persisted seen-sets and disjoint kinds on the relay, so a
+  // failure in one must not poison the other (the catch on each pass is
+  // independent and falls through with a 0 count).
+  const dmResult = await runDmDetectAndPing(activePubkey, readRelays);
+  const cacheResult = await runCacheCommentDetectAndPing(activePubkey, readRelays);
+
+  return {
+    pinged: dmResult.pinged || cacheResult.pinged,
+    freshCount: dmResult.freshCount,
+    freshCacheCommentCount: cacheResult.freshCount,
+  };
+}
+
+/** DM detect-and-ping pass — kind-1059 + kind-4 addressed to the viewer. */
+async function runDmDetectAndPing(
+  activePubkey: string,
+  readRelays: string[],
+): Promise<{ pinged: boolean; freshCount: number }> {
   const { seen, primed } = await loadSeenIds();
   const since = Math.floor(Date.now() / 1000) - LOOKBACK_SEC;
 
@@ -151,6 +188,78 @@ export async function runBackgroundSync(): Promise<BackgroundSyncResult> {
     return { pinged: freshCount > 0, freshCount };
   } catch {
     // Best-effort: a failed relay round-trip just means we retry next wake.
+    return { pinged: false, freshCount: 0 };
+  }
+}
+
+/**
+ * Find-log detect-and-ping pass (#740) — kind-1111 NIP-22 comments whose
+ * `#A` root pointer matches one of the active user's published caches.
+ * Pattern mirrors the DM pass: query a window, dedupe against a persisted
+ * seen-set, fire a single generic notification on fresh arrivals.
+ *
+ * "My caches" comes from a one-shot author-listing query rather than a
+ * persisted snapshot, for two reasons: (a) the background JS context is
+ * disjoint from the foreground React tree, so we can't read NostrContext's
+ * in-memory cache list; (b) author-listings are tiny (kind-37516 by one
+ * pubkey is replaceable and bounded) so the extra round-trip is cheap.
+ * No caches → no filter armed → silent return.
+ */
+async function runCacheCommentDetectAndPing(
+  activePubkey: string,
+  readRelays: string[],
+): Promise<{ pinged: boolean; freshCount: number }> {
+  let myCoords: string[] = [];
+  try {
+    const mine = await fetchCachesByAuthor(activePubkey, readRelays);
+    myCoords = mine.map((c) => c.coord);
+  } catch {
+    // Author-listing failed — skip this pass without poisoning the next.
+    return { pinged: false, freshCount: 0 };
+  }
+  if (myCoords.length === 0) return { pinged: false, freshCount: 0 };
+
+  const { seen, primed } = await loadSeenIds(BG_SEEN_CACHE_COMMENT_IDS_KEY);
+  const since = Math.floor(Date.now() / 1000) - CACHE_COMMENT_LOOKBACK_SEC;
+
+  try {
+    const events = await pool.querySync(
+      readRelays,
+      {
+        kinds: [GC_COMMENT_KIND],
+        '#A': myCoords,
+        since,
+      },
+      { maxWait: QUERY_MAXWAIT_MS },
+    );
+
+    // Genuinely-new = not in the seen-set AND not our own echo (a hider
+    // commenting on their own cache is a maintenance note, not a find we
+    // want to self-ping for).
+    const fresh = events.filter((e) => !seen.has(e.id) && e.pubkey !== activePubkey);
+
+    for (const e of events) seen.add(e.id);
+    await persistSeenIds(seen, BG_SEEN_CACHE_COMMENT_IDS_KEY);
+
+    // First-ever run primes a silent baseline so any historical find-logs
+    // already on the relays don't fire a cold-start flood. Same shape as
+    // the DM pass.
+    if (!primed) return { pinged: false, freshCount: 0 };
+
+    const freshCount = fresh.length;
+    if (freshCount > 0) {
+      await fireCacheNotification({
+        // Sentinel coord — never matches an actively-viewed cache, so the
+        // suppression gate always lets a background ping through. The tap
+        // router falls back to the Geo-caches list when the coord can't
+        // be resolved to a specific detail screen.
+        cacheCoord: '__background__',
+        title: freshCount > 1 ? 'New finds on your caches' : 'New find on your cache',
+        body: 'Open Lightning Piggy to view',
+      });
+    }
+    return { pinged: freshCount > 0, freshCount };
+  } catch {
     return { pinged: false, freshCount: 0 };
   }
 }

--- a/src/services/backgroundSyncService.ts
+++ b/src/services/backgroundSyncService.ts
@@ -217,7 +217,17 @@ async function runCacheCommentDetectAndPing(
     // Author-listing failed — skip this pass without poisoning the next.
     return { pinged: false, freshCount: 0 };
   }
-  if (myCoords.length === 0) return { pinged: false, freshCount: 0 };
+  if (myCoords.length === 0) {
+    // Persist an empty seen-set on the no-cache path so the baseline is
+    // marked as primed — otherwise the very first background pass after
+    // the user publishes their first cache would treat pre-existing
+    // find-logs (within the 1-day window) as baseline (!primed) and
+    // silently swallow them. Idempotent: skip the write if already primed
+    // (a previous run with caches that since vanished). Copilot review #742.
+    const { primed: alreadyPrimed } = await loadSeenIds(BG_SEEN_CACHE_COMMENT_IDS_KEY);
+    if (!alreadyPrimed) await persistSeenIds(new Set(), BG_SEEN_CACHE_COMMENT_IDS_KEY);
+    return { pinged: false, freshCount: 0 };
+  }
 
   const { seen, primed } = await loadSeenIds(BG_SEEN_CACHE_COMMENT_IDS_KEY);
   const since = Math.floor(Date.now() / 1000) - CACHE_COMMENT_LOOKBACK_SEC;

--- a/src/services/cacheNotifySubscription.test.ts
+++ b/src/services/cacheNotifySubscription.test.ts
@@ -1,0 +1,109 @@
+// Tests for the foreground kind-1111 find-log subscription (#740). The
+// nostr-tools pool is mocked so we can assert the filter shape, the empty-
+// coord short-circuit, and the teardown wiring without a real relay.
+
+const mockSubscribeMany = jest.fn();
+const mockClose = jest.fn();
+const mockTrackRelays = jest.fn();
+
+jest.mock('./nostrService', () => ({
+  pool: { subscribeMany: (...a: unknown[]) => mockSubscribeMany(...a) },
+  trackRelays: (...a: unknown[]) => mockTrackRelays(...a),
+}));
+
+import { subscribeCacheCommentsForCoords } from './cacheNotifySubscription';
+import { GC_COMMENT_KIND } from './nostrPlacesService';
+
+const VIEWER = 'a'.repeat(64);
+const RELAYS = ['wss://r.example'];
+const COORDS = [`37516:${VIEWER}:my-piggy-d`, `37516:${VIEWER}:other-d`];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSubscribeMany.mockReturnValue({ close: mockClose });
+});
+
+it('no-ops when cacheCoords is empty (no filter armed, no relay tracking)', () => {
+  const close = subscribeCacheCommentsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: [],
+    onEvent: jest.fn(),
+  });
+  expect(mockSubscribeMany).not.toHaveBeenCalled();
+  expect(mockTrackRelays).not.toHaveBeenCalled();
+  // The returned closer is still callable / a function.
+  expect(typeof close).toBe('function');
+  close();
+  expect(mockClose).not.toHaveBeenCalled();
+});
+
+it("arms the sub with kind-1111 + #A filter on the viewer's cache coords", () => {
+  subscribeCacheCommentsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent: jest.fn(),
+  });
+  expect(mockTrackRelays).toHaveBeenCalledWith(RELAYS);
+  expect(mockSubscribeMany).toHaveBeenCalledTimes(1);
+  const [relaysArg, filterArg] = mockSubscribeMany.mock.calls[0];
+  expect(relaysArg).toEqual(RELAYS);
+  expect(filterArg.kinds).toEqual([GC_COMMENT_KIND]);
+  expect(filterArg['#A']).toEqual(COORDS);
+  expect(typeof filterArg.since).toBe('number');
+  expect(typeof filterArg.limit).toBe('number');
+});
+
+it('caps the lookback to 7 days', () => {
+  const nowSec = Math.floor(Date.now() / 1000);
+  subscribeCacheCommentsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent: jest.fn(),
+  });
+  const filterArg = mockSubscribeMany.mock.calls[0][1] as { since: number };
+  // Should be ~ nowSec − 7 days, with a small tolerance for the second
+  // tick during the test.
+  expect(nowSec - filterArg.since).toBeGreaterThanOrEqual(7 * 24 * 60 * 60 - 5);
+  expect(nowSec - filterArg.since).toBeLessThanOrEqual(7 * 24 * 60 * 60 + 5);
+});
+
+it('returns a teardown that closes the underlying sub', () => {
+  const close = subscribeCacheCommentsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent: jest.fn(),
+  });
+  close();
+  expect(mockClose).toHaveBeenCalledTimes(1);
+});
+
+it("forwards onevent deliveries to the caller's onEvent", () => {
+  const onEvent = jest.fn();
+  subscribeCacheCommentsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent,
+  });
+  const handlers = mockSubscribeMany.mock.calls[0][2] as { onevent: (e: unknown) => void };
+  const fake = { id: 'c1', kind: 1111, pubkey: 'finder', created_at: 1, tags: [], content: '' };
+  handlers.onevent(fake);
+  expect(onEvent).toHaveBeenCalledWith(fake);
+});
+
+it('swallows a teardown exception (best-effort, never throws to caller)', () => {
+  mockClose.mockImplementationOnce(() => {
+    throw new Error('relay went away');
+  });
+  const close = subscribeCacheCommentsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent: jest.fn(),
+  });
+  expect(() => close()).not.toThrow();
+});

--- a/src/services/cacheNotifySubscription.ts
+++ b/src/services/cacheNotifySubscription.ts
@@ -1,0 +1,83 @@
+/**
+ * cacheNotifySubscription — live foreground subscription for kind-1111
+ * NIP-22 find-logs against the active user's published geo-caches (#740).
+ *
+ * Mirrors the shape of `dmLiveSubscription`. Returns a teardown function
+ * the caller invokes on cleanup. Empty `cacheCoords` short-circuits — a
+ * filter with no `#A` values would be a free firehose request and most
+ * relays reject it.
+ *
+ * Find-log events are public (no decryption), so unlike the DM live sub
+ * there is no signer dependency. The single filter shape is
+ *
+ *   { kinds: [1111], '#A': cacheCoords, since: now - 7d, limit: ... }
+ *
+ * — `#A` uppercase because that's the NIP-22 root-pointer tag used by
+ * `buildComment` in `nostrPlacesService.ts`. The 7-day floor matches the
+ * DM live sub: enough that "I haven't opened the app for a week" still
+ * catches recent activity, capped so cold-start restream cost stays
+ * bounded even if the user owns many caches. Per-event freshness is
+ * gated by the caller using `subOpenedAtSec`-style timestamp checks
+ * (same pattern as DMs), NOT by EOSE — so a slow relay replaying backlog
+ * late cannot reintroduce a notification flood.
+ */
+import type { VerifiedEvent } from 'nostr-tools';
+import type { Filter } from 'nostr-tools/filter';
+import { pool, trackRelays } from './nostrService';
+import { GC_COMMENT_KIND } from './nostrPlacesService';
+
+// Match the dmLiveSubscription cap — past 7 days is a different problem
+// (handled by background detect-and-ping with a separate seen-set).
+const CACHE_LIVE_SUB_MAX_LOOKBACK_SECONDS = 7 * 24 * 60 * 60;
+
+// Cap the relay response so a cache with a viral comment thread cannot
+// pin the JS thread on sub open. 500 is more than enough to catch any
+// realistic burst and is what we'd want to surface in the inbox-style
+// "new finds" notification path anyway.
+const CACHE_LIVE_SUB_LIMIT = 500;
+
+export interface CacheNotifySubscriptionInput {
+  /** The active viewer's hex pubkey. Tracked for invariants and future
+   * per-account dedup; the filter itself uses `cacheCoords` not pubkey
+   * (kind-1111 finders can be anyone, including non-followed users). */
+  viewerPubkey: string;
+  /** Read relays the subscription opens against. */
+  relays: string[];
+  /** `<kind>:<pubkey>:<d>` addressable coordinates of the caches the
+   * viewer owns. Empty → the subscription is a no-op (no filter armed). */
+  cacheCoords: string[];
+  /** Fires for every kind-1111 event matching the filter. The caller is
+   * responsible for freshness gating, dedup, and notification fire. */
+  onEvent: (event: VerifiedEvent) => void;
+}
+
+/**
+ * Open the live kind-1111 subscription for the viewer's caches and
+ * return a teardown function. Idempotent: caller decides when to call.
+ */
+export function subscribeCacheCommentsForCoords(input: CacheNotifySubscriptionInput): () => void {
+  if (input.cacheCoords.length === 0) {
+    // No caches — nothing to watch. Returning a no-op closer keeps the
+    // caller's effect cleanup simple.
+    return () => {};
+  }
+  trackRelays(input.relays);
+  const nowSec = Math.floor(Date.now() / 1000);
+  const sinceSec = nowSec - CACHE_LIVE_SUB_MAX_LOOKBACK_SECONDS;
+  const filter: Filter = {
+    kinds: [GC_COMMENT_KIND],
+    '#A': input.cacheCoords,
+    since: sinceSec,
+    limit: CACHE_LIVE_SUB_LIMIT,
+  };
+  const sub = pool.subscribeMany(input.relays, filter, {
+    onevent: (e) => input.onEvent(e as VerifiedEvent),
+  });
+  return () => {
+    try {
+      sub.close();
+    } catch {
+      // best-effort — same swallow as the DM live sub.
+    }
+  };
+}

--- a/src/services/notificationService.test.ts
+++ b/src/services/notificationService.test.ts
@@ -20,9 +20,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   setNotificationsForeground,
   setActiveThread,
+  setActiveCache,
   isThreadActivelyViewed,
+  isCacheActivelyViewed,
   fireMessageNotification,
   firePaymentNotification,
+  fireCacheNotification,
   setLockScreenContentEnabled,
   __resetForTests,
 } from './notificationService';
@@ -149,6 +152,109 @@ describe('firePaymentNotification', () => {
     setNotificationsForeground(true);
     setActiveThread('anything');
     const id = await firePaymentNotification({ kind: 'payment', amountSats: 42 });
+    expect(id).toBe('notif-id');
+    expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+  });
+});
+
+// --- Find-log notifications (#740) -----------------------------------
+
+describe('active-cache suppression (#740)', () => {
+  it('is active only when foreground AND the coord matches', () => {
+    setNotificationsForeground(true);
+    setActiveCache('37516:abc:my-cache');
+    expect(isCacheActivelyViewed('37516:abc:my-cache')).toBe(true);
+    expect(isCacheActivelyViewed('37516:abc:other-cache')).toBe(false);
+  });
+
+  it('is never active while backgrounded, even on the open cache', () => {
+    setActiveCache('37516:abc:my-cache');
+    setNotificationsForeground(false);
+    expect(isCacheActivelyViewed('37516:abc:my-cache')).toBe(false);
+  });
+
+  it('clears when the active cache is unset (screen blur)', () => {
+    setNotificationsForeground(true);
+    setActiveCache('37516:abc:my-cache');
+    setActiveCache(null);
+    expect(isCacheActivelyViewed('37516:abc:my-cache')).toBe(false);
+  });
+
+  it('independent of the active-thread state (a coord matching a thread id does not suppress)', () => {
+    setNotificationsForeground(true);
+    setActiveThread('shared-id');
+    expect(isCacheActivelyViewed('shared-id')).toBe(false);
+    setActiveCache('shared-id');
+    expect(isCacheActivelyViewed('shared-id')).toBe(true);
+    expect(isThreadActivelyViewed('shared-id')).toBe(true);
+  });
+});
+
+describe('fireCacheNotification', () => {
+  it('suppresses (no schedule) when the user is viewing that exact cache', async () => {
+    setNotificationsForeground(true);
+    setActiveCache('37516:abc:my-cache');
+    const id = await fireCacheNotification({
+      cacheCoord: '37516:abc:my-cache',
+      title: 'Find on My Cache',
+      body: 'finderName found it',
+    });
+    expect(id).toBeNull();
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('fires for a different cache than the one being viewed', async () => {
+    setNotificationsForeground(true);
+    setActiveCache('37516:abc:my-cache');
+    await fireCacheNotification({
+      cacheCoord: '37516:abc:other-cache',
+      title: 'Find on Other Cache',
+      body: 'someone found it',
+    });
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    // kind always rides in data for the tap-router; coord is the payload.
+    expect(lastScheduledContent()?.data).toMatchObject({
+      kind: 'cache',
+      cacheCoord: '37516:abc:other-cache',
+    });
+  });
+
+  it('uses generic copy when the lock-screen-content toggle is off (default)', async () => {
+    await fireCacheNotification({
+      cacheCoord: '37516:abc:my-cache',
+      title: 'Find on My Cache',
+      body: 'finderName · "got it!"',
+    });
+    const content = lastScheduledContent();
+    expect(content?.title).toBe('New find on your cache');
+    expect(content?.body).toBe('Open Lightning Piggy to view');
+    // The coord still rides in data for the tap router to pick up on
+    // unlock — only the human-readable title/body is redacted.
+    expect(content?.data).toMatchObject({ kind: 'cache', cacheCoord: '37516:abc:my-cache' });
+  });
+
+  it('uses the real title/body once the user opts in', async () => {
+    await setLockScreenContentEnabled(true);
+    await fireCacheNotification({
+      cacheCoord: '37516:abc:my-cache',
+      title: 'Find on Treasure Pig',
+      body: 'alice · "thanks!"',
+    });
+    const content = lastScheduledContent();
+    expect(content?.title).toBe('Find on Treasure Pig');
+    expect(content?.body).toBe('alice · "thanks!"');
+  });
+
+  it('background sentinel coord (__background__) never matches a real active cache', async () => {
+    // Whatever the user is currently viewing, a background ping with the
+    // sentinel must always get through (it never matches a real coord).
+    setNotificationsForeground(true);
+    setActiveCache('37516:abc:any-real-cache');
+    const id = await fireCacheNotification({
+      cacheCoord: '__background__',
+      title: 'New find on your cache',
+      body: 'Open Lightning Piggy to view',
+    });
     expect(id).toBe('notif-id');
     expect(mockScheduleNotificationAsync).toHaveBeenCalled();
   });

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -60,7 +60,7 @@ const PERMISSION_REQUESTED_KEY = 'notif_pref_permission_asked_v1';
  * Add a new kind here BEFORE adding a new caller — keeps the routing
  * logic exhaustive.
  */
-export type NotificationKind = 'dm' | 'group' | 'payment' | 'zap';
+export type NotificationKind = 'dm' | 'group' | 'payment' | 'zap' | 'cache';
 
 /** Tap-routing data shipped with every notification. The deep-link
  * router (TODO — follow-up) reads these on tap to navigate to the
@@ -70,11 +70,15 @@ export type NotificationKind = 'dm' | 'group' | 'payment' | 'zap';
  *  - group     → groupId (open the group thread)
  *  - payment   → walletId (open that wallet's history)
  *  - zap       → conversationPubkey OR groupId (zap context)
+ *  - cache     → cacheCoord (open the cache detail; #740)
  */
 export interface NotificationData {
   conversationPubkey?: string;
   groupId?: string;
   walletId?: string;
+  /** `<kind>:<pubkey>:<d>` coordinate of the geo-cache the find-log
+   * targets. Read on tap to open HuntPiggyDetail (#740). */
+  cacheCoord?: string;
 }
 
 /** Typed payload every caller passes to `fireNotification`. Centralising
@@ -226,11 +230,22 @@ export async function setLockScreenContentEnabled(enabled: boolean): Promise<voi
   await AsyncStorage.setItem(LOCK_SCREEN_CONTENT_KEY, enabled ? 'true' : 'false').catch(() => {});
 }
 
-/** Map a `NotificationKind` to the Android channel id it should fire on. */
+/** Map a `NotificationKind` to the Android channel id it should fire on.
+ *
+ * `cache` (find-logs on the user's geo-caches, #740) deliberately rides on
+ * the existing Messages channel rather than introducing a third channel.
+ * A new channel would orphan every user's existing per-channel mute
+ * settings, and a find-log is conversationally similar to a DM (someone
+ * pinging you about something you published) — the user who muted
+ * Messages almost certainly wants find-logs muted too. If demand for an
+ * independent "Hunt" channel surfaces, add it later with a careful
+ * migration; until then sharing the channel is the lower-friction default.
+ */
 function channelForKind(kind: NotificationKind): string {
   switch (kind) {
     case 'dm':
     case 'group':
+    case 'cache':
       return CHANNEL_MESSAGES;
     case 'payment':
     case 'zap':
@@ -252,6 +267,8 @@ function genericFor(kind: NotificationKind): { title: string; body: string } {
       return { title: 'Payment received', body: 'Open Lightning Piggy for details' };
     case 'zap':
       return { title: 'Zap received', body: 'Open Lightning Piggy for details' };
+    case 'cache':
+      return { title: 'New find on your cache', body: 'Open Lightning Piggy to view' };
   }
 }
 
@@ -322,6 +339,11 @@ export async function fireNotification(payload: NotificationPayload): Promise<st
 // arriving is always worth surfacing.
 let appInForeground = true;
 let activeThreadId: string | null = null;
+// #740: same idea as `activeThreadId` but keyed on the cache coordinate
+// (`<kind>:<pubkey>:<d>`) so a find-log fired while the user is on that
+// exact HuntPiggyDetail screen stays quiet. Kept independent of the
+// thread id so a cache and a DM thread never collide on the same value.
+let activeCacheCoord: string | null = null;
 
 /** Called by the app root on AppState change. */
 export function setNotificationsForeground(active: boolean): void {
@@ -339,6 +361,19 @@ export function setActiveThread(threadId: string | null): void {
 /** True when the app is foreground AND the user is viewing `threadId`. */
 export function isThreadActivelyViewed(threadId: string): boolean {
   return appInForeground && activeThreadId === threadId;
+}
+
+/**
+ * Called by HuntPiggyDetail / the navigation focus sync on focus (with the
+ * cache coord) and on blur (with `null`). Mirrors `setActiveThread` (#740).
+ */
+export function setActiveCache(cacheCoord: string | null): void {
+  activeCacheCoord = cacheCoord;
+}
+
+/** True when the app is foreground AND the user is viewing `cacheCoord`. */
+export function isCacheActivelyViewed(cacheCoord: string): boolean {
+  return appInForeground && activeCacheCoord === cacheCoord;
 }
 
 /**
@@ -360,6 +395,33 @@ export async function fireMessageNotification(opts: {
     title: opts.title,
     body: opts.body,
     data: opts.data,
+  });
+}
+
+/**
+ * Fire a find-log notification (#740) — someone published a kind-1111
+ * comment against one of the user's geo-caches (Piglet or vanilla
+ * NIP-GC). Suppressed when the user is actively viewing the cache's
+ * detail screen. `cacheCoord` is the addressable `<kind>:<pubkey>:<d>`
+ * triple of the cache and is what the tap-router reads back to open
+ * HuntPiggyDetail.
+ *
+ * The detect-and-ping background path (`runBackgroundSync`) calls this
+ * with the sentinel `cacheCoord: '__background__'` — that value never
+ * matches a real route, so the suppression gate always lets the ping
+ * through and the router falls back to the Geo-caches list.
+ */
+export async function fireCacheNotification(opts: {
+  cacheCoord: string;
+  title: string;
+  body: string;
+}): Promise<string | null> {
+  if (isCacheActivelyViewed(opts.cacheCoord)) return null;
+  return fireNotification({
+    kind: 'cache',
+    title: opts.title,
+    body: opts.body,
+    data: { cacheCoord: opts.cacheCoord },
   });
 }
 
@@ -393,4 +455,5 @@ export function __resetForTests(): void {
   cachedLockScreenContent = null;
   appInForeground = true;
   activeThreadId = null;
+  activeCacheCoord = null;
 }


### PR DESCRIPTION
Extends the OS-notification system (#279 / #282) — previously DM + payment only — to also ping when someone publishes a **kind-1111 NIP-22 find-log** against one of the active user's published geo-caches (Piglets or vanilla NIP-GC caches).

## Live foreground sub
- New `src/services/cacheNotifySubscription.ts` — sibling to `dmLiveSubscription.ts`. Opens a kind-1111 sub with `#A` matching the viewer's cache coordinates. 7-day lookback floor (matches the DM live sub); per-event `created_at` freshness gate keeps the relay's historical replay silent.
- New `src/contexts/useCacheNotifications.ts` — composes the sub into `NostrContext` in one line. Resolves "my caches" via a one-shot `fetchCachesByAuthor` per identity / read-relays change. Bounded session dedup (1k cap); ignores self-echoes and backlog.

## Background detect-and-ping
- `backgroundSyncService.runBackgroundSync` now runs an **independent cache-comment pass** after the DM pass. Its own persisted seen-set (`bg_sync_seen_cache_comment_ids_v1`) so the two streams can't collide on event ids and so a future cap change to one doesn't silently re-flood the other on next wake. First-ever run primes silently (no cold-start flood); sentinel `cacheCoord: '__background__'` keeps the suppression gate honest.

## Notification service
- Extends `NotificationKind` with `'cache'`, adds `cacheCoord` to `NotificationData`, adds `setActiveCache` / `isCacheActivelyViewed`, adds `fireCacheNotification`.
- **Rides the existing Messages channel** rather than adding a new "Hunt" channel. Adding a third channel would orphan every user's existing per-channel mute settings, and a find-log is conversationally similar to a DM (someone pinging you about something you published). If demand for an independent channel surfaces, add it later with a careful migration.
- **Generic copy by default** ("New find on your cache" / "Open Lightning Piggy to view") when the lock-screen-content toggle is OFF; richer copy passed through when ON. The follow-up to resolve cache-name + finder-display-name into the body is noted in the hook comment — doing it inside the hot event handler would block on cache-store + relay round-trips.

## Tap-routing + active-view suppression
- `navigateFromNotification` routes `kind: 'cache'` → `HuntPiggyDetail` via the existing `navigateToHuntPiggyDetail` (with the same Explore-stack seeding so Back walks through Geo-caches). The sentinel coord falls through to the Geo-caches list rather than pushing a doomed detail screen.
- `syncActiveThreadFromNav` also drives `setActiveCache` from the focused `HuntPiggyDetail` route, so a find-log fired while the user is on that exact cache detail screen stays silent. Independent of the thread gate so a DM and a cache coord can't collide on the same identifier.

## File-size discipline
- New logic lives in dedicated files (`cacheNotifySubscription.ts`, `useCacheNotifications.ts`). `NostrContext.tsx` grew by 6 lines (1811 → 1817; baseline 1879). `backgroundSyncService.ts` 156 → 265; `notificationService.ts` 396 → 459 — both well under cap. No new inline `StyleSheet.create`.

## Tests
- New `src/services/cacheNotifySubscription.test.ts` — empty-coord short-circuit, filter shape (`kinds: [1111]`, `#A`), 7-day lookback cap, teardown closes the sub, swallowed teardown exception.
- Extended `notificationService.test.ts` — active-cache suppression matrix, generic vs rich copy, sentinel-coord-never-suppressed, independence from active-thread state.
- Extended `backgroundSyncService.test.ts` — short-circuit when user owns no caches; kind-1111 + `#A` filter shape; first-ever-run primes silently; pings on fresh arrival; self-echoes ignored; dedup against seen-set; disjoint seen-sets between DM and cache passes; DM pass survives a `fetchCachesByAuthor` failure.

832 tests pass total. `npx tsc --noEmit`, `npx eslint`, `npx prettier --check`, and `bash scripts/check-file-size.sh` all pass with no new errors.

Closes #740

## Test plan
- **Foreground**: publish a kind-1111 find-log against one of my caches from another account → one OS notification fires on the Messages channel within seconds; tap opens the cache detail.
- **Active-view suppression**: same scenario while I'm on that cache's detail screen → no notification.
- **Background**: same scenario with the app backgrounded → notification arrives on the next periodic background-sync wake (~15 min worst case on Android), matching the DM detect-and-ping shape.
- **Lock-screen privacy OFF (default)** → generic "New find on your cache" copy.
- **Lock-screen privacy ON** → the title/body passed by the caller is preserved.
- **No caches owned** → cache-comment background pass short-circuits (no relay query, no ping).
- **Self-find** → no notification (hider's own kind-1111 against their own cache is a maintenance note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)