### PR TITLE
perf(messages): yield the cold-start DM inbox decrypt off the JS thread (#788)

### DIFF
--- a/src/contexts/dmRefreshGate.test.ts
+++ b/src/contexts/dmRefreshGate.test.ts
@@ -1,0 +1,72 @@
+import { isColdStartRefresh, shouldSkipForFreshness, shouldStampCursor } from './dmRefreshGate';
+import { DM_INBOX_REFRESH_TTL_MS } from './nostrDmCache';
+
+describe('dmRefreshGate', () => {
+  describe('isColdStartRefresh', () => {
+    it('is true before any refresh has completed (cursor at 0)', () => {
+      expect(isColdStartRefresh(0)).toBe(true);
+    });
+
+    it('is false once a refresh has stamped the cursor', () => {
+      expect(isColdStartRefresh(1234.5)).toBe(false);
+    });
+  });
+
+  describe('shouldStampCursor', () => {
+    it('stamps when the refresh completed (not aborted)', () => {
+      expect(shouldStampCursor(false)).toBe(true);
+    });
+
+    it('does NOT stamp when the refresh was aborted', () => {
+      // The load-bearing case: an aborted refresh must leave the cursor at 0
+      // so the NEXT refresh still reports isColdStart === true and takes
+      // #788's macro-task yield path.
+      expect(shouldStampCursor(true)).toBe(false);
+    });
+  });
+
+  describe('shouldSkipForFreshness', () => {
+    it('never skips a forced refresh, even within the TTL', () => {
+      expect(shouldSkipForFreshness(1000, true, 1000 + 1)).toBe(false);
+    });
+
+    it('does not skip when no refresh has completed (cursor at 0)', () => {
+      expect(shouldSkipForFreshness(0, false, 5_000)).toBe(false);
+    });
+
+    it('skips a non-forced refresh inside the TTL window', () => {
+      const last = 10_000;
+      const now = last + DM_INBOX_REFRESH_TTL_MS - 1;
+      expect(shouldSkipForFreshness(last, false, now)).toBe(true);
+    });
+
+    it('does not skip once the TTL window has elapsed', () => {
+      const last = 10_000;
+      const now = last + DM_INBOX_REFRESH_TTL_MS + 1;
+      expect(shouldSkipForFreshness(last, false, now)).toBe(false);
+    });
+  });
+
+  describe('cold-start survives an aborted refresh (regression for #788)', () => {
+    it('keeps the next refresh a cold start when the prior one aborted', () => {
+      // Simulate the cursor the hook holds.
+      let cursor = 0;
+
+      // First (cold) refresh starts: it IS a cold start.
+      expect(isColdStartRefresh(cursor)).toBe(true);
+
+      // ...but it gets aborted mid-decrypt (e.g. the spurious enforce-flip
+      // refresh, now removed, used to abort it). The hook must not stamp.
+      const aborted = true;
+      if (shouldStampCursor(aborted)) cursor = 999; // would-be stamp
+      expect(cursor).toBe(0);
+
+      // The retry therefore still sees a cold start and takes the yield path.
+      expect(isColdStartRefresh(cursor)).toBe(true);
+
+      // A clean completion finally stamps the cursor.
+      if (shouldStampCursor(false)) cursor = 12_345;
+      expect(isColdStartRefresh(cursor)).toBe(false);
+    });
+  });
+});

--- a/src/contexts/dmRefreshGate.ts
+++ b/src/contexts/dmRefreshGate.ts
@@ -1,0 +1,52 @@
+import { DM_INBOX_REFRESH_TTL_MS } from './nostrDmCache';
+
+/**
+ * Pure freshness-cursor logic for `refreshDmInbox` (#788). The hook holds a
+ * single `dmInboxLastRefreshAt` cursor (`performance.now()` of the last
+ * COMPLETED refresh, `0` before any has finished) that drives three
+ * decisions. Extracting them keeps `useDmInbox` under the file-size cap and,
+ * more importantly, makes the cold-start ↔ abort interaction unit-testable
+ * without standing up the whole hook + relay/decrypt stack.
+ *
+ * The load-bearing invariant: an ABORTED refresh must not advance the cursor.
+ * If it did, the next refresh would (a) see `isColdStart === false` and skip
+ * the cold-start macro-task yield (#788), and (b) be wrongly suppressed by the
+ * TTL freshness gate even though no refresh ever completed.
+ */
+
+/**
+ * Cold start = the first refresh of the session, i.e. no refresh has yet
+ * COMPLETED and advanced the cursor. `force` does NOT exclude a cold start —
+ * the real cold load is MessagesScreen's on-mount focus refresh; the
+ * cold-start wrap cap + macro-task yield must apply to it. (#751/#788)
+ */
+export function isColdStartRefresh(lastRefreshAt: number): boolean {
+  return lastRefreshAt === 0;
+}
+
+/**
+ * Whether to skip the refresh entirely because a previous one COMPLETED within
+ * the freshness TTL. `force` callers (pull-to-refresh) always bypass it; the
+ * Messages-tab `useFocusEffect` uses the default path so tab-bouncing doesn't
+ * re-fire expensive relay+decrypt work. `now` is injected for testability.
+ */
+export function shouldSkipForFreshness(
+  lastRefreshAt: number,
+  force: boolean,
+  now: number,
+): boolean {
+  if (force) return false;
+  if (lastRefreshAt <= 0) return false;
+  return now - lastRefreshAt < DM_INBOX_REFRESH_TTL_MS;
+}
+
+/**
+ * Whether the completion of a refresh should advance the freshness cursor.
+ * The refresh task RESOLVES (never rejects) on abort — it early-returns
+ * internally on `signal.aborted` — so the `await task` site runs in both the
+ * completed and aborted cases. We therefore stamp ONLY when the signal was not
+ * aborted, so an interrupted refresh leaves the next one a genuine cold start.
+ */
+export function shouldStampCursor(aborted: boolean): boolean {
+  return !aborted;
+}

--- a/src/contexts/dmRefreshGate.ts
+++ b/src/contexts/dmRefreshGate.ts
@@ -44,8 +44,18 @@ export function shouldSkipForFreshness(
  * Whether the completion of a refresh should advance the freshness cursor.
  * The refresh task RESOLVES (never rejects) on abort — it early-returns
  * internally on `signal.aborted` — so the `await task` site runs in both the
- * completed and aborted cases. We therefore stamp ONLY when the signal was not
- * aborted, so an interrupted refresh leaves the next one a genuine cold start.
+ * completed and aborted cases. We stamp ONLY when the refresh was NOT aborted,
+ * so an interrupted refresh leaves the next one a genuine cold start.
+ *
+ * IMPORTANT — pass "did this refresh fail to complete its work", NOT
+ * `signal.aborted` read at the stamp site. Those differ in a race: a refresh
+ * can finish (commit + persist) and then have its `AbortController` aborted in
+ * the SAME tick (the user navigates away the instant it resolves). Reading
+ * `signal.aborted` afterward would see `true` and skip the stamp, wrongly
+ * making the NEXT refresh a cold start that bypasses the freshness TTL even
+ * though a refresh genuinely completed. Callers therefore track a
+ * `refreshCompleted` flag set after the commit and pass `!refreshCompleted`
+ * here — a post-completion abort can't flip it (#788 review).
  */
 export function shouldStampCursor(aborted: boolean): boolean {
   return !aborted;

--- a/src/contexts/nostrDecryptPacing.test.ts
+++ b/src/contexts/nostrDecryptPacing.test.ts
@@ -207,6 +207,53 @@ describe('createYieldScheduler', () => {
     cancelRafSpy.mockRestore();
   });
 
+  it('coldStart yields via setTimeout(0) macro-task, not requestAnimationFrame (#788)', async () => {
+    // Cold start: RAF starves while the Choreographer is still settling, so the
+    // scheduler must hand control back via a macro-task instead.
+    const rafSpy = jest.spyOn(global, 'requestAnimationFrame');
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    const scheduler = createYieldScheduler({
+      safetyEvery: 1,
+      budgetMs: DECRYPT_FRAME_BUDGET_MS,
+      coldStart: true,
+    });
+
+    // safetyEvery=1 → the first iteration yields.
+    const p = scheduler.maybeYield();
+    // Drain the macro-task that the cold-start path queued.
+    jest.runOnlyPendingTimers();
+    await p;
+    scheduler.dispose();
+
+    expect(timeoutSpy).toHaveBeenCalled();
+    expect(rafSpy).not.toHaveBeenCalled();
+    expect(scheduler.yieldCount).toBe(1);
+
+    rafSpy.mockRestore();
+    timeoutSpy.mockRestore();
+  });
+
+  it('coldStart yield resolves early on abort without flushing the timer (#788)', async () => {
+    const ctrl = new AbortController();
+    const scheduler = createYieldScheduler({
+      safetyEvery: 1,
+      coldStart: true,
+      signal: ctrl.signal,
+    });
+
+    let settled = false;
+    const p = scheduler.maybeYield().then(() => {
+      settled = true;
+    });
+
+    // Abort without running timers — the macro-task yield must still resolve.
+    ctrl.abort();
+    await p;
+
+    expect(settled).toBe(true);
+    scheduler.dispose();
+  });
+
   it('increments yieldCount only for actual yields', async () => {
     const nowSpy = jest.spyOn(performance, 'now').mockReturnValue(0);
     const scheduler = createYieldScheduler({ safetyEvery: 5, budgetMs: 9999 });

--- a/src/contexts/nostrDecryptPacing.ts
+++ b/src/contexts/nostrDecryptPacing.ts
@@ -1,3 +1,5 @@
+import { yieldMacrotask } from '../utils/yieldingBatch';
+
 /** Yield to the native event loop so UI interactions and paint can tick
  * between chunks of a synchronous decrypt loop (#177, #731).
  *
@@ -71,8 +73,21 @@ export function createYieldScheduler(opts: {
   safetyEvery: number;
   /** ms of unbroken JS work before we force a yield. */
   budgetMs?: number;
+  /** Cold-start mode (#788): yield via a `setTimeout(0)` macro-task instead
+   * of `requestAnimationFrame`. RAF rides the Choreographer vsync signal,
+   * which is the right primitive once the app is settled — but during cold
+   * start the Choreographer hasn't stabilised, so RAF callbacks coalesce and
+   * the decrypt loop runs 1.4–2.1 s synchronous bursts between actual yields
+   * (the gaps Stev.ie measured). A macro-task drains on the next event-loop
+   * tick regardless of vsync, so the loop reliably hands the thread back to
+   * native (touch / render) between chunks while the app is still warming up.
+   * The frame-budget gate below keeps the timer count low (one per ~budgetMs
+   * of work, not one per iteration), so this does NOT reintroduce the #731
+   * Looper timer-flood. Cryptography, dedup and ordering are untouched — only
+   * the yield primitive changes. */
+  coldStart?: boolean;
 }): YieldScheduler {
-  const { signal, safetyEvery, budgetMs = DECRYPT_FRAME_BUDGET_MS } = opts;
+  const { signal, safetyEvery, budgetMs = DECRYPT_FRAME_BUDGET_MS, coldStart = false } = opts;
   let iteration = 0;
   let yields = 0;
   let lastYieldAt = performance.now();
@@ -110,16 +125,23 @@ export function createYieldScheduler(opts: {
     const safetyHit = iteration % safetyEvery === 0;
     if (!overBudget && !safetyHit) return;
     yields++;
-    await new Promise<void>((resolve, reject) => {
-      pendingReject = reject;
-      pendingHandle = requestAnimationFrame(() => {
-        pendingHandle = null;
-        pendingReject = null;
-        resolve();
+    if (coldStart) {
+      // Cold start (#788): macro-task yield. `yieldMacrotask` owns its own
+      // timer + abort-cancel, so the RAF pending-handle bookkeeping is
+      // bypassed entirely on this path.
+      await yieldMacrotask(signal);
+    } else {
+      await new Promise<void>((resolve, reject) => {
+        pendingReject = reject;
+        pendingHandle = requestAnimationFrame(() => {
+          pendingHandle = null;
+          pendingReject = null;
+          resolve();
+        });
+      }).catch(() => {
+        // Aborted — swallow; caller checks signal.aborted after maybeYield.
       });
-    }).catch(() => {
-      // Aborted — swallow; caller checks signal.aborted after maybeYield.
-    });
+    }
     lastYieldAt = performance.now();
   };
 

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -520,10 +520,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
               // scheduler hard-cancels any pending setTimeout so the
               // loop unwinds in the next microtask instead of waiting
               // out one more scheduler round-trip.
-              const nsecYield = createYieldScheduler({
-                signal,
-                safetyEvery: NIP17_LOOP_YIELD_EVERY,
-              });
+              // coldStart (#788): swap RAF yields for setTimeout(0) macro-task
+              // yields on the first refresh, where RAF starves and the loop
+              // otherwise stalls the JS thread in 1.4–2.1 s bursts.
+              const nsecYield = createYieldScheduler({ signal, safetyEvery: NIP17_LOOP_YIELD_EVERY, coldStart: isColdStart }); // prettier-ignore
               try {
                 for (const wrap of kind1059) {
                   // Time-budget yield + abort check (#286, #532). Covers
@@ -663,11 +663,9 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
             let touched = 0;
             let unfollowedPurged = 0;
             let amberSkipSetDirty = false;
-            // Frame-budget scheduler (#532) — see nsec branch above.
-            const amberYield = createYieldScheduler({
-              signal,
-              safetyEvery: NIP17_LOOP_YIELD_EVERY,
-            });
+            // Frame-budget scheduler (#532) + coldStart macro-task yields
+            // (#788) — see nsec branch above for the rationale on both.
+            const amberYield = createYieldScheduler({ signal, safetyEvery: NIP17_LOOP_YIELD_EVERY, coldStart: isColdStart }); // prettier-ignore
             try {
               for (const wrap of kind1059) {
                 // Time-budget yield + abort check (#286, #532) — see nsec branch above for rationale.

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -35,7 +35,6 @@ import {
   writeNip17Cache,
   loadNip17SkipSet,
   writeNip17SkipSet,
-  DM_INBOX_REFRESH_TTL_MS,
   COLD_INITIAL_WRAP_LIMIT,
   DM_INBOX_CAP,
   DM_CONV_CAP,
@@ -48,6 +47,7 @@ import {
   mergeInboxEntries,
 } from './nostrDmCache';
 import type { RefreshDmInboxOptions, ConversationMessage } from './nostrContextTypes';
+import { isColdStartRefresh, shouldSkipForFreshness, shouldStampCursor } from './dmRefreshGate';
 import { startLiveDmSubscription } from './nostrLiveDmSub';
 import { fetchConversationFor } from './nostrFetchConversation';
 import { scheduleColdStartBackfill } from './dmColdStartBackfill';
@@ -116,9 +116,8 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
     promise: Promise<void>;
     includeNonFollows: boolean;
   } | null>(null);
-  /** `performance.now()` of last successful `refreshDmInbox` completion.
-   * Gate for the `DM_INBOX_REFRESH_TTL_MS` throttle so that Messages-tab
-   * focus doesn't re-fire full relay queries on every tab bounce. */
+  /** `performance.now()` of the last COMPLETED `refreshDmInbox` (`0` before
+   * any). Drives the cold-start + freshness-TTL gates — see dmRefreshGate. */
   const dmInboxLastRefreshAt = useRef<number>(0);
 
   /** Eagerly hydrate `dmInbox` from the persisted NIP-17 inbox cache so
@@ -288,10 +287,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // become no-ops AND the cache hydrate skips its filter so the
       // already-cached unfollowed entries don't get masked.
       const includeNonFollows = opts?.includeNonFollows === true;
-      // Cold start = first refresh this session (incl. force: the real cold load
-      // is MessagesScreen's on-mount enforce-flip refresh, which is force:true —
-      // excluding force never capped it; #751). 200-wrap paint, then backfill.
-      const isColdStart = dmInboxLastRefreshAt.current === 0;
+      // Cold start = first refresh this session (incl. force: the real cold
+      // load is MessagesScreen's on-mount focus refresh; the cold-start wrap
+      // cap + #788 macro-task yield must apply to it). See dmRefreshGate.
+      const isColdStart = isColdStartRefresh(dmInboxLastRefreshAt.current);
       // Gate for negative-result skip-set lookups (#743). Bypass when:
       //   force=true (pull-to-refresh) — newly-followed contacts' older
       //     wraps must surface on the next explicit refresh.
@@ -302,15 +301,11 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       //     (Copilot review finding on #744)
       const bypassSkipSet = forceRefresh || includeNonFollows;
       // Freshness TTL: skip the refresh entirely if the previous one
-      // finished within DM_INBOX_REFRESH_TTL_MS, unless the caller
-      // explicitly opts into a forced refresh (pull-to-refresh). The
-      // Messages tab's `useFocusEffect` uses the default TTL path so
-      // tab-bouncing doesn't retrigger expensive relay+decrypt work.
-      if (!opts?.force) {
-        const age = performance.now() - dmInboxLastRefreshAt.current;
-        if (dmInboxLastRefreshAt.current > 0 && age < DM_INBOX_REFRESH_TTL_MS) {
-          return;
-        }
+      // COMPLETED within DM_INBOX_REFRESH_TTL_MS, unless the caller forces it
+      // (pull-to-refresh). Messages-tab `useFocusEffect` uses the default path
+      // so tab-bouncing doesn't retrigger relay+decrypt work. See dmRefreshGate.
+      if (shouldSkipForFreshness(dmInboxLastRefreshAt.current, forceRefresh, performance.now())) {
+        return;
       }
       // Single-flight: piggy-back on in-flight task ONLY when its includeNonFollows matches; otherwise wait then re-run with the wider option.
       if (dmInboxInFlight.current) {
@@ -844,7 +839,14 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       dmInboxInFlight.current = { promise: task, includeNonFollows };
       try {
         await task;
-        dmInboxLastRefreshAt.current = performance.now();
+        // Stamp the freshness cursor ONLY when the refresh completed (not
+        // aborted). The task resolves on abort too, so stamping here
+        // unconditionally would flip the next refresh's `isColdStart` to
+        // false (defeating #788's macro-task yield) and wrongly satisfy the
+        // TTL gate. See dmRefreshGate.shouldStampCursor. (#788)
+        if (shouldStampCursor(signal?.aborted === true)) {
+          dmInboxLastRefreshAt.current = performance.now();
+        }
       } finally {
         dmInboxInFlight.current = null;
         const __perfBlockMs = Math.round(performance.now() - __perfBlockStart);

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -329,6 +329,8 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       const refreshFollows = followPubkeys;
       const passesFollowGate = (pk: string): boolean => includeNonFollows || refreshFollows.has(pk);
 
+      let refreshCompleted = false; // set after commit; gates the stamp (#788 — see helper)
+
       const task = (async () => {
         setDmInboxLoading(true);
         try {
@@ -829,6 +831,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                 )
               : Promise.resolve(),
           ]);
+          refreshCompleted = true; // inbox committed — safe to stamp the cursor
         } catch (error) {
           if (__DEV__) console.warn('[Nostr] refreshDmInbox failed:', error);
         } finally {
@@ -839,12 +842,9 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       dmInboxInFlight.current = { promise: task, includeNonFollows };
       try {
         await task;
-        // Stamp the freshness cursor ONLY when the refresh completed (not
-        // aborted). The task resolves on abort too, so stamping here
-        // unconditionally would flip the next refresh's `isColdStart` to
-        // false (defeating #788's macro-task yield) and wrongly satisfy the
-        // TTL gate. See dmRefreshGate.shouldStampCursor. (#788)
-        if (shouldStampCursor(signal?.aborted === true)) {
+        // Stamp only for a refresh that COMPLETED its work — gate on
+        // `refreshCompleted`, not `signal.aborted` (see the helper). #788.
+        if (shouldStampCursor(!refreshCompleted)) {
           dmInboxLastRefreshAt.current = performance.now();
         }
       } finally {

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -94,8 +94,22 @@ const MessagesScreen: React.FC = () => {
   // already collapses 'all' → 'friends' for non-secret-mode users, so a
   // stale persisted 'all' can't leak past the parental-control gate.
   const enforceFollowingOnly = effectiveWotTier !== 'all';
-  // Tracks last applied value so toggling triggers a data-layer refresh, not just a UI re-filter.
-  const lastAppliedEnforceRef = useRef<boolean>(true);
+  // Tracks the `enforceFollowingOnly` value the LAST refresh actually
+  // applied, so a genuine later toggle triggers a data-layer re-fetch
+  // (not just a UI re-filter). Seeded to `null` (= "no refresh has run
+  // yet") rather than a hardcoded boolean: the WoT tier hydrates async
+  // from AsyncStorage, so on first render `enforceFollowingOnly` reflects
+  // the transient default ('all' → false), not the persisted value. A
+  // hardcoded seed of `true` made the first settle read as a flip, which
+  // fired a SECOND `refreshDmInbox` whose `newRefreshSignal()` aborted the
+  // focus-effect's cold refresh mid-decrypt — stamping the freshness
+  // cursor so the retry no longer counted as a cold start and #788's
+  // macro-task yield never ran (a double-fetch that no-op'd the
+  // optimisation). With `null`, the enforce-flip effect stays dormant
+  // until a refresh has actually recorded which filter it used; the cold
+  // focus refresh is then the SINGLE fetch and carries the correct filter.
+  // (#788)
+  const lastAppliedEnforceRef = useRef<boolean | null>(null);
   const [search, setSearch] = useState('');
   const [searchExpanded, setSearchExpanded] = useState(false);
   const searchInputRef = useRef<TextInput>(null);
@@ -198,9 +212,17 @@ const MessagesScreen: React.FC = () => {
     enforceFollowingOnlyRef.current = enforceFollowingOnly;
   }, [enforceFollowingOnly]);
 
-  // Force-refresh the inbox whenever the effective enforcement flips so all data-layer paths re-apply.
+  // Force-refresh the inbox whenever the effective enforcement GENUINELY
+  // flips (a real WoT-tier toggle), so all data-layer paths re-apply the
+  // new filter. Dormant until the cold focus refresh below has recorded
+  // which filter it applied (`lastAppliedEnforceRef.current !== null`):
+  // on first render the WoT tier is still hydrating, so firing here would
+  // abort the cold refresh and defeat #788's macro-task yield. Once a
+  // refresh has run, a later toggle that differs from the applied value
+  // re-fetches with `force: true` so newly-(un)trusted senders surface.
   useEffect(() => {
     if (!isLoggedIn) return;
+    if (lastAppliedEnforceRef.current === null) return;
     if (lastAppliedEnforceRef.current === enforceFollowingOnly) return;
     lastAppliedEnforceRef.current = enforceFollowingOnly;
     refreshDmInbox({
@@ -243,6 +265,15 @@ const MessagesScreen: React.FC = () => {
           // is effectively dead for aborts. We therefore branch on the signal
           // (not the catch) to choose the TTL marker.
           const signal = newRefreshSignal();
+          // Record the filter this (cold) refresh applies so the
+          // enforce-flip effect above stops being dormant and only
+          // re-fires on a GENUINE later toggle away from this value.
+          // Reading `enforceFollowingOnlyRef.current` here (vs. a stale
+          // closure) means the WoT tier has had until now — past
+          // InteractionManager + the 120 ms margin, comfortably longer
+          // than the AsyncStorage hydrate — to settle, so this single
+          // fetch carries the correct, settled filter. (#788)
+          lastAppliedEnforceRef.current = enforceFollowingOnlyRef.current;
           refreshDmInbox({
             includeNonFollows: !enforceFollowingOnlyRef.current,
             signal,
@@ -550,6 +581,11 @@ const MessagesScreen: React.FC = () => {
     try {
       await Promise.all([refreshContacts(), refreshProfile({ force: true })]);
       // Pull-to-refresh deliberately does NOT call newRefreshSignal() here. If a focus refresh is already in flight, refreshDmInbox's single-flight guard returns the existing promise; aborting that promise via newRefreshSignal() then awaiting it would resolve to AbortError and never start a fresh refresh — making pull-to-refresh a no-op whenever a focus refresh was running. We let the in-flight one finish (its result is what the user wants anyway) and only kick off a new refresh if none is running. The focus-effect signal still aborts on blur, which covers the original snappiness goal. (#413 review)
+      // Record the filter this refresh applies, same as the cold focus
+      // refresh: if pull-to-refresh is the first refresh of the session
+      // it must take the enforce-flip effect out of its dormant (`null`)
+      // state so a later genuine WoT-tier toggle still re-fetches. (#788)
+      lastAppliedEnforceRef.current = enforceFollowingOnly;
       await refreshDmInbox({
         force: true,
         includeNonFollows: !enforceFollowingOnly,

--- a/src/utils/yieldingBatch.test.ts
+++ b/src/utils/yieldingBatch.test.ts
@@ -96,4 +96,24 @@ describe('yieldMacrotask', () => {
     await p;
     expect(resolved).toBe(true);
   });
+
+  it('removes its abort listener on normal fire — no accumulation across yields (#789 review)', async () => {
+    // The decrypt loop calls this many times on ONE long-lived signal; a leaked
+    // listener per yield means a later abort fans out to thousands of stale
+    // handlers. add/remove must stay balanced.
+    const ctrl = new AbortController();
+    const addSpy = jest.spyOn(ctrl.signal, 'addEventListener');
+    const removeSpy = jest.spyOn(ctrl.signal, 'removeEventListener');
+
+    for (let i = 0; i < 5; i++) {
+      const p = yieldMacrotask(ctrl.signal);
+      jest.runOnlyPendingTimers();
+      await p;
+    }
+
+    expect(addSpy).toHaveBeenCalledTimes(5);
+    expect(removeSpy).toHaveBeenCalledTimes(5); // each normal fire cleans up its own listener
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
 });

--- a/src/utils/yieldingBatch.test.ts
+++ b/src/utils/yieldingBatch.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for `yieldMacrotask` — the cold-start macro-task yield used by
+ * the NIP-17 DM-inbox decrypt loop (#788).
+ *
+ * Scope: pure scheduling. These tests assert that the cold-start primitive
+ * (a) yields via `setTimeout(0)` (NOT `requestAnimationFrame`, which starves
+ * during cold start), and (b) is abort-aware — it must not strand the decrypt
+ * loop on a pending timer when the user blurs / unmounts mid-refresh.
+ */
+
+import { yieldMacrotask } from './yieldingBatch';
+
+describe('yieldMacrotask', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not resolve synchronously — it waits for a macro-task', async () => {
+    let resolved = false;
+    const p = yieldMacrotask().then(() => {
+      resolved = true;
+    });
+
+    // Microtask drain alone must NOT resolve it — a setTimeout(0) macro-task
+    // is strictly later than the microtask queue.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    jest.runOnlyPendingTimers();
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('posts a setTimeout (cold start) — NOT requestAnimationFrame', () => {
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    const rafSpy =
+      typeof global.requestAnimationFrame === 'function'
+        ? jest.spyOn(global, 'requestAnimationFrame')
+        : null;
+
+    yieldMacrotask();
+
+    expect(timeoutSpy).toHaveBeenCalledTimes(1);
+    if (rafSpy) expect(rafSpy).not.toHaveBeenCalled();
+
+    timeoutSpy.mockRestore();
+    rafSpy?.mockRestore();
+  });
+
+  it('resolves immediately (no timer queued) when the signal is already aborted', () => {
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    const ctrl = new AbortController();
+    ctrl.abort();
+
+    const p = yieldMacrotask(ctrl.signal);
+
+    // No timer should have been scheduled at all.
+    expect(timeoutSpy).not.toHaveBeenCalled();
+    timeoutSpy.mockRestore();
+
+    // And the promise resolves without needing a timer flush.
+    return expect(p).resolves.toBeUndefined();
+  });
+
+  it('clears the pending timer and resolves early when aborted mid-wait', async () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const ctrl = new AbortController();
+
+    let resolved = false;
+    const p = yieldMacrotask(ctrl.signal).then(() => {
+      resolved = true;
+    });
+
+    // Abort BEFORE the timer fires — the loop must resume promptly so it can
+    // hit its own signal.aborted check, not wait out the tick.
+    ctrl.abort();
+    await p;
+
+    expect(resolved).toBe(true);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('resolves normally when the timer fires before any abort', async () => {
+    const ctrl = new AbortController();
+    let resolved = false;
+    const p = yieldMacrotask(ctrl.signal).then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+    jest.runOnlyPendingTimers();
+    await p;
+    expect(resolved).toBe(true);
+  });
+});

--- a/src/utils/yieldingBatch.ts
+++ b/src/utils/yieldingBatch.ts
@@ -1,0 +1,63 @@
+/**
+ * Cold-start macro-task yield for the NIP-17 DM-inbox decrypt loop (#788).
+ *
+ * ## Why this exists (and why it isn't just `createYieldScheduler`'s RAF path)
+ *
+ * `nostrDecryptPacing.createYieldScheduler` yields via `requestAnimationFrame`.
+ * That is the right primitive for the WARM path (tab-switch, pull-to-refresh):
+ * RAF rides the Choreographer vsync signal, so the JS thread genuinely returns
+ * to native between iterations and the per-yield overhead is amortised. The
+ * `setTimeout(0)` path was deliberately removed from the warm loop in #731
+ * because, when a loop re-enqueues a 0 ms timer on EVERY iteration, the Android
+ * Looper batches all the queued timers into a single `callTimers` bridge hop
+ * and the "yield" inflates to ~90 ms — worse than not yielding.
+ *
+ * Cold start is the OPPOSITE failure mode (#788). At ~T+4.5–6.3 s the app is
+ * still settling: the Choreographer is not producing steady vsync frames yet,
+ * so RAF callbacks get coalesced/delayed and the decrypt loop runs long
+ * synchronous stretches between actual yields — Stev.ie measured 1.4–2.1 s
+ * heartbeat gaps coinciding with the gift-wrap decrypt pass. A `setTimeout(0)`
+ * macro-task, by contrast, always drains on the next event-loop tick whether or
+ * not vsync is ticking, so it reliably returns control to native (touch /
+ * render) between chunks during cold start.
+ *
+ * The #731 timer-flood is avoided by the caller's frame-budget gate
+ * (`createYieldScheduler` only actually yields once per ~`DECRYPT_FRAME_BUDGET_MS`
+ * of work, not once per wrap), so even on the cold path the timer count stays
+ * low — nowhere near the 83-timers-per-frame regime that triggered the Looper
+ * batching in #731.
+ *
+ * ## What this does NOT change
+ *
+ * This is pure SCHEDULING. It performs no cryptography, no dedup, no ordering —
+ * it only decides when the loop hands the thread back to native. Swapping the
+ * warm RAF yield for this cold-start macro-task yield cannot change decryption
+ * correctness; only the cadence of yields differs.
+ */
+
+/**
+ * Yield a single macro-task so the native event loop (touch dispatch, render,
+ * layout) can run before the next chunk of decrypt work. Uses `setTimeout(0)`
+ * deliberately — unlike `requestAnimationFrame` it does not depend on the
+ * Choreographer producing a vsync frame, which is exactly the cold-start
+ * condition where RAF starves (#788).
+ *
+ * Abort-aware: resolves immediately (without queueing a timer) if `signal` is
+ * already aborted, and if an abort fires while the timer is pending it clears
+ * the timer and resolves early so the awaiting loop resumes on the next
+ * microtask and hits its own `signal.aborted` check — matching the
+ * `cancelAnimationFrame`-on-abort behaviour of the RAF scheduler.
+ */
+export function yieldMacrotask(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const id = setTimeout(resolve, 0);
+    if (signal) {
+      const onAbort = () => {
+        clearTimeout(id);
+        resolve();
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}

--- a/src/utils/yieldingBatch.ts
+++ b/src/utils/yieldingBatch.ts
@@ -51,13 +51,17 @@
 export function yieldMacrotask(signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) return Promise.resolve();
   return new Promise((resolve) => {
-    const id = setTimeout(resolve, 0);
-    if (signal) {
-      const onAbort = () => {
-        clearTimeout(id);
-        resolve();
-      };
-      signal.addEventListener('abort', onAbort, { once: true });
-    }
+    const onAbort = () => {
+      clearTimeout(id);
+      resolve();
+    };
+    const id = setTimeout(() => {
+      // Normal fire: drop the abort listener so it doesn't accumulate on a
+      // long-lived signal across the (many) yields of one decrypt pass (#789
+      // review). `{ once: true }` only auto-removes on the abort path.
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, 0);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }


### PR DESCRIPTION
## Summary

The cold-start JS-thread stall Stev.ie measured on a Pixel 8 — heartbeat gaps of **1458ms / 2128ms / 1463ms / 1371ms** at ~T+4.5–6.3s (heartbeats #12–15) — is the **NIP-17 DM inbox gift-wrap decrypt pass** in `refreshDmInbox` (#781 already cleared contacts). This PR makes that decrypt yield the JS thread on cold start **without changing decryption correctness**.

It does **two things**, because the first alone was a no-op on real hardware:

1. **Fix the cold-mount double-fetch** so the cold Messages mount runs a **single** `refreshDmInbox` with the correct WoT filter, and that one fetch is correctly seen as a cold start.
2. **The macro-task yield then fires on it** — the `setTimeout(0)` cold-start scheduler that was already on the branch finally runs on the cold decrypt loop.

This is the **focused first step of the #695 DM-store rewire**. It addresses only **decrypt scheduling on cold mount**; the larger **decrypt-once-and-persist** rewire is the follow-up.

## Root cause — why the cold yield was a no-op

On a cold mount of `MessagesScreen`, **two** refreshes collided:

1. The **focus-effect** DM refresh fires first (after `InteractionManager` + a 120ms margin) → `refreshDmInbox(...)`, `isColdStart === true`, starts the decrypt loop.
2. The **enforce-flip effect** fires on first render: `lastAppliedEnforceRef` was seeded `true`, but the WoT tier hydrates **async** from AsyncStorage, so the on-mount `enforceFollowingOnly = effectiveWotTier !== 'all'` resolves to the transient default (`'all'` → `false`). The guard `lastAppliedEnforceRef.current !== enforceFollowingOnly` read `true !== false` as a **flip on first render** and fired a SECOND `refreshDmInbox({ force, signal: newRefreshSignal() })`. `newRefreshSignal()` **aborts the first (cold) refresh** mid-decrypt and starts a second.
3. The aborted first refresh had already stamped `dmInboxLastRefreshAt.current` (the refresh task **resolves** on abort — it early-returns internally on `signal.aborted`), so the second refresh computed `isColdStart = (cursor === 0)` → **false** → took the **RAF** yield path, not the cold-start `setTimeout(0)` path.

Net before this PR: the inbox was fetched twice, and the cold-start decrypt yield never ran.

## Fix (behaviour-preserving; WoT privacy filter intact)

**`MessagesScreen.tsx` — single cold fetch, right filter:**
- Seed `lastAppliedEnforceRef` to `null` ("no refresh has applied a filter yet") instead of a hardcoded boolean. The enforce-flip effect stays **dormant** until a refresh records which filter it used, so the first async tier-settle is **not** treated as a flip — no spurious abort.
- The cold **focus refresh** records the filter it applies (`lastAppliedEnforceRef.current = enforceFollowingOnlyRef.current`), read past `InteractionManager` + 120ms — comfortably after the AsyncStorage tier hydrate — so the **single** fetch carries the **settled** filter. Pull-to-refresh records it too.
- A **genuine later WoT-tier toggle** still re-fetches with `force: true` (`lastAppliedEnforceRef.current !== null && !== enforceFollowingOnly`), so newly-(un)trusted senders surface. **Only the spurious first-render flip is removed.**

**`useDmInbox.ts` — cold start survives an abort:**
- Stamp `dmInboxLastRefreshAt` **only when the refresh COMPLETED** (`!signal?.aborted`), so an interrupted refresh leaves the next one a genuine cold start, and doesn't wrongly satisfy the TTL freshness gate with a refresh that never finished.

**Extraction (keeps `useDmInbox.ts` under the cap + makes the logic testable):**
- The cold-start / freshness-TTL / cursor-stamp decisions move to a pure `src/contexts/dmRefreshGate.ts` module, unit-tested (incl. the cold-start-survives-abort regression). `useDmInbox.ts` ends at **999 lines** (under the 1000 cap).

## WoT privacy guard preserved

When `enforceFollowingOnly` is true the inbox must never show DMs from non-followed senders. The single-fetch path applies the **same** filter the double-fetch eventually settled on:
- The cold refresh reads the settled `enforceFollowingOnlyRef.current`.
- In the rare race where the tier hydrates to a stricter value **after** the cold refresh started, the enforce-flip effect re-fires (ref is no longer `null`, value differs) and re-fetches with the stricter filter — the corrective re-fetch that double-fetch used to do, kept for exactly the case that needs it.
- `buildDmSummaries` + `refreshDmInbox`'s data-layer follow gate are untouched. No filter is weakened.

#412/#413 **abort-on-blur** behaviour is unchanged — leaving Messages still aborts the in-flight unwrap loop. The #788 `yieldMacrotask` + `coldStart` scheduler is untouched (crypto untouched).

## Test plan

Automated gates (all green, run in the worktree):

- `npx tsc --noEmit` — clean
- `npx jest` — **85 suites / 1003 tests pass** (full suite, incl. DM/inbox). New: `dmRefreshGate.test.ts` (9 tests, incl. cold-start-survives-abort).
- `npx eslint <changed>` — **0 errors** (2 pre-existing `no-unused-vars` warnings on `insets`/`profile` in the untouched part of `MessagesScreen.tsx`, match baseline)
- `npx prettier --write <changed>` — formatted
- `bash scripts/check-file-size.sh` — passes (`useDmInbox.ts` 999 ≤ 1000; nothing grew)

Manual / measurement plan (Pixel, so the cold double-fetch + 1.4–2.1s gaps can be confirmed broken):

1. Cold-start the app (force-stop, relaunch) on a real device with a busy NIP-17 inbox (hundreds of gift-wraps), nsec signer, then open the Messages tab.
2. `adb logcat | grep -E '\[Perf\] (nip17-cache|refreshDmInbox)|\[PerfBlock\]'`:
   - There should be **ONE** `[Perf] refreshDmInbox` for the cold mount (not two back-to-back), and **no** abort-then-refetch pair.
   - The cold `[Perf] nip17-cache` line should report a **higher `yields=` count** — proof the cold-start macro-task yields are now firing (they couldn't before, because the cold refresh was being aborted / the retry took the RAF path).
3. Watch the JS-thread heartbeat (the harness used for the original #781/#788 capture under `/tmp/perf-781-full-baseline/`): the **1.4–2.1s gaps at ~T+4.5–6.3s should break into sub-frame slices** — no single heartbeat gap over a few hundred ms during the decrypt pass.
4. Confirm the inbox still **fully populates** and the rendered count matches a warm `force: true` pull-to-refresh — and that with WoT = Friends, **no non-followed senders appear** (privacy guard intact).
5. Cold-start then immediately tab away from Messages — the in-flight refresh should still abort promptly (no stranded loop).

Closes #788
