### PR TITLE
perf(map): release frozen-tab MapLibre GL + stop 1 Hz live-location re-render (#778)

### DIFF
--- a/src/components/ExploreMiniMap.tsx
+++ b/src/components/ExploreMiniMap.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo } from 'react';
+import { View, Text } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
+import { MapPin } from 'lucide-react-native';
+import { LibreMiniMap } from './LibreMiniMap';
+import { useThemeColors } from '../contexts/ThemeContext';
+import { createExploreMiniMapStyles } from '../styles/ExploreMiniMap.styles';
+import type { BtcMapPlace } from '../services/btcMapService';
+import type { ParsedCache, ParsedEvent } from '../services/nostrPlacesService';
+
+interface Props {
+  locationDenied: boolean;
+  lat: number | null;
+  lon: number | null;
+  userLat: number | null;
+  userLon: number | null;
+  userAccuracyMetres: number | null;
+  merchants: BtcMapPlace[];
+  caches: ParsedCache[];
+  events: ParsedEvent[];
+  onTapMap: () => void;
+  onOpenLegend: () => void;
+  onSelectMerchant: (m: BtcMapPlace) => void;
+  onSelectCache: (c: ParsedCache) => void;
+  onSelectEvent: (e: ParsedEvent) => void;
+}
+
+/**
+ * Explore hub's preview mini-map, focus-gated (#778).
+ *
+ * MapLibre's native GL context + tile cache (~130–175 MB) persist for the
+ * whole session once Explore is visited — `react-native-screens`'
+ * `freezeOnBlur` releases the SurfaceView buffers but NOT the GL context, so
+ * a second RenderThread leaks for the session. Gating the `LibreMiniMap`
+ * render on `useIsFocused()` means the GL context is torn down whenever the
+ * tab is frozen and only re-created on re-focus (the intended tradeoff: a
+ * one-off re-init for a permanent memory win).
+ *
+ * While unfocused we render a lightweight placeholder occupying the same
+ * layout slot (mirrors LibreMiniMap's own null-`lat` empty-View placeholder)
+ * so the rail layout below doesn't jump on focus changes.
+ */
+export const ExploreMiniMap: React.FC<Props> = ({
+  locationDenied,
+  lat,
+  lon,
+  userLat,
+  userLon,
+  userAccuracyMetres,
+  merchants,
+  caches,
+  events,
+  onTapMap,
+  onOpenLegend,
+  onSelectMerchant,
+  onSelectCache,
+  onSelectEvent,
+}) => {
+  const colors = useThemeColors();
+  const styles = useMemo(() => createExploreMiniMapStyles(colors), [colors]);
+  const isFocused = useIsFocused();
+
+  if (locationDenied) {
+    return (
+      <View style={styles.deniedCard}>
+        <MapPin size={20} color={colors.brandPink} strokeWidth={2.5} />
+        <View style={{ flex: 1 }}>
+          <Text style={styles.deniedTitle}>Allow location for nearby content</Text>
+          <Text style={styles.deniedSub}>
+            We use a coarse 5 km area to find merchants, caches, and meetups around you. Nothing
+            leaves your device beyond that.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  // Unfocused: don't mount MapLibre at all — render an empty layout-matching
+  // placeholder so the GL context is released while the tab is frozen. Keep
+  // the testID so flows still find the slot.
+  if (!isFocused) {
+    return <View style={styles.placeholder} testID="explore-minimap" />;
+  }
+
+  return (
+    <LibreMiniMap
+      // Mini-map is non-interactive (zoom-only, follows GPS) — so the camera
+      // anchor SHOULD track the live position, not the stale one-shot `pos`
+      // (seeded from a cached merchant-centroid anchor on cold start). Falls
+      // back to `pos` only while the live fix is still resolving.
+      lat={lat}
+      lon={lon}
+      userLat={userLat}
+      userLon={userLon}
+      userAccuracyMetres={userAccuracyMetres}
+      merchants={merchants}
+      caches={caches}
+      events={events}
+      onTapMap={onTapMap}
+      onOpenLegend={onOpenLegend}
+      // Pin-tap handlers — open the same MerchantDetailSheet / CacheDetailSheet
+      // that MapScreen renders so the interaction shape is identical across
+      // surfaces (PR #630). Events have no dedicated sheet in MapScreen either,
+      // so the event tap navigates directly to EventDetail.
+      onSelectMerchant={onSelectMerchant}
+      onSelectCache={onSelectCache}
+      onSelectEvent={onSelectEvent}
+      // Maestro flow test-explore-tab-rename.yaml asserts this testID —
+      // preserved across the MapLibre swap so the e2e smoke test isn't
+      // repointed.
+      testID="explore-minimap"
+    />
+  );
+};
+
+export default ExploreMiniMap;

--- a/src/hooks/useConversationLiveLocation.stableRecord.test.ts
+++ b/src/hooks/useConversationLiveLocation.stableRecord.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-native';
+import { useStableRecord } from './useConversationLiveLocation';
+
+// Guards the 1 Hz re-render fix (#778): the status / remaining read-models are
+// rebuilt every second tick, so `useStableRecord` must hand back the PREVIOUS
+// object reference whenever the content is unchanged — otherwise a fresh
+// reference flows into ConversationScreen's renderItem deps and re-renders
+// every visible row each second during a live-location share.
+describe('useStableRecord', () => {
+  it('returns the same reference when a new but equal object is passed', () => {
+    const { result, rerender } = renderHook(
+      (props: { value: Record<string, string> }) => useStableRecord(props.value),
+      {
+        initialProps: { value: { a: 'active', b: 'ended' } as Record<string, string> },
+      },
+    );
+    const first = result.current;
+
+    // New object, identical content (what the 1 Hz tick produces).
+    rerender({ value: { a: 'active', b: 'ended' } });
+    expect(result.current).toBe(first);
+  });
+
+  it('swaps to the new reference when content actually changes', () => {
+    const { result, rerender } = renderHook(
+      (props: { value: Record<string, string> }) => useStableRecord(props.value),
+      {
+        initialProps: { value: { a: 'active' } as Record<string, string> },
+      },
+    );
+    const first = result.current;
+
+    rerender({ value: { a: 'ended' } });
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({ a: 'ended' });
+  });
+
+  it('treats key changes (added / removed sessions) as a real change', () => {
+    const { result, rerender } = renderHook(
+      (props: { value: Record<string, number> }) => useStableRecord(props.value),
+      {
+        initialProps: { value: { a: 1 } as Record<string, number> },
+      },
+    );
+    const first = result.current;
+
+    rerender({ value: { a: 1, b: 2 } });
+    expect(result.current).not.toBe(first);
+
+    const second = result.current;
+    rerender({ value: { a: 1, b: 2 } });
+    expect(result.current).toBe(second);
+  });
+
+  it('keeps a numeric countdown moving each tick (the bubble still updates)', () => {
+    const { result, rerender } = renderHook(
+      (props: { value: Record<string, number> }) => useStableRecord(props.value),
+      {
+        initialProps: { value: { s: 30000 } as Record<string, number> },
+      },
+    );
+    const first = result.current;
+
+    // Active share: remaining-ms decrements, so the reference SHOULD change so
+    // the countdown bubble's own row re-renders.
+    rerender({ value: { s: 29000 } });
+    expect(result.current).not.toBe(first);
+    expect(result.current.s).toBe(29000);
+  });
+});

--- a/src/hooks/useConversationLiveLocation.ts
+++ b/src/hooks/useConversationLiveLocation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { LIVE_LOCATION_PING_KIND } from '../services/liveLocationService';
 import { subscribeLiveLocationPings } from '../services/nostrLiveLocation';
 import { decryptIncomingLivePing } from '../services/liveLocationPingReceive';
@@ -9,6 +9,22 @@ import type { Item } from '../utils/conversationItems';
 import type { RelayConfig } from '../types/nostr';
 
 type LiveStatus = 'active' | 'paused' | 'ended' | 'expired' | undefined;
+
+// Stabilise an object's identity across renders (#778). The status / remaining
+// read-models below are rebuilt every 1 Hz `secondTick`, handing back a NEW
+// Record each second even when nothing changed. That new reference flows into
+// ConversationScreen's `renderItem` deps → a new `renderItem` → FlatList
+// re-evaluates every visible row → every `ConversationMessageRow` (React.memo,
+// shallow compare) re-renders once a second during a live share. Returning the
+// PREVIOUS object when its content is unchanged (cheap JSON compare — these
+// maps hold at most a handful of small entries) keeps `renderItem` stable, so
+// only the countdown bubble's own row re-renders when its value actually moves.
+export function useStableRecord<T extends object>(next: T): T {
+  const prevRef = useRef<T>(next);
+  if (JSON.stringify(next) === JSON.stringify(prevRef.current)) return prevRef.current;
+  prevRef.current = next;
+  return next;
+}
 
 // Receive-side live-location plumbing for the 1:1 ConversationScreen (#206).
 // Extracted from the screen (#703 size cap): owns the kind-20069 coordinate
@@ -143,7 +159,7 @@ export function useConversationLiveLocation(params: {
   // Per-session status the bubble renders: `ended` once an end marker arrives,
   // otherwise the context's authoritative status for our own shares, otherwise
   // active/ended by wall-clock for inbound shares.
-  const liveLocationBubbleStatus = useMemo<Record<string, LiveStatus>>(() => {
+  const liveLocationBubbleStatusRaw = useMemo<Record<string, LiveStatus>>(() => {
     const out: Record<string, LiveStatus> = {};
     const seenEndIds = new Set<string>();
     for (const it of items) {
@@ -171,8 +187,11 @@ export function useConversationLiveLocation(params: {
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- secondTick re-runs the Date.now() wall-clock status each second
   }, [items, sessionsByRecipient, pubkey, secondTick]);
+  // Keep a stable reference while content is unchanged so the 1 Hz tick doesn't
+  // churn ConversationScreen's renderItem (#778).
+  const liveLocationBubbleStatus = useStableRecord(liveLocationBubbleStatusRaw);
 
-  const liveLocationBubbleRemaining = useMemo<Record<string, number | undefined>>(() => {
+  const liveLocationBubbleRemainingRaw = useMemo<Record<string, number | undefined>>(() => {
     const out: Record<string, number | undefined> = {};
     const now = Date.now();
     for (const it of items) {
@@ -192,6 +211,10 @@ export function useConversationLiveLocation(params: {
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- secondTick re-runs the Date.now() remaining-time countdown each second
   }, [items, remainingMsForSession, secondTick]);
+  // Stable reference while content is unchanged (#778). NOTE: the remaining-ms
+  // values DO change each second for an active share, so the countdown bubble's
+  // own row still re-renders every tick — only unrelated rows are spared.
+  const liveLocationBubbleRemaining = useStableRecord(liveLocationBubbleRemainingRaw);
 
   // Drive the 1 Hz tick declared above — but only when the thread actually has a live-location bubble, so chats with none don't re-render once a second for nothing.
   const hasLiveMarkers = useMemo(

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react-native';
 import TabHeader from '../components/TabHeader';
 import { ContentRail } from '../components/ContentRail';
-import { LibreMiniMap } from '../components/LibreMiniMap';
+import { ExploreMiniMap } from '../components/ExploreMiniMap';
 import { LpPayoutBadge } from '../components/LpPayoutBadge';
 import { MerchantDetailSheet } from '../components/MerchantDetailSheet';
 import { CacheDetailSheet } from '../components/CacheDetailSheet';
@@ -864,53 +864,29 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
           />
         }
       >
-        {locationDenied ? (
-          <View style={localStyles.deniedCard}>
-            <MapPin size={20} color={colors.brandPink} strokeWidth={2.5} />
-            <View style={{ flex: 1 }}>
-              <Text style={localStyles.deniedTitle}>Allow location for nearby content</Text>
-              <Text style={localStyles.deniedSub}>
-                We use a coarse 5 km area to find merchants, caches, and meetups around you. Nothing
-                leaves your device beyond that.
-              </Text>
-            </View>
-          </View>
-        ) : (
-          <LibreMiniMap
-            // Mini-map is non-interactive (zoom-only, follows GPS) — so
-            // the camera anchor SHOULD track the live position, not
-            // the stale one-shot `pos` (which was seeded from a cached
-            // merchant-centroid anchor on cold start). Falls back to
-            // `pos` only while the live fix is still resolving.
-            lat={livePos?.lat ?? pos?.lat ?? null}
-            lon={livePos?.lon ?? pos?.lon ?? null}
-            userLat={livePos?.lat ?? null}
-            userLon={livePos?.lon ?? null}
-            // Cached anchor accuracy is only useful BEFORE a live fix
-            // arrives. Once livePos exists, trust its accuracy (even
-            // if null) so the halo never renders around live coords
-            // using stale data from a different measurement.
-            userAccuracyMetres={livePos ? livePos.accuracy : (pos?.accuracy ?? null)}
-            merchants={merchants}
-            caches={cachesArr}
-            events={eventsArr}
-            onTapMap={onTapMap}
-            onOpenLegend={onOpenLegend}
-            // Pin-tap handlers — open the same MerchantDetailSheet /
-            // CacheDetailSheet that MapScreen renders so the interaction
-            // shape is identical across surfaces (PR #630). Events have
-            // no dedicated sheet in MapScreen either, so the event tap
-            // navigates directly to EventDetail — consistent with the
-            // event rail card tap below.
-            onSelectMerchant={(m) => setSelectedMerchant(m)}
-            onSelectCache={(c) => setSelectedCache(c)}
-            onSelectEvent={(e) => navigation.navigate('EventDetail', { coord: e.coord })}
-            // Maestro flow test-explore-tab-rename.yaml asserts this
-            // testID — preserved across the MapLibre swap so the e2e
-            // smoke test doesn't need to be repointed.
-            testID="explore-minimap"
-          />
-        )}
+        <ExploreMiniMap
+          locationDenied={locationDenied}
+          // Mini-map is non-interactive (zoom-only, follows GPS) — so the
+          // camera anchor SHOULD track the live position, not the stale
+          // one-shot `pos` (seeded from a cached merchant-centroid anchor on
+          // cold start). Falls back to `pos` only while the live fix resolves.
+          lat={livePos?.lat ?? pos?.lat ?? null}
+          lon={livePos?.lon ?? pos?.lon ?? null}
+          userLat={livePos?.lat ?? null}
+          userLon={livePos?.lon ?? null}
+          // Cached anchor accuracy is only useful BEFORE a live fix arrives.
+          // Once livePos exists, trust its accuracy (even if null) so the halo
+          // never renders around live coords using stale data.
+          userAccuracyMetres={livePos ? livePos.accuracy : (pos?.accuracy ?? null)}
+          merchants={merchants}
+          caches={cachesArr}
+          events={eventsArr}
+          onTapMap={onTapMap}
+          onOpenLegend={onOpenLegend}
+          onSelectMerchant={(m) => setSelectedMerchant(m)}
+          onSelectCache={(c) => setSelectedCache(c)}
+          onSelectEvent={(e) => navigation.navigate('EventDetail', { coord: e.coord })}
+        />
 
         <ContentRail<{ place: BtcMapPlace; distance: number }>
           title="Places near you"
@@ -1332,27 +1308,6 @@ const createLocalStyles = (colors: Palette) =>
       fontSize: 13,
       color: colors.textSupplementary,
       lineHeight: 19,
-    },
-    deniedCard: {
-      flexDirection: 'row',
-      gap: 12,
-      backgroundColor: colors.surface,
-      marginHorizontal: 16,
-      marginBottom: 18,
-      padding: 14,
-      borderRadius: 12,
-      alignItems: 'flex-start',
-    },
-    deniedTitle: {
-      fontSize: 14,
-      fontWeight: '700',
-      color: colors.textHeader,
-    },
-    deniedSub: {
-      fontSize: 12,
-      color: colors.textSupplementary,
-      marginTop: 4,
-      lineHeight: 17,
     },
   });
 

--- a/src/styles/ExploreMiniMap.styles.ts
+++ b/src/styles/ExploreMiniMap.styles.ts
@@ -1,0 +1,41 @@
+import { StyleSheet } from 'react-native';
+import type { Palette } from './palettes';
+
+export const createExploreMiniMapStyles = (colors: Palette) =>
+  StyleSheet.create({
+    // Unfocused placeholder. Mirrors LibreMiniMap's `container` (height 200,
+    // 16dp side margins, 18dp bottom gap, 14dp radius) so the rail layout
+    // below doesn't shift when the GL map mounts / unmounts on focus changes
+    // (#778). Brand-pink surface so the empty slot still reads as our UI.
+    placeholder: {
+      height: 200,
+      marginHorizontal: 16,
+      marginBottom: 18,
+      borderRadius: 14,
+      overflow: 'hidden',
+      backgroundColor: colors.brandPink,
+    },
+    deniedCard: {
+      flexDirection: 'row',
+      gap: 12,
+      backgroundColor: colors.surface,
+      marginHorizontal: 16,
+      marginBottom: 18,
+      padding: 14,
+      borderRadius: 12,
+      alignItems: 'flex-start',
+    },
+    deniedTitle: {
+      fontSize: 14,
+      fontWeight: '700',
+      color: colors.textHeader,
+    },
+    deniedSub: {
+      fontSize: 12,
+      color: colors.textSupplementary,
+      marginTop: 4,
+      lineHeight: 17,
+    },
+  });
+
+export type ExploreMiniMapStyles = ReturnType<typeof createExploreMiniMapStyles>;


### PR DESCRIPTION
Two independent perf fixes from Stev.ie's long-session map-memory audit (one PR).

## Fix 1 — Gate the Explore mini-map's MapLibre GL on focus

`react-native-screens`' `freezeOnBlur` releases the SurfaceView buffers when a tab is frozen, but MapLibre's **native GL context + ~130–175 MB tile cache PERSIST for the whole session** once Explore is visited — a permanent second RenderThread.

The Explore preview map is extracted into a new `ExploreMiniMap` component (one nameable responsibility: "the focus-gated Explore preview map") which renders the live `LibreMiniMap` **only while `useIsFocused()`**. When the tab is frozen it renders a lightweight placeholder occupying the same layout slot (height 200, same margins/radius — mirrors `LibreMiniMap`'s own null-`lat` empty-`View`), so the GL context is torn down while frozen and re-created on re-focus. That re-init on focus is the intended tradeoff for a permanent memory win.

This also **net-shrinks the over-cap `ExploreHomeScreen`** (1377 → 1332), so the size gate stays green.

- New: `src/components/ExploreMiniMap.tsx`, `src/styles/ExploreMiniMap.styles.ts`
- The `explore-minimap` testID is preserved on both the live map and the placeholder, so `test-explore-tab-rename.yaml` still finds it.

## Fix 2 — Stop the 1 Hz FlatList re-render in ConversationScreen during a live share

`useConversationLiveLocation` returned `liveLocationBubbleStatus` / `liveLocationBubbleRemaining` as **new `Record` references every `secondTick` (1 s)**. That flowed into `ConversationScreen`'s `renderItem` deps → new `renderItem` ref → FlatList re-evaluated every visible row → every `ConversationMessageRow` (`React.memo`, shallow compare) re-rendered **once a second** while a live-location share was active.

Fix: a `useStableRecord` ref-holder returns the **previous** object when a `JSON.stringify` compare shows the content is unchanged, applied to both Records. The countdown bubble still updates each tick (its remaining-ms value genuinely changes, so its own row re-renders); unrelated rows stop churning.

Adds `src/hooks/useConversationLiveLocation.stableRecord.test.ts` covering: stable ref on equal content, swap on real change, key add/remove, and a moving numeric countdown.

## Test plan

Gates (all green locally):
- `npx tsc --noEmit` — 0 errors
- `npx eslint <changed>` — 0 errors (1 pre-existing unused-disable warning in `ExploreHomeScreen`, present on main, shifted line only)
- `npx prettier --write <changed>` — clean
- `npx jest src/hooks/ src/services/liveLocation` — 50/50 pass (incl. 4 new stable-ref tests)
- `bash scripts/check-file-size.sh` — pass (`ExploreHomeScreen` 1377 → 1332)

Manual on-device:

**Fix 1 (GL release):**
1. Cold-start the app, capture baseline memory: `adb shell dumpsys meminfo <pkg> | grep TOTAL`.
2. Open the Explore tab, let the mini-map render, then switch to another tab (Home / Messages / Friends).
3. Re-check meminfo — the MapLibre GL native allocation / second RenderThread should be released while Explore is blurred (vs. before, where it persisted for the session). Confirm via `adb shell dumpsys meminfo` GL/EGL lines or a Perfetto RenderThread trace.
4. Re-focus Explore — the map re-mounts cleanly, shows the "you" dot + merchant/cache/event markers, and the rail layout below does not jump (placeholder held the slot).

**Fix 2 (re-render):**
1. Start an inbound live-location share in a 1:1 conversation so the countdown bubble is active.
2. With React DevTools "Highlight updates" (or a row-level render log), confirm only the live-location bubble's row repaints each second — the surrounding message rows no longer flash once a second.
3. Confirm the countdown text still ticks down each second and the share still ends correctly at expiry.

Closes #778


---

## 📊 Measured performance (before → after, Pixel 8 — Stev.ie)

**GL release on Explore blur** (Maestro: launch → Explore → Home; `dumpsys meminfo` + RenderThread count):

| State | GL mtrack (main → branch) | RenderThreads (main → branch) |
|---|---|---|
| Explore focused | 85 MB → 108 MB | 4 → 3 |
| Explore **blurred** | 73 MB → **70 MB** | 3 → **2** |
| Re-focused | clean remount, no layout jump | → 3 |

**Verdict: works.** Blurring Explore releases **1 extra RenderThread** (the 2nd MapLibre GL context) + ~3 MB tile cache vs baseline. The 51 MB EGL surface releases on both — that's `freezeOnBlur`, not this PR; the PR's contribution is the RenderThread teardown + tile-cache release.

**Honest caveat:** the original 130–175 MB projection came from a *long, heavy* session (the 8h live-share that caused the near-freeze). A short fresh session only caches ~85–108 MB, so the absolute release here is modest — **the benefit scales with session length / map use, i.e. it's largest in exactly the long-session scenario this targets.**

**Fix 2 (1 Hz re-render):** unit-tested (`useStableRecord`); not measurable in isolation without an active live-location share. No regression observed.
