### PR TITLE
fix(map): keep user-location dot on top of co-located place pins (#749)

### DIFF
--- a/src/components/LibreMiniMap.tsx
+++ b/src/components/LibreMiniMap.tsx
@@ -450,44 +450,6 @@ const LibreMiniMapInner: React.FC<Props> = ({
             (dev-pinned positions, no-GPS state) — silently misleading
             the user about their precision was the pre-fix behaviour. */}
         {haloFeature && <AccuracyHalo feature={haloFeature} />}
-        {/* User position — solid dot. Three prop modes:
-              - userLat/userLon both numbers → render there.
-              - userLat/userLon both undefined (mini-map default: not
-                passed) → render at camera centre [lon, lat]; centre
-                IS the user in those flows.
-              - userLat/userLon explicitly null → the caller (a detail
-                screen) is telling us "we don't know yet". DON'T fall
-                through to camera centre — that would plant the dot
-                on the cache / merchant / event for one frame before
-                the cached fix arrives, which is exactly the
-                "location momentarily showed as the geo-cache then
-                jumped" bug we hit.
-            The pixel-sized Marker stays a position indicator — sizing
-            it geographically would make it vanish at wide zoom and
-            dominate at close zoom. */}
-        {(() => {
-          const userLatProvided = userLat !== undefined;
-          const userLonProvided = userLon !== undefined;
-          const dotLat = userLatProvided ? userLat : lat;
-          const dotLon = userLonProvided ? userLon : lon;
-          if (dotLat === null || dotLon === null) return null;
-          return (
-            <Marker id="user" lngLat={[dotLon, dotLat]}>
-              <View style={styles.userMarkerWrap}>
-                {/* Pixel-marker pulse is only useful as a "find
-                    yourself" affordance when no geographic halo is
-                    rendered (no accuracy / dev-pinned position). Once
-                    the GeoJSON halo is in place it makes the dot
-                    look like it has two halos — drop the pixel
-                    pulse in that case. */}
-                {!haloFeature && (
-                  <Animated.View style={[styles.userDotPulse, { transform: [{ scale: pulse }] }]} />
-                )}
-                <View style={styles.userDot} />
-              </View>
-            </Marker>
-          );
-        })()}
         {/* Merchants: pin colour signals payment type (pink Lightning,
             orange on-chain only). Glyph mirrors the BTC Map category
             icon the user sees on the Places-for-you rail card for the
@@ -561,6 +523,53 @@ const LibreMiniMapInner: React.FC<Props> = ({
             </Marker>
           );
         })}
+        {/* User position — solid dot, rendered LAST so it draws on top
+            of any co-located place pin (e.g. when the user is standing
+            at a merchant like Bee Happy Farm) instead of being hidden
+            behind it. The wrapper is pointerEvents="none" so the
+            decorative dot (no onPress) never captures taps — the
+            co-located clickable merchant / cache / event pin underneath
+            stays tappable even though the dot sits visually on top.
+            This supersedes the earlier "no zIndex, render underneath"
+            approach, which kept the dot invisible whenever a pin shared
+            its coordinate. Three prop modes:
+              - userLat/userLon both numbers → render there.
+              - userLat/userLon both undefined (mini-map default: not
+                passed) → render at camera centre [lon, lat]; centre
+                IS the user in those flows.
+              - userLat/userLon explicitly null → the caller (a detail
+                screen) is telling us "we don't know yet". DON'T fall
+                through to camera centre — that would plant the dot
+                on the cache / merchant / event for one frame before
+                the cached fix arrives, which is exactly the
+                "location momentarily showed as the geo-cache then
+                jumped" bug we hit.
+            The pixel-sized Marker stays a position indicator — sizing
+            it geographically would make it vanish at wide zoom and
+            dominate at close zoom. */}
+        {(() => {
+          const userLatProvided = userLat !== undefined;
+          const userLonProvided = userLon !== undefined;
+          const dotLat = userLatProvided ? userLat : lat;
+          const dotLon = userLonProvided ? userLon : lon;
+          if (dotLat === null || dotLon === null) return null;
+          return (
+            <Marker id="user" lngLat={[dotLon, dotLat]}>
+              <View style={styles.userMarkerWrap} pointerEvents="none">
+                {/* Pixel-marker pulse is only useful as a "find
+                    yourself" affordance when no geographic halo is
+                    rendered (no accuracy / dev-pinned position). Once
+                    the GeoJSON halo is in place it makes the dot
+                    look like it has two halos — drop the pixel
+                    pulse in that case. */}
+                {!haloFeature && (
+                  <Animated.View style={[styles.userDotPulse, { transform: [{ scale: pulse }] }]} />
+                )}
+                <View style={styles.userDot} />
+              </View>
+            </Marker>
+          );
+        })()}
       </MapLibreMap>
 
       {/* Top-left: +/− zoom column. Matches ExploreMiniMap's layout
@@ -668,11 +677,13 @@ const createStyles = (colors: Palette) =>
     // Blue dot at the same 22 px diameter as the merchant / cache /
     // event pin chassis so the GPS marker reads as a peer rather than a
     // smaller secondary element. The accuracy halo sits behind it.
-    // No zIndex so merchant / cache / event pins layered on top of the
-    // user dot remain tappable. The user-dot Marker is decorative — it
-    // has no onPress — so being underneath a clickable pin is the right
-    // visual + tap behaviour. (Previously zIndex:2 made the dot capture
-    // taps on co-located pins like Bee Happy Farm.)
+    // Tappability of co-located pins is handled by rendering the
+    // user-dot Marker LAST with a pointerEvents="none" wrapper (see the
+    // marker JSX above), NOT by z-order here — the dot is removed from
+    // hit-testing entirely, so a co-located clickable pin (e.g. Bee
+    // Happy Farm) stays tappable even though the dot draws on top of it.
+    // (An earlier attempt lifted the dot with zIndex:2, which made it
+    // capture those taps; pointerEvents="none" is the correct fix.)
     userDot: {
       width: 22,
       height: 22,


### PR DESCRIPTION
## Problem

On the Explore screen (and every map surface), the user's current-location **blue dot is invisible** whenever a place pin sits at the same coordinate. Spotted on the Pixel preview build: standing at **Bee Happy Farm**, the merchant pin fully covers the GPS dot, so the user looks like they have no location fix.

## Cause

`src/components/LibreMiniMap.tsx` is the single shared map (Explore, Places, Geo-caches, MapScreen, detail screens). The user-dot `<Marker>` was rendered **first**, so every place marker drawn afterward (merchants → caches → events) stacks **on top** — MapLibre draw order is render order. A previous change had *removed* `zIndex` from the dot specifically so it wouldn't capture taps meant for co-located clickable pins (the old comment names Bee Happy Farm). That traded "dot visible" for "pin tappable."

## Fix

Render the user-dot marker **last** (draws on top → always visible) **and** set `pointerEvents="none"` on its wrapper. The dot is decorative (no `onPress`), so removing it from hit-testing means the co-located clickable pin underneath **stays tappable** even with the dot on top — resolving both concerns at once. Strictly safer than the old "no zIndex" hack.

Because it's the shared component, the fix lands on Explore, Places, Geo-caches and the full MapScreen uniformly.

## Screenshots

_Before / after storyboard added below once the verification build is installed on-device._

## Testing

- `npx tsc --noEmit` ✅
- `eslint` ✅ · `prettier --check` ✅
- [ ] On-device: blue dot visible when standing on Bee Happy Farm
- [ ] On-device: Bee Happy Farm pin still opens its detail sheet on tap

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)