### PR TITLE
chore(hunt): deny-list the "Swavesey Stash" dev test cache

### DIFF
--- a/src/services/devEventDenylist.test.ts
+++ b/src/services/devEventDenylist.test.ts
@@ -9,16 +9,18 @@ const { DEV_LEFTOVER_PUBKEYS } = __TEST__;
 
 describe('devEventDenylist', () => {
   describe('DEV_LEFTOVER_PUBKEYS', () => {
-    it('contains the four disposable-nsec Geo-Cache 1 signers', () => {
-      // These are the four signers discovered 2026-05-18 — locked in
-      // here so a careless edit to the deny-list (e.g. accidental
-      // dedupe past zero) shows up as a test failure rather than a
-      // silent regression where leftover events leak back into the UI.
+    it('contains the disposable-nsec test signers (4 Geo-Cache 1 + Swavesey Stash)', () => {
+      // Locked in here so a careless edit to the deny-list (e.g. accidental
+      // dedupe past zero) shows up as a test failure rather than a silent
+      // regression where leftover events leak back into the UI.
       const expected = [
+        // Four signers of d=big-piggy-geo-cache-1, discovered 2026-05-18.
         'b8d38e654adff224418002ae752155a84a86dab6fa94b4bc9e81ca9e25dce9e7',
         '1251920ed2f86d0ff2e14d95a2dba42e5f0c23da6e766549ec28318fd2a6004c',
         '5a6f56679c4d6d6b0a6c0be95cb1bed7758c53b618420e3dda579a98e277c372',
         'b94b5013aa137c1ecddffaea073b279a0c7a7d1a350d30a6bded87d2068f5e97',
+        // One-off signer of d=swavesey-trad-cache ("Swavesey Stash"), #774.
+        'b5ce7bd9825e3e6176d13dcfb34ed36b700215bfa6f70cf51e802225f558146e',
       ];
       for (const pk of expected) {
         expect(DEV_LEFTOVER_PUBKEYS.has(pk)).toBe(true);

--- a/src/services/devEventDenylist.ts
+++ b/src/services/devEventDenylist.ts
@@ -48,6 +48,14 @@ const DEV_LEFTOVER_PUBKEYS: ReadonlySet<string> = new Set([
   '5a6f56679c4d6d6b0a6c0be95cb1bed7758c53b618420e3dda579a98e277c372',
   //   npub1h994qya2zd7panwllt4qwwe8ngx85lg6x5xnpf4aakrayp50t6tsurqqlq
   'b94b5013aa137c1ecddffaea073b279a0c7a7d1a350d30a6bded87d2068f5e97',
+  // One-off disposable signer of `d=swavesey-trad-cache` (name="Swavesey
+  // Stash"), published 2026-05-10 via scripts/publish-test-piggy.mjs with
+  // LP_LABEL=0 — deliberately unlabelled so it masqueraded as a vanilla
+  // third-party NIP-GC cache during testing. Predates the script's
+  // named-fixture guard (#774 investigation), so the key is a lost
+  // throwaway: no nsec to NIP-09 delete or replace the event.
+  //   npub1kh88hkvztclxzak38h8mxnknddcqy9dl5mmseag7sq3zta2cz3hqun06j6
+  'b5ce7bd9825e3e6176d13dcfb34ed36b700215bfa6f70cf51e802225f558146e',
 ]);
 
 // O(1) membership test against the leftover set. Called per-event at


### PR DESCRIPTION
## What & why

Investigation (#774 thread) confirmed **"Swavesey Stash"** is not a genuine third-party geocache — it's our own dev test fixture, published 2026-05-10 via `scripts/publish-test-piggy.mjs` with `LP_LABEL=0` (deliberately unlabelled so it stands in for a vanilla third-party NIP-GC cache during testing). It was signed with a **one-off disposable key** (`b5ce7bd9…`, `npub1kh88hkv…`) that predates the script's named-fixture guard — so there's no nsec left to publish a NIP-09 delete or replace the event under its `d` tag. It sits on relays indefinitely.

This adds its pubkey to the existing ingestion-layer **dev-event deny-list** (`src/services/devEventDenylist.ts`), which filters such orphaned test events client-side before they reach storage / the rail / the map / the Hunt screen — exactly the documented purpose of that list. The entry meets the file's own criteria (NIP-GC kind-37516 dev event; key confirmed lost; not a BIG/MIDDLE/LITTLE/EVIL fixture).

## Test plan

Automated (CI): `devEventDenylist.test.ts` updated — the membership + exact-size guard now expects 5 entries (the 4 Geo-Cache-1 signers + Swavesey); `npx jest src/services/devEventDenylist.test.ts` passes (7/7), tsc/ESLint/Prettier clean.

Manual: on a build with this change, the "Swavesey Stash" cache no longer appears on the Map / Explore rail / Geo-caches list (it's dropped at the subscribe + querySync ingestion points in `nostrPlacesPublisher`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
