### PR TITLE
perf(nostr): skip-set for non-inbox NIP-17 wraps cuts warm refreshDmInbox (#743)

### DIFF
--- a/src/contexts/nostrDmCache.ts
+++ b/src/contexts/nostrDmCache.ts
@@ -32,6 +32,59 @@ export const wrapCacheFileName = (key: string): string => `${key}.json`;
 // Legacy AsyncStorage key from the now-removed "Enable NIP-17 on Amber" toggle (#404). Cleared on logout so old installs don't leave dead bytes around.
 export const AMBER_NIP17_ENABLED_KEY_LEGACY = 'amber_nip17_enabled';
 
+// Negative-result skip-set: wrap ids that were decrypted in a prior
+// refresh but produced no inbox entry — because the rumor was a group
+// message (routed to group storage) or from a non-followed sender. On
+// subsequent warm refreshes the relay re-delivers the same wraps and
+// the decrypt loop re-pays the schnorr + NIP-44 cost for each one.
+// Persisting the skip-set lets the loop short-circuit without
+// re-decrypting. Only the wrap *id* (a public nonce on the sealed
+// outer envelope) is stored — no plaintext, no sender pubkey.
+// Invariant: a wrap id is added to the skip-set ONLY after a successful
+// decrypt proves it carries a non-inbox rumor; failed decrypts (wrong
+// key, corrupt wrap) are left out so the next refresh retries them.
+// Cap matches the positive cache to prevent unbounded growth.
+export const NSEC_NIP17_SKIP_KEY_BASE = 'nsec_nip17_skip_v1';
+export const AMBER_NIP17_SKIP_KEY_BASE = 'amber_nip17_skip_v1';
+export const NIP17_SKIP_CAP = 50_000;
+
+/** Load and parse the skip-set from its file, returning an empty Set on
+ * any failure (missing file, corrupt JSON). The outer Set is O(1) lookup
+ * vs the per-entry object used by the positive cache — a tiny extra
+ * allocation but nicer ergonomics for `has(id)` + `add(id)`. */
+export async function loadNip17SkipSet(storageKey: string): Promise<Set<string>> {
+  try {
+    const f = new File(Paths.document, wrapCacheFileName(storageKey));
+    if (!f.exists) return new Set<string>();
+    const raw = await f.text();
+    const arr: unknown = JSON.parse(raw);
+    if (Array.isArray(arr)) return new Set<string>(arr as string[]);
+  } catch {
+    // Treat corrupt file as empty — the next refresh repopulates it.
+  }
+  return new Set<string>();
+}
+
+/** Persist the skip-set to its per-account file. Enforces NIP17_SKIP_CAP
+ * by dropping the first (oldest-inserted) entries when over the limit —
+ * insertion order of a Set is stable in JS so oldest goes first. Write
+ * failures are surfaced as a warn so a broken storage subsystem isn't
+ * silent. */
+export async function writeNip17SkipSet(storageKey: string, set: Set<string>): Promise<void> {
+  // Trim to cap before persisting — keep the newest (end of insertion
+  // order) because recently-skipped wraps are more likely to re-appear.
+  let arr = Array.from(set);
+  if (arr.length > NIP17_SKIP_CAP) arr = arr.slice(arr.length - NIP17_SKIP_CAP);
+  try {
+    const f = new File(Paths.document, wrapCacheFileName(storageKey));
+    if (f.exists) f.delete();
+    f.create();
+    f.write(JSON.stringify(arr));
+  } catch (err) {
+    console.warn(`[Nostr] NIP-17 skip-set file write failed (${storageKey}):`, err);
+  }
+}
+
 /** Persistent wrap-id → DmInboxEntry cache. Only ever contains rumors
  * from followed senders — see refreshDmInbox's filter gate. */
 export type Nip17CacheEntry = DmInboxEntry & { wrapId: string };

--- a/src/contexts/nostrDmCacheSkipSet.test.ts
+++ b/src/contexts/nostrDmCacheSkipSet.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the NIP-17 negative-result skip-set (#743).
+ *
+ * The skip-set persists wrap ids that were successfully decrypted in a
+ * prior `refreshDmInbox` pass but produced no inbox entry — because the
+ * rumor was a group message (routed elsewhere) or from a non-followed
+ * sender. On subsequent warm refreshes the skip-set lets the loop
+ * short-circuit before paying the NIP-44 decrypt cost again.
+ *
+ * Tests cover:
+ *   - `loadNip17SkipSet` — returns empty Set on missing/corrupt file.
+ *   - `writeNip17SkipSet` — persists the Set as a JSON array, enforces
+ *     the NIP17_SKIP_CAP by dropping the oldest (front) entries.
+ *   - `loadNip17SkipSet` round-trip — loaded Set matches what was written.
+ *   - Cap enforcement — entries beyond NIP17_SKIP_CAP are trimmed from
+ *     the front (oldest-inserted) before writing.
+ *
+ * expo-file-system is mocked so the tests run in Jest without a native
+ * runtime. The mock captures the last `write()` call so round-trip tests
+ * can inspect what would have been persisted.
+ */
+
+// --- expo-file-system mock -------------------------------------------
+//
+// `nostrDmCache.ts` constructs `new File(Paths.document, filename)` and
+// calls `f.exists`, `f.text()`, `f.delete()`, `f.create()`, `f.write()`.
+// We provide a per-test in-memory store so each test starts clean.
+//
+// The mock is hoisted before the import so jest.mock(...) evaluates
+// before the module under test is loaded.
+
+const fileStore: Record<string, string> = {};
+
+jest.mock('expo-file-system', () => {
+  const MockFile = class {
+    private path: string;
+    constructor(_dir: string, name: string) {
+      this.path = name;
+    }
+    get exists(): boolean {
+      return Object.prototype.hasOwnProperty.call(fileStore, this.path);
+    }
+    async text(): Promise<string> {
+      return fileStore[this.path] ?? '';
+    }
+    delete(): void {
+      delete fileStore[this.path];
+    }
+    create(): void {
+      // no-op — write() will populate
+    }
+    write(data: string): void {
+      fileStore[this.path] = data;
+    }
+  };
+  return {
+    File: MockFile,
+    Paths: { document: '/mock/document' },
+  };
+});
+
+// AsyncStorage mock (required by nostrDmCache imports)
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+// --- imports (after mocks) -------------------------------------------
+import { loadNip17SkipSet, writeNip17SkipSet, NIP17_SKIP_CAP } from './nostrDmCache';
+
+beforeEach(() => {
+  // Clear the in-memory file store so tests are independent.
+  for (const k of Object.keys(fileStore)) delete fileStore[k];
+});
+
+describe('loadNip17SkipSet', () => {
+  it('returns an empty Set when the file does not exist', async () => {
+    const set = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(set).toBeInstanceOf(Set);
+    expect(set.size).toBe(0);
+  });
+
+  it('returns an empty Set when the file contains invalid JSON', async () => {
+    // Seed a corrupt file directly into the store.
+    fileStore['nsec_nip17_skip_v1_aabbcc.json'] = 'not-json{{{';
+    const set = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(set.size).toBe(0);
+  });
+
+  it('returns an empty Set when the file contains a non-array JSON value', async () => {
+    fileStore['nsec_nip17_skip_v1_aabbcc.json'] = '{"a":1}';
+    const set = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(set.size).toBe(0);
+  });
+
+  it('hydrates correctly from a valid persisted array', async () => {
+    fileStore['nsec_nip17_skip_v1_aabbcc.json'] = JSON.stringify(['id1', 'id2', 'id3']);
+    const set = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(set.size).toBe(3);
+    expect(set.has('id1')).toBe(true);
+    expect(set.has('id2')).toBe(true);
+    expect(set.has('id3')).toBe(true);
+  });
+});
+
+describe('writeNip17SkipSet', () => {
+  it('persists the Set as a JSON array readable by loadNip17SkipSet', async () => {
+    const set = new Set(['wrap-a', 'wrap-b', 'wrap-c']);
+    await writeNip17SkipSet('nsec_nip17_skip_v1_aabbcc', set);
+    const loaded = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(loaded.size).toBe(3);
+    expect(loaded.has('wrap-a')).toBe(true);
+    expect(loaded.has('wrap-b')).toBe(true);
+    expect(loaded.has('wrap-c')).toBe(true);
+  });
+
+  it('overwrites a previous write (no stale entries after update)', async () => {
+    const first = new Set(['old-wrap']);
+    await writeNip17SkipSet('nsec_nip17_skip_v1_aabbcc', first);
+
+    const second = new Set(['new-wrap-1', 'new-wrap-2']);
+    await writeNip17SkipSet('nsec_nip17_skip_v1_aabbcc', second);
+
+    const loaded = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(loaded.size).toBe(2);
+    expect(loaded.has('old-wrap')).toBe(false);
+    expect(loaded.has('new-wrap-1')).toBe(true);
+  });
+
+  it('enforces NIP17_SKIP_CAP by dropping oldest (front) entries', async () => {
+    // Build a Set just over the cap.
+    const set = new Set<string>();
+    const total = NIP17_SKIP_CAP + 50;
+    for (let i = 0; i < total; i++) set.add(`wrap-${i}`);
+
+    await writeNip17SkipSet('nsec_nip17_skip_v1_aabbcc', set);
+    const loaded = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+
+    // Exactly NIP17_SKIP_CAP entries survive.
+    expect(loaded.size).toBe(NIP17_SKIP_CAP);
+    // Oldest 50 entries (wrap-0 … wrap-49) are dropped.
+    for (let i = 0; i < 50; i++) expect(loaded.has(`wrap-${i}`)).toBe(false);
+    // Newest 50 entries survive.
+    for (let i = total - 50; i < total; i++) expect(loaded.has(`wrap-${i}`)).toBe(true);
+  });
+
+  it('writes an empty array when given an empty Set (no file content error)', async () => {
+    await writeNip17SkipSet('nsec_nip17_skip_v1_aabbcc', new Set());
+    const loaded = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(loaded.size).toBe(0);
+  });
+});
+
+describe('skip-set round-trip', () => {
+  it('survives a write → load cycle with a large realistic set', async () => {
+    const ids = Array.from({ length: 200 }, (_, i) => `aabbcc${i.toString(16).padStart(4, '0')}`);
+    const set = new Set(ids);
+    await writeNip17SkipSet('nsec_nip17_skip_v1_aabbcc', set);
+    const loaded = await loadNip17SkipSet('nsec_nip17_skip_v1_aabbcc');
+    expect(loaded.size).toBe(200);
+    for (const id of ids) expect(loaded.has(id)).toBe(true);
+  });
+});

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -28,9 +28,13 @@ import {
 import {
   AMBER_NIP17_CACHE_KEY_BASE,
   NSEC_NIP17_CACHE_KEY_BASE,
+  AMBER_NIP17_SKIP_KEY_BASE,
+  NSEC_NIP17_SKIP_KEY_BASE,
   type Nip17CacheEntry,
   safeParseRecord,
   writeNip17Cache,
+  loadNip17SkipSet,
+  writeNip17SkipSet,
   DM_INBOX_REFRESH_TTL_MS,
   DM_INBOX_CAP,
   DM_CONV_CAP,
@@ -266,6 +270,12 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // multi-second freezes that coincide with this call. #554.
       const __perfBlockStart = performance.now();
       const signal = opts?.signal;
+      // When true, the negative-result skip-set is bypassed so wraps that
+      // were previously skipped (non-follows, group routes) get re-evaluated
+      // against the current follow set. Necessary because a user who follows
+      // a new contact should see their older wraps surface on the next
+      // pull-to-refresh, not remain silently skipped. (#743)
+      const forceRefresh = opts?.force === true;
       // Dev-only "Following only=off" bypass — read once at the top so
       // the closure captures a stable value across the async work below.
       // When true, all six follow-gate `continue`s in the decrypt loops
@@ -322,6 +332,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           let nip17Misses = 0;
           let nip17Evictions = 0;
           let nip17CacheSize = 0;
+          // Wraps short-circuited by the negative-result skip-set (#743).
+          // Counted separately from positive-cache hits so we can see
+          // how much decrypt work the skip-set is saving per refresh.
+          let nip17SkipHits = 0;
           // Number of actual `setTimeout(0)` yields the NIP-17 loop
           // performed this refresh — emitted in the [Perf] nip17-cache
           // line so we can track how often the new frame-budget
@@ -458,11 +472,24 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
               // filter gate below. This is the fix for #176. Per-account
               // namespaced (#288).
               const nsecCacheKey = perAccountKey(NSEC_NIP17_CACHE_KEY_BASE, refreshForPubkey);
-              const raw = await safeGetDmCacheItem(nsecCacheKey);
+              // Negative-result skip-set: wrap ids that were successfully
+              // decrypted in a prior refresh but produced no inbox entry
+              // (group rumor or non-followed sender). The relay re-delivers
+              // the same wraps on every warm refresh and each miss pays the
+              // full NIP-44 schnorr + decrypt cost again. Persisting the
+              // set lets the loop short-circuit to a Set.has(id) check.
+              // Only the wrap id (a public nonce on the outer envelope) is
+              // stored — no plaintext, no sender pubkey. (#743)
+              const nsecSkipKey = perAccountKey(NSEC_NIP17_SKIP_KEY_BASE, refreshForPubkey);
+              const [raw, skipSet] = await Promise.all([
+                safeGetDmCacheItem(nsecCacheKey),
+                loadNip17SkipSet(nsecSkipKey),
+              ]);
               const cache = safeParseRecord<Nip17CacheEntry>(raw);
               const newlyCached: Nip17CacheEntry[] = [];
               let unfollowedPurged = 0;
               let touched = 0;
+              let skipSetDirty = false;
               // Frame-budget scheduler (#532): yield whenever we've held
               // the JS thread for >= DECRYPT_FRAME_BUDGET_MS, with the
               // count-based modulo kept as a safety cap. On abort, the
@@ -512,6 +539,15 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                     });
                     continue;
                   }
+                  // Skip-set hit: this wrap was previously decrypted and
+                  // found to carry a group rumor or a non-followed sender —
+                  // short-circuit without re-paying the NIP-44 decrypt cost.
+                  // Bypassed on force-refresh so a newly-followed contact's
+                  // older wraps get re-evaluated. (#743)
+                  if (!forceRefresh && skipSet.has(wrap.id)) {
+                    nip17SkipHits++;
+                    continue;
+                  }
                   nip17Misses++;
                   const rumor = unwrapWrapNsec(wrap, secretKey, onSkip);
                   // No per-decrypt yield here: the frame-budget scheduler
@@ -524,13 +560,29 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                   // never sees group messages — they belong to a different
                   // surface (GroupConversationScreen).
                   const routeResult = await tryRouteGroupRumor(rumor, refreshForPubkey, wrap.id);
-                  if (routeResult.kind !== 'not-group') continue;
+                  if (routeResult.kind !== 'not-group') {
+                    // Successful decrypt, no inbox entry — add to skip-set
+                    // so subsequent refreshes don't re-decrypt. (#743)
+                    skipSet.add(wrap.id);
+                    skipSetDirty = true;
+                    continue;
+                  }
                   const partnership = partnerFromRumor(rumor, refreshForPubkey);
                   if (!partnership) continue;
                   // B1 — drop non-follows at the data layer. No caching, no
                   // state. The filter is load-bearing ("parental control"),
                   // so it runs here not in the view.
-                  if (!passesFollowGate(partnership.partnerPubkey)) continue;
+                  if (!passesFollowGate(partnership.partnerPubkey)) {
+                    // Successful decrypt, non-followed sender — add to
+                    // skip-set. If the user later follows this sender the
+                    // skip-set is not invalidated: the live NIP-17 sub
+                    // delivers new wraps in real time, and pull-to-refresh
+                    // (force: true) bypasses the skip-set by resetting it.
+                    // (#743)
+                    skipSet.add(wrap.id);
+                    skipSetDirty = true;
+                    continue;
+                  }
                   const entry: Nip17CacheEntry = {
                     id: wrap.id,
                     wrapId: wrap.id,
@@ -563,18 +615,28 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
               if (newlyCached.length > 0 || unfollowedPurged > 0 || touched > 0) {
                 nip17Evictions += await writeNip17Cache(nsecCacheKey, cache);
               }
+              if (skipSetDirty) {
+                await writeNip17SkipSet(nsecSkipKey, skipSet);
+              }
               nip17CacheSize = Object.keys(cache).length;
             }
           } else if (refreshForSigner === 'amber' && kind1059.length > 0) {
             // Always run the unwrap loop — Amber's silent content-resolver path returns PERMISSION_NOT_GRANTED on the first wrap if the user hasn't granted nip44_decrypt yet, which we surface via setAmberNip44Permission('denied') so NostrScreen can show the one-shot "Grant permission in Amber" button. Closes #404.
             // Persistent cache keyed by wrap id. Only ever contains rumors from *followed* senders — see the filter gate below. Per-account namespaced (#288).
             const amberCacheKey = perAccountKey(AMBER_NIP17_CACHE_KEY_BASE, refreshForPubkey);
-            const raw = await safeGetDmCacheItem(amberCacheKey);
-            const cache = safeParseRecord<Nip17CacheEntry>(raw);
+            // Negative-result skip-set — same semantics as the nsec branch.
+            // (#743)
+            const amberSkipKey = perAccountKey(AMBER_NIP17_SKIP_KEY_BASE, refreshForPubkey);
+            const [rawAmber, amberSkipSet] = await Promise.all([
+              safeGetDmCacheItem(amberCacheKey),
+              loadNip17SkipSet(amberSkipKey),
+            ]);
+            const cache = safeParseRecord<Nip17CacheEntry>(rawAmber);
             const newlyCached: Nip17CacheEntry[] = [];
             let permissionDenied = false;
             let touched = 0;
             let unfollowedPurged = 0;
+            let amberSkipSetDirty = false;
             // Frame-budget scheduler (#532) — see nsec branch above.
             const amberYield = createYieldScheduler({
               signal,
@@ -606,6 +668,12 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                   });
                   continue;
                 }
+                // Skip-set hit — short-circuit without an Amber IPC call.
+                // Bypassed on force-refresh. (#743)
+                if (!forceRefresh && amberSkipSet.has(wrap.id)) {
+                  nip17SkipHits++;
+                  continue;
+                }
                 nip17Misses++;
                 // Uncached — unwrap via Amber's silent content-resolver path.
                 // If Amber hasn't granted blanket nip44_decrypt permission,
@@ -616,14 +684,19 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                   // Multi-recipient (group) rumors: route to group storage
                   // and short-circuit the DM-inbox path.
                   const routeResult = await tryRouteGroupRumor(rumor, refreshForPubkey, wrap.id);
-                  if (routeResult.kind !== 'not-group') continue;
+                  if (routeResult.kind !== 'not-group') {
+                    amberSkipSet.add(wrap.id);
+                    amberSkipSetDirty = true;
+                    continue;
+                  }
                   const partnership = partnerFromRumor(rumor, refreshForPubkey);
                   if (!partnership) continue;
-                  // B1 — never cache rumors from non-followed senders. The
-                  // cost is re-decrypting them on the next refresh, but the
-                  // silent path is ~1 ms per call and keeps plaintext off
-                  // AsyncStorage.
-                  if (!passesFollowGate(partnership.partnerPubkey)) continue;
+                  // B1 — never cache rumors from non-followed senders. (#743)
+                  if (!passesFollowGate(partnership.partnerPubkey)) {
+                    amberSkipSet.add(wrap.id);
+                    amberSkipSetDirty = true;
+                    continue;
+                  }
                   const entry: Nip17CacheEntry = {
                     id: wrap.id,
                     wrapId: wrap.id,
@@ -669,6 +742,9 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
             if (newlyCached.length > 0 || touched > 0 || unfollowedPurged > 0) {
               nip17Evictions += await writeNip17Cache(amberCacheKey, cache);
             }
+            if (amberSkipSetDirty) {
+              await writeNip17SkipSet(amberSkipKey, amberSkipSet);
+            }
             nip17CacheSize = Object.keys(cache).length;
           }
 
@@ -704,6 +780,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           console.log(
             `[Perf] nip17-cache: ` +
               `hits=${nip17Hits}, ` +
+              `skipHits=${nip17SkipHits}, ` +
               `misses=${nip17Misses}, ` +
               `evictions=${nip17Evictions}, ` +
               `size=${nip17CacheSize}, ` +


### PR DESCRIPTION
## Summary

- Warm `refreshDmInbox` ran 16–19 s on the After-#741 benchmark (Pixel 8, pr423 preview, 2026-05-28). Root cause: the relay re-delivers ~87 kind-1059 wraps on every warm refresh (no `since` floor — NIP-59 randomised timestamps make it unreliable). Of those, 59 hit the positive wrap-id cache (fast O(1) lookup). The remaining 28 pay full NIP-44 schnorr + decrypt every time, because they carry **group rumors** or **non-followed-sender messages** — both paths `continue` before `cache[wrap.id] = entry`, so nothing is persisted and the same 28 get re-decrypted on the next refresh.
- Adds a **negative-result skip-set** (`Set<string>` of wrap ids, file-backed per-account alongside the positive cache). After a successful decrypt that reaches a group-route or non-follow `continue`, the wrap id is added to the skip-set. Subsequent warm refreshes hit `Set.has(wrap.id)` at O(1) before any crypto work.
- `force: true` (pull-to-refresh) bypasses the skip-set so a newly-followed contact's older wraps surface on the next manual refresh.
- Both nsec and Amber decrypt branches wired identically.
- `[Perf] nip17-cache` log line gains `skipHits=N` field for before/after visibility in logcat.

## Test plan

- [ ] On the preview build (with `EXPO_PUBLIC_KEEP_PERF_LOGS=1`), open Messages tab cold, let `refreshDmInbox` complete, then tab-away and return (TTL expires after 30 s). Check logcat: second refresh should show `skipHits=28` (or however many were non-inbox on first pass) and `misses=0` for those same wraps. Wall-clock should drop from ~16 s to ~4 s.
- [ ] Pull-to-refresh on Messages tab: `[Perf] nip17-cache` line should show `skipHits=0` and `misses=N` as normal (skip-set bypassed by `forceRefresh`). Conversations from any newly-followed contacts should appear.
- [ ] `npx jest --testPathPattern="nostrDmCacheSkipSet"` — 9 tests, all green.
- [ ] `npx tsc --noEmit` — clean.
- [ ] `npx eslint src/contexts/useDmInbox.ts src/contexts/nostrDmCache.ts` — clean.

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>