### PR TITLE
fix(map): back from DM-opened Map returns to the DM, not Home

### DIFF
--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -99,7 +99,13 @@ export type ExploreStackParamList = {
   Lessons: undefined;
   CourseDetail: { courseId: string };
   MissionDetail: { courseId: string; missionId: string };
-  Map: undefined;
+  // `returnTo` is set only when the Map is opened from a DM conversation's
+  // live-location card — it carries that conversation's route so Map's back
+  // button returns to the DM rather than the Explore tab. In-stack entry
+  // points (Explore/Places/Events/Hunt) omit it and fall back to goBack().
+  Map:
+    | { returnTo?: { screen: 'Conversation'; params: RootStackParamList['Conversation'] } }
+    | undefined;
   Places: undefined;
   PlaceDetail: { placeId: number };
   Hunt: undefined;

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -472,9 +472,17 @@ const ConversationScreen: React.FC = () => {
     () =>
       navigation.navigate('Main', {
         screen: 'MainTabs',
-        params: { screen: 'Explore', params: { screen: 'Map' } },
+        params: {
+          screen: 'Explore',
+          params: {
+            screen: 'Map',
+            // Carry this DM's route so the Map's back button returns here
+            // instead of dropping the user on the Explore tab.
+            params: { returnTo: { screen: 'Conversation', params: route.params } },
+          },
+        },
       }),
-    [navigation],
+    [navigation, route.params],
   );
 
   const handlePayInvoice = useCallback((raw: string) => {

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -377,18 +377,31 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
   const handleBack = useCallback(() => {
     const returnTo = route.params?.returnTo;
     if (returnTo?.screen === 'Conversation') {
+      // Pop this Map off the Explore stack first, otherwise it stays mounted
+      // (with its returnTo param) underneath the DM and re-appears next time
+      // the user visits the Explore tab.
+      navigation.popToTop();
       navigation.navigate('Conversation', returnTo.params);
       return;
     }
     navigation.goBack();
   }, [navigation, route.params]);
 
+  // The header + permission-screen back button can now return to a DM, so the
+  // "Back to Explore" wording only fits the in-stack entry points.
+  const backLabel = route.params?.returnTo ? 'Back' : 'Back to Explore';
+
   // ------- render --------------------------------------------------------
 
   if (permission === 'denied') {
     return (
       <View style={styles.container} testID="map-screen">
-        <Header onBack={handleBack} onOpenFilters={() => setFiltersOpen(true)} colors={colors} />
+        <Header
+          onBack={handleBack}
+          onOpenFilters={() => setFiltersOpen(true)}
+          colors={colors}
+          backLabel={backLabel}
+        />
         <View style={styles.deniedBody}>
           <MapPin size={64} color={colors.textSupplementary} strokeWidth={1.5} />
           <Text style={styles.deniedTitle}>Location permission required</Text>
@@ -401,7 +414,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
             onPress={handleBack}
             testID="map-permission-back-button"
           >
-            <Text style={styles.deniedButtonText}>Back to Explore</Text>
+            <Text style={styles.deniedButtonText}>{backLabel}</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -410,7 +423,12 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
 
   return (
     <View style={styles.container} testID="map-screen">
-      <Header onBack={handleBack} onOpenFilters={() => setFiltersOpen(true)} colors={colors} />
+      <Header
+        onBack={handleBack}
+        onOpenFilters={() => setFiltersOpen(true)}
+        colors={colors}
+        backLabel={backLabel}
+      />
       <View style={styles.webviewWrapper}>
         <LibreMiniMap
           lat={pos?.lat ?? null}
@@ -524,13 +542,14 @@ const Header: React.FC<{
   onBack: () => void;
   onOpenFilters: () => void;
   colors: Palette;
-}> = ({ onBack, onOpenFilters, colors }) => {
+  backLabel: string;
+}> = ({ onBack, onOpenFilters, colors, backLabel }) => {
   const styles = useMemo(() => createMapScreenStyles(colors), [colors]);
   return (
     <View style={styles.header}>
       <TouchableOpacity
         onPress={onBack}
-        accessibilityLabel="Back to Explore"
+        accessibilityLabel={backLabel}
         testID="map-back-button"
         hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
       >

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -31,7 +31,8 @@ import { useThemeColors } from '../contexts/ThemeContext';
 import { useTrustGraph } from '../contexts/TrustGraphContext';
 import type { Palette } from '../styles/palettes';
 import { createMapScreenStyles, type MapScreenStyles } from '../styles/MapScreen.styles';
-import { ExploreNavigation } from '../navigation/types';
+import { ExploreNavigation, RootNavigation, ExploreStackParamList } from '../navigation/types';
+import type { CompositeNavigationProp, RouteProp } from '@react-navigation/native';
 import {
   Bbox,
   BtcMapPlace,
@@ -60,7 +61,10 @@ import { useFriendsLiveLocations } from '../hooks/useFriendsLiveLocations';
 import { useIsFocused } from '@react-navigation/native';
 
 interface Props {
-  navigation: ExploreNavigation;
+  // Composite so the back handler can return to the DM (`Conversation` is a
+  // RootStack screen) when the Map is opened from a live-location card.
+  navigation: CompositeNavigationProp<ExploreNavigation, RootNavigation>;
+  route: RouteProp<ExploreStackParamList, 'Map'>;
 }
 
 type PermissionState = 'unknown' | 'granted' | 'denied';
@@ -73,7 +77,7 @@ type PermissionState = 'unknown' | 'granted' | 'denied';
  * Renderer is native MapLibre via the shared LibreMiniMap component (no
  * Google Maps, no API key, OSM tiles streamed from openstreetmap.org).
  */
-const MapScreen: React.FC<Props> = ({ navigation }) => {
+const MapScreen: React.FC<Props> = ({ navigation, route }) => {
   const colors = useThemeColors();
   // Tier-aware predicate from the Web-of-Trust context. `isTrusted`
   // already encodes the current wotTier (Friends / FoF / All), so
@@ -367,16 +371,24 @@ const MapScreen: React.FC<Props> = ({ navigation }) => {
     [refreshPlaces],
   );
 
+  // Back target: when opened from a DM live-location card the route carries
+  // `returnTo`, so return to that conversation; otherwise pop the stack —
+  // preserving back for the Explore / Places / Events / Hunt entry points.
+  const handleBack = useCallback(() => {
+    const returnTo = route.params?.returnTo;
+    if (returnTo?.screen === 'Conversation') {
+      navigation.navigate('Conversation', returnTo.params);
+      return;
+    }
+    navigation.goBack();
+  }, [navigation, route.params]);
+
   // ------- render --------------------------------------------------------
 
   if (permission === 'denied') {
     return (
       <View style={styles.container} testID="map-screen">
-        <Header
-          onBack={() => navigation.goBack()}
-          onOpenFilters={() => setFiltersOpen(true)}
-          colors={colors}
-        />
+        <Header onBack={handleBack} onOpenFilters={() => setFiltersOpen(true)} colors={colors} />
         <View style={styles.deniedBody}>
           <MapPin size={64} color={colors.textSupplementary} strokeWidth={1.5} />
           <Text style={styles.deniedTitle}>Location permission required</Text>
@@ -386,7 +398,7 @@ const MapScreen: React.FC<Props> = ({ navigation }) => {
           </Text>
           <TouchableOpacity
             style={styles.deniedButton}
-            onPress={() => navigation.goBack()}
+            onPress={handleBack}
             testID="map-permission-back-button"
           >
             <Text style={styles.deniedButtonText}>Back to Explore</Text>
@@ -398,11 +410,7 @@ const MapScreen: React.FC<Props> = ({ navigation }) => {
 
   return (
     <View style={styles.container} testID="map-screen">
-      <Header
-        onBack={() => navigation.goBack()}
-        onOpenFilters={() => setFiltersOpen(true)}
-        colors={colors}
-      />
+      <Header onBack={handleBack} onOpenFilters={() => setFiltersOpen(true)} colors={colors} />
       <View style={styles.webviewWrapper}>
         <LibreMiniMap
           lat={pos?.lat ?? null}


### PR DESCRIPTION
## Summary

Reported in testing: from a DM, tapping a **live-location card** opens the full Map, but **Back goes to Home (the Explore tab), not the originating DM**.

**Root cause:** `ConversationScreen.onOpenMap` cross-tab-navigates into `Explore → Map`. The Map's back was `navigation.goBack()`, which pops *within the Explore stack* (to Explore home) — it has no path back to the conversation, which lives on the root stack.

**Fix:** the DM now passes a `returnTo` param carrying its own route; `MapScreen.handleBack` navigates back to that `Conversation` when `returnTo` is present, and otherwise calls `goBack()`. So the **other entry points keep working unchanged** — Explore, Places, Events, Hunt, and the geo-cache/place detail screens all reach Map *within* the Explore stack and fall through to `goBack()`.

- `src/navigation/types.ts` — `Map` gains an optional `returnTo: { screen: 'Conversation'; params }`.
- `src/screens/ConversationScreen.tsx` — `onOpenMap` passes `returnTo` with this DM's route params.
- `src/screens/MapScreen.tsx` — `handleBack` honours `returnTo` (applied to the header back **and** the permission-screen back); nav prop widened to `CompositeNavigationProp<ExploreNavigation, RootNavigation>`.

tsc / ESLint (0 new errors) / Prettier all clean.

## Test plan
- [ ] DM → tap a live-location card → Map opens → **Back returns to that DM**.
- [ ] Explore → Map → Back → Explore home (unchanged).
- [ ] Places/Events/Hunt/geo-cache detail → Map → Back → that screen (unchanged).


Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
