### PR TITLE
fix(map): drop NIP-40-expired Piglets from the map (#762)

### DIFF
--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -314,8 +314,16 @@ const MapScreen: React.FC<Props> = ({ navigation }) => {
   }, [places, filters.lightning, filters.onchain, categoryFilter]);
 
   const visibleCaches = useMemo(() => {
+    // Drop NIP-40-expired caches — relays that don't honour expiration keep
+    // serving them, so the client filters them out. The Geo-caches list
+    // (HuntScreen) already does this; the map must too, else an expired Piglet
+    // lingers on the map after it's gone from the list (#762).
+    const nowSec = Date.now() / 1000;
     return [...caches.values()].filter(
-      (c) => (c.isLpPiggy ? filters.piglet : filters.nipgcCache) && isTrusted(c.hiderPubkey),
+      (c) =>
+        (c.isLpPiggy ? filters.piglet : filters.nipgcCache) &&
+        isTrusted(c.hiderPubkey) &&
+        (c.expiresAt === null || c.expiresAt > nowSec),
     );
   }, [caches, filters.piglet, filters.nipgcCache, isTrusted]);
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -313,19 +313,29 @@ const MapScreen: React.FC<Props> = ({ navigation }) => {
     });
   }, [places, filters.lightning, filters.onchain, categoryFilter]);
 
+  // Re-evaluate the NIP-40 expiry filter as time advances even if nothing else
+  // changes — a cache can expire while the map just sits open. A 60s tick is
+  // plenty (expiry is a slow day/year-scale boundary) and, unlike putting a
+  // per-render `Date.now()` in the memo deps (which would recompute
+  // visibleCaches every render), keeps the memo cached between ticks (#763).
+  const [nowSec, setNowSec] = useState(() => Date.now() / 1000);
+  useEffect(() => {
+    const t = setInterval(() => setNowSec(Date.now() / 1000), 60_000);
+    return () => clearInterval(t);
+  }, []);
+
   const visibleCaches = useMemo(() => {
     // Drop NIP-40-expired caches — relays that don't honour expiration keep
     // serving them, so the client filters them out. The Geo-caches list
     // (HuntScreen) already does this; the map must too, else an expired Piglet
     // lingers on the map after it's gone from the list (#762).
-    const nowSec = Date.now() / 1000;
     return [...caches.values()].filter(
       (c) =>
         (c.isLpPiggy ? filters.piglet : filters.nipgcCache) &&
         isTrusted(c.hiderPubkey) &&
         (c.expiresAt === null || c.expiresAt > nowSec),
     );
-  }, [caches, filters.piglet, filters.nipgcCache, isTrusted]);
+  }, [caches, filters.piglet, filters.nipgcCache, isTrusted, nowSec]);
 
   const refreshPlaces = useCallback(async (bbox: Bbox) => {
     try {


### PR DESCRIPTION
## Summary
The Geo-caches **list** (`HuntScreen.tsx`) already filters out NIP-40-expired caches client-side — public relays (damus, nostr.band, nos.lol, primal) mostly don't honour NIP-40 and keep serving expired events, so the client drops them. The **map** (`MapScreen` `visibleCaches`) didn't apply that filter, so an **expired Piglet still showed on the map** after it had disappeared from the list.

Surfaced by a user question about Piglet expiration.

## Change
One predicate added to `visibleCaches`, mirroring `HuntScreen`:
```
(c.expiresAt === null || c.expiresAt > nowSec)
```

## Out of scope (noted in #762)
Public relays keep the listing regardless (no `kind-5` deletion on expiry) — actively removing data from relays is a separate, larger follow-up. The bearer LNURL is never on relays.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` 0 errors on touched file
- [x] `npx prettier --check` clean
- [x] `bash scripts/check-file-size.sh` pass
- [ ] On-device: a Piglet past its NIP-40 expiry no longer renders a map pin but its non-expired neighbours still do

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)