### PR TITLE
perf(dm): cut warm + cold DM-inbox relay-fetch locks (#751)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,11 @@ docs/*.pdf
 # regardless of subsequent `!` exceptions.
 .claude/*
 !.claude/agents/
+
+# Local-only dev/debug scripts that must never be committed — some embed
+# LNURL-withdraw k1 bearer secrets. Kept on disk for local use; ignored so an
+# accidental `git add -A` can't sweep them into a (public) commit again (#752).
+scripts/check-hawthorn.mjs
+scripts/check-lnurlw.mjs
+scripts/send-test-dm.mjs
+scripts/wait-compare.mjs

--- a/scripts/send-bulk-dms.mjs
+++ b/scripts/send-bulk-dms.mjs
@@ -1,0 +1,61 @@
+// Dev helper (#751 freeze repro): bulk-publish many NIP-17 gift-wrapped DMs
+// from the LITTLE test account to the BIG test account, so a logged-in BIG
+// app builds up a large kind-1059 inbox backlog — the volume that triggers
+// the cold-start fetch/ingest freeze we're hunting. NOT shipped — repro tool.
+//
+//   node --env-file=.env scripts/send-bulk-dms.mjs [count] [concurrency]
+//
+// Reads MAESTRO_NSEC_LITTLE + MAESTRO_NPUB_BIG from .env. Node 22 has a global
+// WebSocket, so nostr-tools' SimplePool works here. Throttled (small batches +
+// inter-batch delay) to avoid tripping public-relay rate-limit bans.
+import { decode } from 'nostr-tools/nip19';
+import { wrapEvent } from 'nostr-tools/nip17';
+import { SimplePool } from 'nostr-tools/pool';
+
+const littleNsec = process.env.MAESTRO_NSEC_LITTLE;
+const bigNpub = process.env.MAESTRO_NPUB_BIG;
+if (!littleNsec || !bigNpub) {
+  console.error('Missing MAESTRO_NSEC_LITTLE or MAESTRO_NPUB_BIG (load with --env-file=.env)');
+  process.exit(1);
+}
+
+const senderSK = decode(littleNsec).data; // Uint8Array
+const recipientPk = decode(bigNpub).data; // hex string
+const COUNT = Number(process.argv[2] || 500);
+const CONC = Number(process.argv[3] || 10);
+const DELAY_MS = 250; // pause between batches — be gentle on public relays
+
+// Keep to the most reliable relays the app actually reads (DEFAULT_RELAYS).
+const relays = ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net'];
+const pool = new SimplePool();
+
+let ok = 0;
+let fail = 0;
+const startedAt = Date.now();
+
+console.log(`Seeding ${COUNT} NIP-17 wraps  LITTLE → BIG(${recipientPk.slice(0, 10)}…)  on ${relays.length} relays, conc=${CONC}`);
+
+for (let base = 0; base < COUNT; base += CONC) {
+  const batch = [];
+  for (let j = 0; j < CONC && base + j < COUNT; j++) {
+    const i = base + j;
+    const msg = `Repro msg #${i + 1} 🐷 — building NIP-17 inbox backlog for #751 (ts ${Date.now()})`;
+    const wrap = wrapEvent(senderSK, { publicKey: recipientPk }, msg);
+    batch.push(
+      Promise.allSettled(pool.publish(relays, wrap)).then((rs) => {
+        const anyOk = rs.some((r) => r.status === 'fulfilled');
+        if (anyOk) ok++;
+        else fail++;
+      }),
+    );
+  }
+  await Promise.all(batch);
+  if ((base + CONC) % 50 === 0 || base + CONC >= COUNT) {
+    console.log(`  ${Math.min(base + CONC, COUNT)}/${COUNT}  (ok=${ok} fail=${fail}, ${((Date.now() - startedAt) / 1000).toFixed(0)}s)`);
+  }
+  await new Promise((r) => setTimeout(r, DELAY_MS));
+}
+
+console.log(`done: ${ok} wraps accepted by ≥1 relay, ${fail} failed, in ${((Date.now() - startedAt) / 1000).toFixed(0)}s`);
+pool.close(relays);
+process.exit(0);

--- a/src/contexts/dmColdStartBackfill.ts
+++ b/src/contexts/dmColdStartBackfill.ts
@@ -28,6 +28,12 @@ export function scheduleColdStartBackfill(args: {
 }): void {
   if (!args.isColdStart || args.signal?.aborted) return;
   InteractionManager.runAfterInteractions(() => {
+    // Re-check: the signal may have aborted between scheduling and now (e.g. a
+    // tab blur during the interaction window). Skip so we don't toggle loading
+    // state or advance the refresh TTL for a backfill the user no longer wants
+    // (#752 Copilot). querySyncAbortable would also short-circuit, but bailing
+    // here avoids the wasted refreshDmInbox setup entirely.
+    if (args.signal?.aborted) return;
     void args.refreshRef.current?.({
       force: true,
       includeNonFollows: args.includeNonFollows,

--- a/src/contexts/dmColdStartBackfill.ts
+++ b/src/contexts/dmColdStartBackfill.ts
@@ -1,0 +1,37 @@
+import type React from 'react';
+import { InteractionManager } from 'react-native';
+import type { RefreshDmInboxOptions } from './nostrContextTypes';
+
+/**
+ * Schedule the cold-start inbox backfill (#751).
+ *
+ * The first refresh of a session fetches only a recent slice of wraps
+ * (COLD_INITIAL_WRAP_LIMIT) so the Messages tab paints fast instead of blocking
+ * the JS thread on the full backlog ingest (~12 s for 508 wraps × 5 relays).
+ * This tops up to the full backlog afterwards — but in the background:
+ *
+ *  - deferred via `runAfterInteractions` so it never blocks the tab transition;
+ *  - carrying the original `signal`, so a tab-blur cancels it (the in-flight
+ *    relay subscription closes via querySyncAbortable);
+ *  - with `force: true`, which fetches the full limit, skips the `since` floor
+ *    (NIP-59 wrap timestamps are randomised), and — crucially — marks this pass
+ *    a non-cold-start, so it can never recurse.
+ *
+ * `refreshRef` (rather than the callback directly) keeps the caller from having
+ * to list refreshDmInbox as its own dependency.
+ */
+export function scheduleColdStartBackfill(args: {
+  isColdStart: boolean;
+  signal?: AbortSignal;
+  includeNonFollows: boolean;
+  refreshRef: React.MutableRefObject<((opts?: RefreshDmInboxOptions) => Promise<void>) | null>;
+}): void {
+  if (!args.isColdStart || args.signal?.aborted) return;
+  InteractionManager.runAfterInteractions(() => {
+    void args.refreshRef.current?.({
+      force: true,
+      includeNonFollows: args.includeNonFollows,
+      signal: args.signal,
+    });
+  });
+}

--- a/src/contexts/nostrDmCache.ts
+++ b/src/contexts/nostrDmCache.ts
@@ -163,6 +163,15 @@ export async function writeNip17Cache(
 export const DM_INBOX_REFRESH_TTL_MS = 30_000;
 
 /**
+ * Cold-start initial wrap fetch size (#751). The first inbox refresh of a
+ * session fetches only this many kind-1059 wraps so the Messages tab paints
+ * fast instead of blocking the JS thread on the full backlog ingest (508 wraps
+ * × 5 relays measured at ~12 s). `refreshDmInbox` then schedules a full-limit
+ * backfill in the background, deferred past interactions and abortable on blur.
+ */
+export const COLD_INITIAL_WRAP_LIMIT = 200;
+
+/**
  * Persisted inbox + per-peer message caches (PR B).
  *
  * Key shape: `<prefix>_<userPubkeyHex>` — per-user so multiple nsec

--- a/src/contexts/nostrLiveDmSub.ts
+++ b/src/contexts/nostrLiveDmSub.ts
@@ -25,6 +25,7 @@ import {
   type Nip17CacheEntry,
   safeParseRecord,
   writeNip17Cache,
+  COLD_INITIAL_WRAP_LIMIT,
   DM_INBOX_CAP,
   inboxCacheKey,
   inboxLastSeenKey,
@@ -551,6 +552,10 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
       viewerPubkey,
       relays: readRelays,
       sinceK4,
+      // Bound the kind-1059 backlog re-stream so arming the live sub doesn't
+      // re-ingest the full wrap history on the JS thread (#751). Deeper backlog
+      // is covered by refreshDmInbox's deferred backfill; new wraps stream live.
+      wrapsLimit: COLD_INITIAL_WRAP_LIMIT,
       onEvent: (ev) => {
         // Fire-and-forget: handleInboxEvent awaits its own state, and any throw is caught + logged here so the sub keeps running. Whether a notification fires is gated inside on the message's own timestamp (isFreshArrival), not on EOSE.
         handleInboxEvent(ev).catch((e) => {

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -48,6 +48,12 @@ const SEEN_CAP = 1000;
 // (Copilot review #742). Bounded (5 s maxWait inside fetchCachesByAuthor)
 // and inexpensive (kind-37516 by one pubkey is replaceable + small).
 const REFETCH_COORDS_INTERVAL_MS = 60_000;
+// Minimum gap between actual refetch passes. The 60 s interval and one-time
+// mount call sit well above it; its job is to coalesce AppState 'active'
+// bursts — the OS can deliver several 'active' events back-to-back on resume,
+// each otherwise firing an overlapping fetchCachesByAuthor that piles onto the
+// JS thread during warm re-foreground (#751 warm-path audit #5).
+const REFETCH_MIN_GAP_MS = 10_000;
 
 export interface UseCacheNotificationsParams {
   /** Active viewer's hex pubkey. Null when logged out — sub stays closed. */
@@ -86,6 +92,8 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
     // Coord set the sub is currently armed with. Compared against each
     // refetch to skip tear-down + re-arm when nothing changed.
     let currentCoords: string[] = [];
+    // Wall-clock of the last refetch we actually started — see REFETCH_MIN_GAP_MS.
+    let lastRefetchStartedAt = 0;
     const seen = new Set<string>();
     const subOpenedAtSec = Math.floor(Date.now() / 1000);
 
@@ -138,6 +146,11 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
      */
     const refetchAndRearm = async (): Promise<void> => {
       if (cancelled) return;
+      // Throttle bursts (esp. multiple back-to-back AppState 'active' events on
+      // resume) so we don't fire overlapping relay fetches (#751 audit #5).
+      const startNow = Date.now();
+      if (startNow - lastRefetchStartedAt < REFETCH_MIN_GAP_MS) return;
+      lastRefetchStartedAt = startNow;
       try {
         const myCaches = await fetchCachesByAuthor(pubkey, readRelays);
         if (cancelled) return;

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -36,6 +36,7 @@ import {
   loadNip17SkipSet,
   writeNip17SkipSet,
   DM_INBOX_REFRESH_TTL_MS,
+  COLD_INITIAL_WRAP_LIMIT,
   DM_INBOX_CAP,
   DM_CONV_CAP,
   inboxCacheKey,
@@ -49,6 +50,7 @@ import {
 import type { RefreshDmInboxOptions, ConversationMessage } from './nostrContextTypes';
 import { startLiveDmSubscription } from './nostrLiveDmSub';
 import { fetchConversationFor } from './nostrFetchConversation';
+import { scheduleColdStartBackfill } from './dmColdStartBackfill';
 
 /**
  * Options the provider threads into the DM-inbox + conversation hook.
@@ -258,6 +260,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
     [pubkey, isLoggedIn, signerType, getReadRelays, decryptNip04ViaSigner],
   );
 
+  // Stable self-reference so the cold-start backfill can re-invoke
+  // refreshDmInbox without it listing itself as a dependency (declared here,
+  // assigned just after the useCallback).
+  const refreshDmInboxRef = useRef<((opts?: RefreshDmInboxOptions) => Promise<void>) | null>(null);
   const refreshDmInbox = useCallback(
     async (opts?: RefreshDmInboxOptions): Promise<void> => {
       if (!pubkey || !isLoggedIn) {
@@ -282,6 +288,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // become no-ops AND the cache hydrate skips its filter so the
       // already-cached unfollowed entries don't get masked.
       const includeNonFollows = opts?.includeNonFollows === true;
+      // Cold start = first (non-force) refresh this session: fetch only
+      // COLD_INITIAL_WRAP_LIMIT wraps for a fast paint, then backfill the full
+      // limit in the background (#751). Read before the TTL gate writes the ref.
+      const isColdStart = dmInboxLastRefreshAt.current === 0 && !forceRefresh;
       // Gate for negative-result skip-set lookups (#743). Bypass when:
       //   force=true (pull-to-refresh) — newly-followed contacts' older
       //     wraps must surface on the next explicit refresh.
@@ -390,7 +400,11 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           const { kind4, kind1059 } = await nostrService.fetchInboxDmEvents(
             refreshForPubkey,
             readRelays,
-            opts?.force ? {} : { since: lastSeen },
+            {
+              ...(opts?.force ? {} : { since: lastSeen }),
+              signal,
+              ...(isColdStart ? { limit: COLD_INITIAL_WRAP_LIMIT } : {}),
+            },
           );
           if (signal?.aborted) return;
           const entries: DmInboxEntry[] = [];
@@ -841,6 +855,15 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           console.log(`[PerfBlock] refreshDmInbox: ${__perfBlockMs}ms`);
         }
       }
+
+      // Cold-start backfill (#751) — recent slice painted fast above; top up to
+      // the full backlog in the background (deferred + abortable). See module.
+      scheduleColdStartBackfill({
+        isColdStart,
+        signal,
+        includeNonFollows,
+        refreshRef: refreshDmInboxRef,
+      });
     },
     [
       pubkey,
@@ -852,6 +875,8 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       amberNip44DecryptSilent,
     ],
   );
+  // Keep the self-ref pointed at the latest refreshDmInbox closure.
+  refreshDmInboxRef.current = refreshDmInbox;
 
   useEffect(() => {
     if (!isLoggedIn) setDmInbox([]);

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -401,7 +401,8 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
             refreshForPubkey,
             readRelays,
             {
-              ...(opts?.force ? {} : { since: lastSeen }),
+              // Cold start keeps `since` for kind-4 even under force — the on-mount enforce-flip refresh is force but doesn't need the full kind-4 backlog (that was the ~11s cold remainder; #751). Non-cold force still drops it so a follow-toggle / pull-to-refresh re-fetches older kind-4. Wraps ignore `since` internally regardless (random NIP-59 ts).
+              ...(opts?.force && !isColdStart ? {} : { since: lastSeen }),
               signal,
               ...(isColdStart ? { limit: COLD_INITIAL_WRAP_LIMIT } : {}),
             },

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -288,10 +288,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // become no-ops AND the cache hydrate skips its filter so the
       // already-cached unfollowed entries don't get masked.
       const includeNonFollows = opts?.includeNonFollows === true;
-      // Cold start = first (non-force) refresh this session: fetch only
-      // COLD_INITIAL_WRAP_LIMIT wraps for a fast paint, then backfill the full
-      // limit in the background (#751). Read before the TTL gate writes the ref.
-      const isColdStart = dmInboxLastRefreshAt.current === 0 && !forceRefresh;
+      // Cold start = first refresh this session (incl. force: the real cold load
+      // is MessagesScreen's on-mount enforce-flip refresh, which is force:true —
+      // excluding force never capped it; #751). 200-wrap paint, then backfill.
+      const isColdStart = dmInboxLastRefreshAt.current === 0;
       // Gate for negative-result skip-set lookups (#743). Bypass when:
       //   force=true (pull-to-refresh) — newly-followed contacts' older
       //     wraps must surface on the next explicit refresh.

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -28,7 +28,7 @@ import { useUserLocation } from '../contexts/UserLocationContext';
 import LegendSheet from '../components/LegendSheet';
 import { btcMapIconComponent } from '../utils/btcMapIcon';
 import { perfPageReady } from '../utils/perfLog';
-import { claimExploreByAuthorFetch, releaseExploreByAuthorFetch } from '../utils/exploreFetchGuard';
+import { joinExploreByAuthorFetch } from '../utils/exploreFetchGuard';
 import { courses, type Course } from '../data/learnContent';
 import {
   getProgress,
@@ -511,14 +511,15 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   useEffect(() => {
     if (!signedInPubkey) return;
     const fetchKey = `${signedInPubkey}:${refreshKey}`;
-    if (!claimExploreByAuthorFetch(fetchKey)) return;
     let cancelled = false;
     const readRelays = userRelays.filter((r) => r.read).map((r) => r.url);
-    fetchCachesByAuthor(signedInPubkey, readRelays.length > 0 ? readRelays : undefined)
+    // Join an in-flight fetch so concurrent effect re-runs don't fire parallel
+    // requests, and the current run still merges on cancel (#752 Copilot).
+    joinExploreByAuthorFetch(fetchKey, () =>
+      fetchCachesByAuthor(signedInPubkey, readRelays.length > 0 ? readRelays : undefined),
+    )
       .then((mine) => {
-        // Release on cancel too so a remount can retry — safe: async, after the
-        // claim-deduped mount burst (#752 Copilot).
-        if (cancelled) return releaseExploreByAuthorFetch(fetchKey);
+        if (cancelled) return;
         console.log(
           `[PerfBlock] ExploreHome by-author merge: fetched=${mine.length} ` +
             mine.map((c) => `${c.name ?? c.d}@${c.geohash?.slice(0, 5) ?? '??'}`).join(', '),
@@ -541,7 +542,6 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
         });
       })
       .catch((e) => {
-        releaseExploreByAuthorFetch(fetchKey);
         console.warn(`[PerfBlock] ExploreHome by-author fetch threw: ${(e as Error).message}`);
       });
     return () => {

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -28,7 +28,7 @@ import { useUserLocation } from '../contexts/UserLocationContext';
 import LegendSheet from '../components/LegendSheet';
 import { btcMapIconComponent } from '../utils/btcMapIcon';
 import { perfPageReady } from '../utils/perfLog';
-import { claimExploreByAuthorFetch } from '../utils/exploreFetchGuard';
+import { claimExploreByAuthorFetch, releaseExploreByAuthorFetch } from '../utils/exploreFetchGuard';
 import { courses, type Course } from '../data/learnContent';
 import {
   getProgress,
@@ -539,6 +539,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
         });
       })
       .catch((e) => {
+        releaseExploreByAuthorFetch(fetchKey);
         console.warn(`[PerfBlock] ExploreHome by-author fetch threw: ${(e as Error).message}`);
       });
     return () => {

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -28,6 +28,7 @@ import { useUserLocation } from '../contexts/UserLocationContext';
 import LegendSheet from '../components/LegendSheet';
 import { btcMapIconComponent } from '../utils/btcMapIcon';
 import { perfPageReady } from '../utils/perfLog';
+import { claimExploreByAuthorFetch } from '../utils/exploreFetchGuard';
 import { courses, type Course } from '../data/learnContent';
 import {
   getProgress,
@@ -502,18 +503,15 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // nearby sub filters by geohash prefix, which excludes the user's
   // own listing if they hid it outside their current viewport OR if
   // the sub was paused (#557) at the moment the relay echoed back.
-  // One-shot per pubkey via `byAuthorFetchedForRef` so re-renders
-  // don't refire.
+  // One-shot per (pubkey, refreshKey) via the module-scoped
+  // `claimExploreByAuthorFetch` guard — re-runs on pull-to-refresh and
+  // pubkey change but never on unrelated re-renders, and is immune to the
+  // concurrent parallel-fire a component useRef suffered (#751 audit #4).
   const { pubkey: signedInPubkey, relays: userRelays } = useNostr();
-  // Track the (pubkey, refreshKey) tuple that last triggered the fetch
-  // so we re-run on pull-to-refresh AND on pubkey change, but never on
-  // unrelated re-renders.
-  const byAuthorFetchedForRef = useRef<string | null>(null);
   useEffect(() => {
     if (!signedInPubkey) return;
     const fetchKey = `${signedInPubkey}:${refreshKey}`;
-    if (byAuthorFetchedForRef.current === fetchKey) return;
-    byAuthorFetchedForRef.current = fetchKey;
+    if (!claimExploreByAuthorFetch(fetchKey)) return;
     let cancelled = false;
     const readRelays = userRelays.filter((r) => r.read).map((r) => r.url);
     fetchCachesByAuthor(signedInPubkey, readRelays.length > 0 ? readRelays : undefined)

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -516,7 +516,9 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     const readRelays = userRelays.filter((r) => r.read).map((r) => r.url);
     fetchCachesByAuthor(signedInPubkey, readRelays.length > 0 ? readRelays : undefined)
       .then((mine) => {
-        if (cancelled) return;
+        // Release on cancel too so a remount can retry — safe: async, after the
+        // claim-deduped mount burst (#752 Copilot).
+        if (cancelled) return releaseExploreByAuthorFetch(fetchKey);
         console.log(
           `[PerfBlock] ExploreHome by-author merge: fetched=${mine.length} ` +
             mine.map((c) => `${c.name ?? c.d}@${c.geohash?.slice(0, 5) ?? '??'}`).join(', '),

--- a/src/screens/GroupsScreen.tsx
+++ b/src/screens/GroupsScreen.tsx
@@ -83,6 +83,16 @@ const GroupsScreen: React.FC = () => {
   // logged in #560. Same shape MessagesScreen uses for the Messages
   // tab (#412).
   const refreshAbortRef = useRef<AbortController | null>(null);
+  // Screen-level TTL gate (mirrors MessagesScreen #412/#731). Without it the
+  // `force: true` below — kept so newly-arrived group rumors, whose NIP-59 wrap
+  // timestamps are randomised, aren't dropped by a `since` filter — also
+  // bypasses refreshDmInbox's own TTL gate, re-ingesting the ENTIRE wrap
+  // backlog on every Groups focus (~10 s JS-thread lock per visit; #751
+  // warm-path audit). The gate preserves `force` semantics when we do fetch
+  // but skips the fetch on a re-focus within the TTL window. 0 = never.
+  const dmInboxLastRefreshAt = useRef<number>(0);
+  const DM_INBOX_REFRESH_TTL_MS = 30_000;
+  const DM_INBOX_ABORT_TTL_MS = 10_000;
   const newRefreshSignal = useCallback((): AbortSignal => {
     refreshAbortRef.current?.abort();
     const ctrl = new AbortController();
@@ -92,13 +102,29 @@ const GroupsScreen: React.FC = () => {
   useFocusEffect(
     useCallback(() => {
       if (!isLoggedIn) return;
-      const handle = InteractionManager.runAfterInteractions(() =>
+      const handle = InteractionManager.runAfterInteractions(() => {
+        // Skip entirely if the inbox was refreshed within the TTL window —
+        // tab-bouncing into Groups no longer re-runs the full relay fetch.
+        if (Date.now() - dmInboxLastRefreshAt.current < DM_INBOX_REFRESH_TTL_MS) return;
+        const startedAt = Date.now();
+        const signal = newRefreshSignal();
         refreshDmInbox({
           force: true,
           includeNonFollows: !enforceFollowingOnly,
-          signal: newRefreshSignal(),
-        }),
-      );
+          signal,
+        })
+          .then(() => {
+            // Aborted (fast tab-hop) → short TTL so we retry sooner; clean
+            // completion → full 30 s TTL. Same shape as MessagesScreen.
+            dmInboxLastRefreshAt.current = signal.aborted
+              ? Date.now() - (DM_INBOX_REFRESH_TTL_MS - DM_INBOX_ABORT_TTL_MS)
+              : startedAt;
+          })
+          .catch(() => {
+            dmInboxLastRefreshAt.current =
+              Date.now() - (DM_INBOX_REFRESH_TTL_MS - DM_INBOX_ABORT_TTL_MS);
+          });
+      });
       return () => {
         handle.cancel();
         refreshAbortRef.current?.abort();

--- a/src/services/dmLiveSubscription.ts
+++ b/src/services/dmLiveSubscription.ts
@@ -34,6 +34,16 @@ export function subscribeInboxDmsForViewer(input: {
   onEose?: () => void;
   // Optional kind-4 `since` cursor (unix seconds). When provided, the kind-4 filter resolves to `clamp(providedSince - 120s, now-7d, now)` — the 120 s safety buffer in case relay clock skew tagged a wrap slightly older than our cursor, the 7-day floor caps cold-start restream when the cursor is very stale, and the `now` cap defends against a future-dated cursor (corrupted persisted value or a wrap with a bad clock) that would otherwise silently miss new DMs until wall-clock catches up. If absent, falls back to the 7-day floor.
   sinceK4?: number;
+  // Cap on the kind-1059 backlog the relay re-streams when the sub opens.
+  // Wraps can't use a `since` cursor (randomised NIP-59 timestamps), so without
+  // a bound the relay replays the FULL wrap history on every arm and nostr-tools
+  // parses every event synchronously before our knownWrapIds early-return —
+  // re-introducing the cold-start ingest freeze via the live-sub path even when
+  // refreshDmInbox capped its own fetch (#751, Copilot review on #752). Defaults
+  // to DM_INBOX_LIMIT; callers pass the smaller cold-start limit. New wraps still
+  // arrive live after EOSE regardless of this cap, and the deeper backlog is
+  // covered by refreshDmInbox's deferred full backfill.
+  wrapsLimit?: number;
 }): () => void {
   trackRelays(input.relays);
   const onevent = (ev: Parameters<typeof input.onEvent>[0]): void => {
@@ -73,8 +83,9 @@ export function subscribeInboxDmsForViewer(input: {
     {
       kinds: [1059],
       '#p': [input.viewerPubkey],
-      // No `since` — NIP-59 random timestamps would drop fresh wraps.
-      limit: DM_INBOX_LIMIT,
+      // No `since` — NIP-59 random timestamps would drop fresh wraps. Bound the
+      // backlog re-stream with `wrapsLimit` instead (see the input doc above).
+      limit: input.wrapsLimit ?? DM_INBOX_LIMIT,
     } as Filter,
     {
       onevent,

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -10,6 +10,7 @@ import {
   type VerifiedEvent,
 } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
+import { querySyncAbortable } from './relayQuery';
 import * as nip19 from 'nostr-tools/nip19';
 import * as nip04 from 'nostr-tools/nip04';
 import * as nip44 from 'nostr-tools/nip44';
@@ -959,7 +960,7 @@ export interface FetchedInboxEvents {
 export async function fetchInboxDmEvents(
   myPubkey: string,
   relays: string[],
-  options: { limit?: number; since?: number } = {},
+  options: { limit?: number; since?: number; signal?: AbortSignal } = {},
 ): Promise<FetchedInboxEvents> {
   const allRelays = [...new Set([...relays, ...DEFAULT_RELAYS])];
   trackRelays(allRelays);
@@ -998,9 +999,9 @@ export async function fetchInboxDmEvents(
     // inbox fetch genuinely terminates — unlike withTimeout which only raced the
     // Promise and left the underlying subscribeEose sub running for up to ~60 s.
     const [sentK4, receivedK4, wraps] = await Promise.all([
-      pool.querySync(allRelays, sentK4Filter, { maxWait: 15000 }),
-      pool.querySync(allRelays, recvK4Filter, { maxWait: 15000 }),
-      pool.querySync(allRelays, wrapsFilter, { maxWait: 15000 }),
+      querySyncAbortable(pool, allRelays, sentK4Filter, { maxWait: 15000, signal: options.signal }),
+      querySyncAbortable(pool, allRelays, recvK4Filter, { maxWait: 15000, signal: options.signal }),
+      querySyncAbortable(pool, allRelays, wrapsFilter, { maxWait: 15000, signal: options.signal }),
     ]);
     // [Perf] Cold-start freeze attribution (#751). querySync ingests every
     // returned event synchronously (JSON.parse + validateEvent + matchFilters)

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -992,6 +992,7 @@ export async function fetchInboxDmEvents(
     sentK4Filter.since = since;
     recvK4Filter.since = since;
   }
+  const __t0 = performance.now();
   try {
     // maxWait: per-relay EOSE timeout closes the sub at 15 s, so the cold-start
     // inbox fetch genuinely terminates — unlike withTimeout which only raced the
@@ -1001,6 +1002,18 @@ export async function fetchInboxDmEvents(
       pool.querySync(allRelays, recvK4Filter, { maxWait: 15000 }),
       pool.querySync(allRelays, wrapsFilter, { maxWait: 15000 }),
     ]);
+    // [Perf] Cold-start freeze attribution (#751). querySync ingests every
+    // returned event synchronously (JSON.parse + validateEvent + matchFilters)
+    // before resolving — logs the wrap count + wall-clock so we can tell
+    // whether the dominant cost is fetch volume (reduce limit/fan-out) or
+    // per-event ingest (yield). Prints here, inside the fetch, so it survives
+    // the caller's post-fetch abort short-circuit (useDmInbox.ts:395) which
+    // otherwise suppresses the [Perf] refreshDmInbox count line.
+    console.log(
+      `[Perf] fetchInboxDmEvents: ${(performance.now() - __t0).toFixed(0)}ms ` +
+        `wraps=${wraps.length} sentK4=${sentK4.length} recvK4=${receivedK4.length} ` +
+        `relays=${allRelays.length} limit=${limit}`,
+    );
     const k4 = new Map<string, RawDmEvent>();
     for (const ev of sentK4) k4.set(ev.id, ev as RawDmEvent);
     for (const ev of receivedK4) k4.set(ev.id, ev as RawDmEvent);

--- a/src/services/relayQuery.test.ts
+++ b/src/services/relayQuery.test.ts
@@ -1,4 +1,4 @@
-import { querySyncAbortable } from '../../src/services/relayQuery';
+import { querySyncAbortable } from './relayQuery';
 import type { SimplePool } from 'nostr-tools/pool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 

--- a/src/services/relayQuery.ts
+++ b/src/services/relayQuery.ts
@@ -1,0 +1,60 @@
+import type { SimplePool } from 'nostr-tools/pool';
+import type { Filter } from 'nostr-tools/filter';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+
+/**
+ * Abortable variant of `pool.querySync`. nostr-tools' `querySync` collects
+ * events until EOSE but its public *type* omits the `abort` param — even though
+ * the implementation forwards it down to `subscribe`, which closes the sub on
+ * abort (see nostr-tools pool.js). This typed wrapper exposes that: the promise
+ * resolves with whatever has arrived when EOSE fires, the per-relay `maxWait`
+ * elapses, OR `signal` aborts.
+ *
+ * That last case is the point — it lets a screen cancel an in-flight inbox
+ * fetch on tab-blur/unmount instead of the JS thread chewing through the full
+ * wrap backlog after the user has already navigated away (#751: the abort was
+ * plumbed to refreshDmInbox but never reached the relay subscription, so
+ * nav-away still waited the full fetch). The pool is passed in (rather than
+ * imported) to keep this a leaf module with no dependency back on nostrService.
+ */
+export function querySyncAbortable(
+  pool: SimplePool,
+  relays: string[],
+  filter: Filter,
+  params: { maxWait?: number; signal?: AbortSignal },
+): Promise<NostrEvent[]> {
+  return new Promise((resolve) => {
+    const events: NostrEvent[] = [];
+    if (params.signal?.aborted) {
+      resolve(events);
+      return;
+    }
+    let settled = false;
+    let closer: { close: (reason?: string) => void } | undefined;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        closer?.close();
+      } catch {
+        // sub may already be closing (abort/eose race) — ignore.
+      }
+      resolve(events);
+    };
+    closer = pool.subscribeMany(relays, filter, {
+      maxWait: params.maxWait,
+      abort: params.signal,
+      onevent(event) {
+        events.push(event);
+      },
+      oneose() {
+        finish();
+      },
+    });
+    // Resolve on abort too. nostr-tools closes the sub on abort, but it sets
+    // `signal.onabort` (single-slot, overwritten when one signal is shared
+    // across several parallel queries) — our additive listener fires for every
+    // query and closes each sub, so a shared signal cancels them all.
+    params.signal?.addEventListener('abort', finish, { once: true });
+  });
+}

--- a/src/utils/exploreFetchGuard.ts
+++ b/src/utils/exploreFetchGuard.ts
@@ -1,0 +1,24 @@
+// One-shot guard for ExploreHomeScreen's by-author cache fetch. Module-scoped
+// on purpose (NOT a component useRef): React 18 concurrent scheduling re-runs
+// the triggering effect 2–3× in quick succession on mount — `userRelays`
+// changes reference as relays hydrate — and the re-runs can fire before a ref
+// write is observed, launching parallel `fetchCachesByAuthor` calls (3 to 5
+// relays each). That was a real symptom in the #751 warm-path audit (three
+// completions within 10 ms). Module state is synchronous and shared across
+// those runs, so the first to claim a key wins and the rest skip.
+//
+// Keyed by `${pubkey}:${refreshKey}`, so pull-to-refresh (new refreshKey) and
+// an account switch (new pubkey) still re-fetch — only the redundant parallel
+// re-fires of the *same* key are suppressed.
+const claimedKeys = new Set<string>();
+
+/**
+ * Claim a fetch key. Returns `true` the first time a key is seen (the caller
+ * should proceed with the fetch) and `false` on every subsequent call for that
+ * key (the caller should skip — a fetch for it already started).
+ */
+export function claimExploreByAuthorFetch(key: string): boolean {
+  if (claimedKeys.has(key)) return false;
+  claimedKeys.add(key);
+  return true;
+}

--- a/src/utils/exploreFetchGuard.ts
+++ b/src/utils/exploreFetchGuard.ts
@@ -1,34 +1,35 @@
-// One-shot guard for ExploreHomeScreen's by-author cache fetch. Module-scoped
-// on purpose (NOT a component useRef): React 18 concurrent scheduling re-runs
-// the triggering effect 2–3× in quick succession on mount — `userRelays`
-// changes reference as relays hydrate — and the re-runs can fire before a ref
-// write is observed, launching parallel `fetchCachesByAuthor` calls (3 to 5
-// relays each). That was a real symptom in the #751 warm-path audit (three
-// completions within 10 ms). Module state is synchronous and shared across
-// those runs, so the first to claim a key wins and the rest skip.
+// In-flight de-duplication for ExploreHomeScreen's by-author cache fetch.
 //
-// Keyed by `${pubkey}:${refreshKey}`, so pull-to-refresh (new refreshKey) and
-// an account switch (new pubkey) still re-fetch — only the redundant parallel
-// re-fires of the *same* key are suppressed.
-const claimedKeys = new Set<string>();
+// React 18 concurrent scheduling re-runs the triggering effect 2–3× in quick
+// succession on mount (`userRelays` changes reference as relays hydrate). A
+// plain "claimed keys" Set prevented the parallel fetches but had a stranding
+// race (#752 Copilot): if the effect was cleaned up mid-flight, the replacement
+// run saw the key still claimed and skipped, and when the old promise later
+// resolved it discarded the data — so the user's own Piggies could stay missing
+// until a pull-to-refresh changed the key.
+//
+// Instead we store the in-flight PROMISE per key. Concurrent callers JOIN it
+// rather than starting a parallel request, and — crucially — the current
+// (non-cancelled) effect run shares that same promise and performs the merge
+// when it resolves, so cancellation never strands the data. The entry clears on
+// settle, so a later mount or a failed fetch re-fetches.
+const inFlight = new Map<string, Promise<unknown>>();
 
 /**
- * Claim a fetch key. Returns `true` the first time a key is seen (the caller
- * should proceed with the fetch) and `false` on every subsequent call for that
- * key (the caller should skip — a fetch for it already started).
+ * Run `fetchFn` for `key` at most once concurrently. The first caller starts the
+ * request; concurrent callers with the same key receive the same promise. The
+ * entry is removed once the promise settles (success or failure), so subsequent
+ * calls start a fresh request.
  */
-export function claimExploreByAuthorFetch(key: string): boolean {
-  if (claimedKeys.has(key)) return false;
-  claimedKeys.add(key);
-  return true;
-}
-
-/**
- * Release a previously-claimed key so a later mount can retry. Call this when
- * the fetch failed or was cancelled before its result was merged — otherwise a
- * claim that never produced data would permanently suppress the fetch for that
- * key (Copilot review on #752).
- */
-export function releaseExploreByAuthorFetch(key: string): void {
-  claimedKeys.delete(key);
+export function joinExploreByAuthorFetch<T>(key: string, fetchFn: () => Promise<T>): Promise<T> {
+  const existing = inFlight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = fetchFn();
+  inFlight.set(key, p);
+  void Promise.resolve(p)
+    .catch(() => undefined)
+    .finally(() => {
+      if (inFlight.get(key) === p) inFlight.delete(key);
+    });
+  return p;
 }

--- a/src/utils/exploreFetchGuard.ts
+++ b/src/utils/exploreFetchGuard.ts
@@ -22,3 +22,13 @@ export function claimExploreByAuthorFetch(key: string): boolean {
   claimedKeys.add(key);
   return true;
 }
+
+/**
+ * Release a previously-claimed key so a later mount can retry. Call this when
+ * the fetch failed or was cancelled before its result was merged — otherwise a
+ * claim that never produced data would permanently suppress the fetch for that
+ * key (Copilot review on #752).
+ */
+export function releaseExploreByAuthorFetch(key: string): void {
+  claimedKeys.delete(key);
+}

--- a/tests/unit/relayQuery.test.ts
+++ b/tests/unit/relayQuery.test.ts
@@ -1,0 +1,84 @@
+import { querySyncAbortable } from '../../src/services/relayQuery';
+import type { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+
+type SubParams = {
+  maxWait?: number;
+  abort?: AbortSignal;
+  onevent: (e: NostrEvent) => void;
+  oneose: () => void;
+};
+
+const makeEvent = (id: string): NostrEvent =>
+  ({ id, kind: 1, pubkey: 'p', created_at: 0, tags: [], content: '', sig: 's' }) as NostrEvent;
+
+/** Fake pool whose subscribeMany hands the caller the registered handlers so a
+ *  test can drive onevent / oneose / abort deterministically. */
+function fakePool(): { pool: SimplePool; params: () => SubParams; close: jest.Mock } {
+  let captured: SubParams | undefined;
+  const close = jest.fn();
+  const pool = {
+    subscribeMany: (_relays: string[], _filter: unknown, params: SubParams) => {
+      captured = params;
+      return { close };
+    },
+  } as unknown as SimplePool;
+  return {
+    pool,
+    params: () => {
+      if (!captured) throw new Error('subscribeMany was not called');
+      return captured;
+    },
+    close,
+  };
+}
+
+describe('querySyncAbortable', () => {
+  it('collects events and resolves on EOSE, closing the sub', async () => {
+    const { pool, params, close } = fakePool();
+    const promise = querySyncAbortable(pool, ['wss://r'], { kinds: [1] }, { maxWait: 1000 });
+    params().onevent(makeEvent('a'));
+    params().onevent(makeEvent('b'));
+    params().oneose();
+    const events = await promise;
+    expect(events.map((e) => e.id)).toEqual(['a', 'b']);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves with partial results and closes the sub when the signal aborts', async () => {
+    const { pool, params, close } = fakePool();
+    const ctrl = new AbortController();
+    const promise = querySyncAbortable(pool, ['wss://r'], { kinds: [1] }, { signal: ctrl.signal });
+    params().onevent(makeEvent('a'));
+    ctrl.abort();
+    const events = await promise;
+    expect(events.map((e) => e.id)).toEqual(['a']);
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('resolves empty immediately without subscribing if the signal is already aborted', async () => {
+    const subscribeMany = jest.fn();
+    const pool = { subscribeMany } as unknown as SimplePool;
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const events = await querySyncAbortable(
+      pool,
+      ['wss://r'],
+      { kinds: [1] },
+      { signal: ctrl.signal },
+    );
+    expect(events).toEqual([]);
+    expect(subscribeMany).not.toHaveBeenCalled();
+  });
+
+  it('settles only once even if EOSE fires after an abort', async () => {
+    const { pool, params, close } = fakePool();
+    const ctrl = new AbortController();
+    const promise = querySyncAbortable(pool, ['wss://r'], { kinds: [1] }, { signal: ctrl.signal });
+    ctrl.abort();
+    // A late EOSE from the relay must not throw or re-resolve.
+    params().oneose();
+    await promise;
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

JS-thread **locks moving between tabs** — cold (open onto Messages) *and* warm (tab-bouncing in a running app). Captured on a seeded account: the inbox fetch alone is `fetchInboxDmEvents: 12140ms wraps=508 … relays=5` — **96% of `refreshDmInbox`**, with heartbeat gaps of 4.7 s / 7.2 s.

## Why the last dozen PRs didn't fix it

Two Stevie perf audits (cold-start + a warm-path re-audit) attributed the locks to the relay **fetch/ingest** phase, **not** the NIP-17 decrypt loop that #193 #496 #505 #508 #532 #542 #560 #687 #730 #731 #745 #747 all optimised. nostr-tools parses + validates **every** incoming event synchronously *inside the library* before our code runs, so the cost is **volume × relay fan-out** (508 wraps × 5 relays). kind-1059 is already skip-verify, so it was never schnorr either. The instrumentation reported decrypt counters, which kept pointing everyone at the wrong phase.

## Fixes

1. **Abortable fetch** (`src/services/relayQuery.ts`) — `querySyncAbortable` wraps `pool.subscribeMany` and closes the sub on `abort`; `fetchInboxDmEvents` threads an `AbortSignal`. The abort was plumbed to `refreshDmInbox` but never reached the subscription (the #739 leak), so nav-away still waited the full fetch — now it cancels.
2. **GroupsScreen TTL gate** — it fired `force: true` on *every* focus, bypassing the 30 s TTL and re-ingesting the whole backlog (~10 s) each visit. Adds the MessagesScreen TTL+abort pattern, keeping `force` only when it actually fetches.
3. **Cold-start small fetch + deferred backfill** (`src/contexts/dmColdStartBackfill.ts`) — first refresh fetches only `COLD_INITIAL_WRAP_LIMIT` (200) wraps for a fast paint; a full-limit backfill runs in the background (deferred past interactions, abortable on blur).
4. **Explore triple-fire guard** (`src/utils/exploreFetchGuard.ts`) — a component `useRef` was defeated by React 18 concurrent scheduling, firing 3 parallel `fetchCachesByAuthor` on mount; moved to a module-scoped guard.
5. **`useCacheNotifications` AppState throttle** — coalesces back-to-back `active` events to one refetch per 10 s.

Three cohesive modules were **extracted** (`relayQuery`, `dmColdStartBackfill`, `exploreFetchGuard`) so `nostrService.ts` and `useDmInbox.ts` stay under their size caps. (`useDmInbox.ts` is at 998/1000 — a fuller split is worth a follow-up.)

## Test plan

1. **Automated:** `npx tsc --noEmit` ✅ · ESLint ✅ · Prettier ✅ · file-size gate ✅ · `jest` 155/155 ✅.
2. **On-device (seeded BIG account, 500 NIP-17 wraps on the emulator):** _before/after `heartbeat gap` + `fetchInboxDmEvents wraps=` numbers to be appended once the verification build lands_ — expected: cold Messages paints with `wraps≈200` (not 1000) and no multi-second gap; full backlog backfills in the background.
3. Drive the warm tab sequence (`tab-home` → `tab-explore` → `tab-friends` → `tab-messages` → repeat) and confirm: no ~10 s lock on **Groups** focus within the TTL window; Messages→Explore renders without waiting for the fetch (abort closes the sub); no triple `fetchCachesByAuthor` on Explore mount.

Refs #31 #193 #496 #505 #508 #532 #542 #560 #687 #730 #731 #739 #745 #747

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)
