### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## What & why

Marketing-version bump **1.2.1 → 1.3.0** for the v1.3.0 release (package.json is the single source of truth; `app.config.ts` reads `version: pkg.version`). Routed through a PR because `main` is protected — the documented `push main --follow-tags` requires direct-push rights.

After merge I'll cut the GitHub Release `v1.3.0` against `main`, which triggers `release.yml` → EAS cloud builds (both platforms) + iOS TestFlight. `versionCode`/`buildNumber` are left untouched — EAS owns those via the remote auto-increment.

### Highlights since v1.2.1 (57 commits)
- Live-location sharing in DMs (#206/#336), NFC LNURL-withdraw claim (#103), scan-to-pay (#756), open/write Nostr profile via NFC + deep-link (#754/#755)
- Hide-a-Piglet text-hint input (#774), hider contact-sheet banner/zap/view-profile + bio (#770)
- NWC rate-limit publish backoff + amber "Not responding" wallet status (#785/#786)
- Perf: cold-start lazy-load + focus-scoped subs (#760), map frozen-tab GL release + 1 Hz re-render (#778), NostrContext contacts split (#779), DM cold-start decrypt yield (#788)
- Fixes: U+FFFC tofu strip (#764), map back-to-DM nav (#772), NIP-40-expired Piglets off the map (#762)

## Test plan

N/A — version-string bump only (no runtime/logic change). `tsc`/lint/prettier/coverage gates still run on this PR. The shipped version is verified by the release build, which sets `package.json` from the `v1.3.0` tag.
