### PR TITLE
fix(ci): npm ci in release jobs so eas build:list can resolve the project (#791)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,15 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # `eas build:list` (below) resolves the EAS project by EVALUATING
+      # app.config.ts, whose `extra.eas.projectId` is the only place the id
+      # lives. app.config.ts `import`s `expo/config` + ./package.json, so it
+      # can't load without node_modules — without this step every build:list
+      # call dies with a bare `Error: build:list command failed.` (the build
+      # job works only because it runs npm ci; this job and Attach didn't).
+      - name: Install dependencies
+        run: npm ci
+
       - name: Verify ASC API key is wired
         env:
           # The ASC API key is stored under the EXPO_ASC_* secret names (the
@@ -267,6 +276,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+
+      # Required so `eas build:list` can evaluate app.config.ts (which holds
+      # the only copy of extra.eas.projectId and imports expo/config). Missing
+      # this is what made every poll attempt below fail with `Error: build:list
+      # command failed.` on v1.3.0 — the retries masked a hard config-load
+      # error as a transient hiccup, burning the full poll then erroring.
+      - name: Install dependencies
+        run: npm ci
 
       - name: Resolve latest finished Android APK URL
         id: find

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: npm
 
       # `eas build:list` (below) resolves the EAS project by EVALUATING
       # app.config.ts, whose `extra.eas.projectId` is the only place the id
@@ -276,6 +277,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+          cache: npm
 
       # Required so `eas build:list` can evaluate app.config.ts (which holds
       # the only copy of extra.eas.projectId and imports expo/config). Missing


### PR DESCRIPTION
## What & why

On the v1.3.0 release the EAS build **succeeded**, but two follow-up jobs failed and the just-built APK was never attached to the Release:

- **Attach Android APK to Release**
- **Set TestFlight "What to Test"**

Both jobs check out the repo and set up Node, then call `eas build:list` — but **neither runs `npm ci`**. `eas build:list` resolves the EAS project by *evaluating* `app.config.ts`, which is the only place `extra.eas.projectId` lives. `app.config.ts` does `import { ExpoConfig, ConfigContext } from 'expo/config'` and `import pkg from './package.json'`, so it cannot be loaded without `node_modules`. Every call therefore exits non-zero with a bare:

```
Error: build:list command failed.
```

The attach job's 12× retry loop was written to ride out an *eventual-consistency* lag (#674), so it masked this **hard config-load error** as a transient hiccup — burning ~4 minutes of `sleep 20` and then failing with a misleading "build not surfaced yet". The `build-and-submit` job works only because it is the one job that runs `npm ci`.

## Fix

Add an `Install dependencies` (`npm ci`) step to the two jobs that call `eas build:list`, mirroring the build job. Each has a comment explaining why the deps are load-bearing so a future maintainer doesn't strip it.

This makes future releases attach the Android APK and populate TestFlight "What to Test" automatically — no manual `gh release upload` after the fact.

> Note: v1.3.0's APK has already been attached manually (`gh release upload v1.3.0`), so that release page is correct; this just prevents the recurrence.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → YAML OK
- [x] Confirmed `extra.eas.projectId` exists only in `app.config.ts` (not `eas.json`/`app.json`), so `eas build:list` must evaluate it
- [x] Confirmed the two failing jobs lacked `npm ci` and the passing build job had it
- [ ] Next release (or a manual `workflow_dispatch`) attaches the Android APK + sets TestFlight notes without manual intervention

Closes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)
