### PR TITLE
fix(nostr): NIP-17 skip-set bypassed when includeNonFollows is active (#748)

### DIFF
--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -282,6 +282,15 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // become no-ops AND the cache hydrate skips its filter so the
       // already-cached unfollowed entries don't get masked.
       const includeNonFollows = opts?.includeNonFollows === true;
+      // Gate for negative-result skip-set lookups (#743). Bypass when:
+      //   force=true (pull-to-refresh) — newly-followed contacts' older
+      //     wraps must surface on the next explicit refresh.
+      //   includeNonFollows=true ("All (dev)" toggle) — the follow gate is
+      //     disabled, so wraps from non-followed senders that were already
+      //     added to the skip-set must now be re-evaluated and surfaced.
+      //     Without this, "Following only=off" would silently skip them.
+      //     (Copilot review finding on #744)
+      const bypassSkipSet = forceRefresh || includeNonFollows;
       // Freshness TTL: skip the refresh entirely if the previous one
       // finished within DM_INBOX_REFRESH_TTL_MS, unless the caller
       // explicitly opts into a forced refresh (pull-to-refresh). The
@@ -544,7 +553,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                   // short-circuit without re-paying the NIP-44 decrypt cost.
                   // Bypassed on force-refresh so a newly-followed contact's
                   // older wraps get re-evaluated. (#743)
-                  if (!forceRefresh && skipSet.has(wrap.id)) {
+                  if (!bypassSkipSet && skipSet.has(wrap.id)) {
                     nip17SkipHits++;
                     continue;
                   }
@@ -672,7 +681,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                 }
                 // Skip-set hit — short-circuit without an Amber IPC call.
                 // Bypassed on force-refresh. (#743)
-                if (!forceRefresh && amberSkipSet.has(wrap.id)) {
+                if (!bypassSkipSet && amberSkipSet.has(wrap.id)) {
                   nip17SkipHits++;
                   continue;
                 }


### PR DESCRIPTION
## Summary

Copilot blocking finding on #744: the negative-result skip-set introduced in #746 guards against re-decryption using `!forceRefresh`, but the "Following only=off" dev toggle (`includeNonFollows=true`) was not treated the same way. With `includeNonFollows=true`, `passesFollowGate()` becomes a no-op — but wraps from non-followed senders that were already added to the skip-set during a prior normal refresh would still be `continue`'d, so the toggle would never surface those older wraps until an explicit pull-to-refresh.

Fix: introduce `bypassSkipSet = forceRefresh || includeNonFollows` and replace both `!forceRefresh &&` guards (nsec and Amber decrypt branches) with `!bypassSkipSet &&`.

## Test plan

- [ ] With "Following only=off" active, pull-to-refresh Messages once (populates skip-set). Tab away and back (TTL expired). Logcat should show `skipHits=0` and `misses=N` for the non-follow wraps — they are re-evaluated, not skipped.
- [ ] With "Following only" active (normal mode), warm refresh should still show `skipHits=28` (or N) as before.
- [ ] `npx tsc --noEmit` — clean. `npx eslint src/contexts/useDmInbox.ts` — clean.
- [ ] `npx jest --testPathPattern="nostrDmCacheSkipSet|nip17"` — 38/38.

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
