### PR TITLE
feat(profile): pull-to-refresh re-fetches contact profile + posts

### DIFF
--- a/src/components/FriendNoteFeed.tsx
+++ b/src/components/FriendNoteFeed.tsx
@@ -18,6 +18,9 @@ import type { Palette } from '../styles/palettes';
 interface Props {
   authorPubkey: string;
   limit?: number;
+  // Bumped by the parent's pull-to-refresh to re-open the subscription and
+  // re-query for new posts (the sub is otherwise opened once per focus).
+  reloadNonce?: number;
 }
 
 const RENDER_CAP = 20;
@@ -25,7 +28,7 @@ const RENDER_CAP = 20;
 // sub stays open in the background but the UI shifts to the empty state.
 const FIRST_EVENT_GRACE_MS = 6000;
 
-const FriendNoteFeed: React.FC<Props> = ({ authorPubkey, limit = 30 }) => {
+const FriendNoteFeed: React.FC<Props> = ({ authorPubkey, limit = 30, reloadNonce = 0 }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const { relays } = useNostr();
@@ -126,7 +129,7 @@ const FriendNoteFeed: React.FC<Props> = ({ authorPubkey, limit = 30 }) => {
         clearTimeout(graceTimer);
         unsubscribe();
       };
-    }, [authorPubkey, readRelays, limit]),
+    }, [authorPubkey, readRelays, limit, reloadNonce]),
   );
 
   if (!authorPubkey) return null;

--- a/src/screens/ContactProfileScreen.tsx
+++ b/src/screens/ContactProfileScreen.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   ScrollView,
+  RefreshControl,
   Linking,
   Share,
 } from 'react-native';
@@ -83,6 +84,9 @@ const ContactProfileScreen: React.FC = () => {
   const [sharing, setSharing] = useState(false);
   const [nfcWriteVisible, setNfcWriteVisible] = useState(false);
   const [nfcSupported, setNfcSupported] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  // Bumped on pull-to-refresh to make FriendNoteFeed re-query for new posts.
+  const [notesReloadNonce, setNotesReloadNonce] = useState(0);
 
   // React Navigation may reuse this screen instance and only update params
   // when navigating to ContactProfile while it's already in the stack.
@@ -172,6 +176,38 @@ const ContactProfileScreen: React.FC = () => {
       cancelled = true;
     };
   }, [contact.pubkey, contact.about, contact.lightningAddress, relays]);
+
+  // Pull-to-refresh: unlike the gap-fill effect above (which only fills
+  // missing about/lud16, once), this re-fetches the kind-0 from relays and
+  // OVERWRITES every displayed field with the latest — so a friend who
+  // updated their name, picture, banner, bio or Lightning address surfaces
+  // without waiting out the 24h profile cache. `fetchProfile` is a direct
+  // relay query, so there's no cache to bypass.
+  const handleRefresh = useCallback(async () => {
+    if (!contact.pubkey) return;
+    setRefreshing(true);
+    try {
+      const readRelays = relays.filter((r) => r.read).map((r) => r.url);
+      const fresh = await fetchProfile(contact.pubkey, readRelays);
+      if (fresh) {
+        setContact((prev) => ({
+          ...prev,
+          name: fresh.displayName ?? fresh.name ?? prev.name,
+          picture: fresh.picture ?? null,
+          banner: fresh.banner ?? null,
+          about: fresh.about ?? null,
+          lightningAddress: fresh.lud16 ?? null,
+          nip05: fresh.nip05 ?? prev.nip05 ?? null,
+        }));
+      }
+    } catch {
+      // best-effort — a failed refresh leaves the current data in place
+    } finally {
+      setRefreshing(false);
+    }
+    // Re-query the kind-1 note feed for new posts too.
+    setNotesReloadNonce((n) => n + 1);
+  }, [contact.pubkey, relays]);
 
   useEffect(() => {
     if (contact.pubkey) {
@@ -405,7 +441,11 @@ const ContactProfileScreen: React.FC = () => {
         )}
       </View>
 
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+      >
         {/* Banner — contact's own if set, else the brand pink-ostrich texture. */}
         <View style={styles.bannerContainer}>
           {contact.banner ? (
@@ -622,7 +662,9 @@ const ContactProfileScreen: React.FC = () => {
         )}
 
         {/* Friend's recent kind-1 notes. Hidden for phone-only contacts. */}
-        {contact.pubkey && <FriendNoteFeed authorPubkey={contact.pubkey} />}
+        {contact.pubkey && (
+          <FriendNoteFeed authorPubkey={contact.pubkey} reloadNonce={notesReloadNonce} />
+        )}
       </ScrollView>
 
       {npub && (

--- a/src/screens/ContactProfileScreen.tsx
+++ b/src/screens/ContactProfileScreen.tsx
@@ -197,7 +197,7 @@ const ContactProfileScreen: React.FC = () => {
           banner: fresh.banner ?? null,
           about: fresh.about ?? null,
           lightningAddress: fresh.lud16 ?? null,
-          nip05: fresh.nip05 ?? prev.nip05 ?? null,
+          nip05: fresh.nip05 ?? null,
         }));
       }
     } catch {


### PR DESCRIPTION
## Summary

Adds **pull-to-refresh** to the friend profile page (`ContactProfileScreen`). Previously the page only **gap-filled** missing `about`/`lud16` once (`prev.x ?? …`) and never refreshed `name`/`picture`/`banner` — so a friend who updated their profile, or a freshly-published `lud16`, wouldn't surface until the **24h profile cache** expired.

Now pulling down:
- Re-fetches the contact's **kind‑0** via `fetchProfile` — a direct `pool.get` relay query, so there's no cache to bypass — and **overwrites** `name`, `picture`, `banner`, `about`, `lightningAddress` (and `nip05`) with the latest.
- Bumps a `reloadNonce` passed to **`FriendNoteFeed`**, which now includes it in the subscription effect deps, so the **kind‑1 note feed re-queries for new posts** too.

### Files
- `src/screens/ContactProfileScreen.tsx` — `RefreshControl` + `handleRefresh` (profile overwrite) + nonce.
- `src/components/FriendNoteFeed.tsx` — optional `reloadNonce` prop wired into the sub effect deps.

tsc / ESLint (0 errors) / Prettier clean.

## Why this matters
Mirrors the Friends‑tab pull-to-refresh (`refreshContacts` → `loadContacts({force:true})`), giving the same "get the latest" affordance on the individual profile — the gap that left a friend's just-updated `lud16`/banner stale when viewing their profile.

## Test plan
- [ ] Open a friend's profile → pull down → name/picture/banner/bio/Lightning address update to their latest kind‑0.
- [ ] New kind‑1 posts by that friend appear after the pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #784