### PR TITLE
docs(learn): note #523 back-arrow visibility fixed in v1.1.0 (#523)

### DIFF
--- a/src/screens/CourseDetailScreen.tsx
+++ b/src/screens/CourseDetailScreen.tsx
@@ -51,8 +51,7 @@ const CourseDetailScreen: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <View style={styles.container}>
-      {/* Back button floats above scroll — pink chevron on white pill so
-       * it stays visible against any course hero image. */}
+      {/* Pink chevron on a white pill, floating above the scroll — stays visible against any course hero image. Fixes #523 (white-on-white arrow); shipped in v1.1.0. */}
       <TouchableOpacity
         style={styles.backButton}
         onPress={() => navigation.goBack()}


### PR DESCRIPTION
## Summary

#523 reported the Learn → Course detail **back arrow rendering white-on-white** (invisible) over the hero image.

Verified this is **already fixed**: since #488 (shipped **v1.1.0**), `CourseDetailScreen`'s back button is a **pink chevron on a white pill** (`styles.backButton`), so it stays visible against any course hero image. `MissionDetailScreen`'s overlay arrow is likewise white-on-a-pink-circle.

This PR just **documents** that — collapsing the existing two-line comment into a single line that references the issue and the fix version — so #523 can be closed as resolved. **No behavioural or visual change.**

## Why no screenshot
There's no UI delta in this PR (comment-only). The current fixed state is the pink-chevron-on-white-pill already in `main`.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)