### PR TITLE
fix: Optimize cache handling in ExploreHomeScreen and MyPigletsScreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1474,6 +1474,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1889,6 +1890,7 @@
       "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
       "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config-types": "^55.0.5",
         "@expo/json-file": "~10.0.13",
@@ -3308,6 +3310,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -3783,6 +3786,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3860,6 +3864,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4380,6 +4385,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5290,6 +5296,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6616,6 +6623,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6815,6 +6823,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7380,6 +7389,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.9.tgz",
       "integrity": "sha512-bYDhqr2v2UtTf/9s493bUVRtxsYqXF4KXkaS3sSW827DmgxNJv0NuWKWwfqFdDxKvDELd488J5X9l9ogqUrwOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "55.0.19",
@@ -7443,6 +7453,7 @@
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-55.0.17.tgz",
       "integrity": "sha512-pK9HHJuFqjE8kDUcbMFsZj3Cz8WdXpvZHZmYl7ouFQp59P83BvHln6VnqPDGlO+/4929G0Lm8ZUzbONuNRhi9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/image-utils": "^0.8.14",
         "expo-constants": "~55.0.16"
@@ -7523,6 +7534,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.16.tgz",
       "integrity": "sha512-Z15/No94UHoogD+pulxjudGAeOHTEIWZgb/vnX48Wx5D+apWTeCbnKxQZZtGQlosvduYL5kaic2/W8U+NHfBQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/env": "~2.1.2"
       },
@@ -7688,6 +7700,7 @@
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.6.tgz",
       "integrity": "sha512-xI72FTm469FfuuBL2R5aNtthgH+GR7ygOpsx/KcPS0K8AZaZd7VjtEExbzn9/qyyYkWW3T+3dAmCDKOMX8gdmQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -7985,6 +7998,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.4.tgz",
       "integrity": "sha512-ZKeGTFffPygvY5dM/9ATM2p7QDkhsaHopH7wFAWgP2lKzqUMS9B/RxCvw5CaObr9Ro7x9YptyeRKX2HmgmMfrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -9527,6 +9541,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -12954,6 +12969,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12991,6 +13007,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.4.tgz",
       "integrity": "sha512-H5Wco3UJyY6zZsjoBayY8RM9uiAEQ3FeG4G2NAt+lr9DO43QeqPlVe9xxxYEukMkEmeIhNjR70F6bhXuWArOMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.4",
@@ -13090,6 +13107,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.1.tgz",
       "integrity": "sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -13171,6 +13189,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.2.1.tgz",
       "integrity": "sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "1.2.1",
         "semver": "7.7.3"
@@ -13208,6 +13227,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13218,6 +13238,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz",
       "integrity": "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -13232,6 +13253,7 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.3.tgz",
       "integrity": "sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -13310,6 +13332,7 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
       "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -13527,6 +13550,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13537,6 +13561,7 @@
       "integrity": "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-is": "^19.2.0",
         "scheduler": "^0.27.0"
@@ -14894,6 +14919,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15135,6 +15161,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -570,16 +570,10 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                     continue;
                   }
                   nip17Misses++;
-                  // Check abort before paying the ~25ms schnorr cost of
-                  // unwrapWrapNsec. Without this, a tab-switch mid-loop waits
-                  // until the next maybeYield() — up to DECRYPT_FRAME_BUDGET_MS
-                  // + one decrypt — before the blur handler's abort takes hold.
-                  if (signal?.aborted) return;
+                  if (signal?.aborted) return; // bail before the ~25ms schnorr unwrapWrapNsec
                   const rumor = unwrapWrapNsec(wrap, secretKey, onSkip);
-                  // No per-decrypt yield here: the frame-budget scheduler
-                  // at the top of the loop already yields whenever the
-                  // accumulated work exceeds DECRYPT_FRAME_BUDGET_MS,
-                  // which captures the cost of unwrapWrapNsec naturally.
+                  // No per-decrypt yield: the frame-budget scheduler at the loop top
+                  // already yields on DECRYPT_FRAME_BUDGET_MS, covering unwrapWrapNsec.
                   if (!rumor) continue;
                   // Multi-recipient (group) rumors: route to group storage
                   // and short-circuit the DM-inbox path. The 1:1 inbox
@@ -701,11 +695,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                   continue;
                 }
                 nip17Misses++;
-                // Check abort before launching the Amber IPC call. Same
-                // rationale as the nsec path: a tab-switch during cache-hit
-                // processing shouldn't have to pay one more IPC round-trip
-                // before the abort takes hold.
-                if (signal?.aborted) return;
+                if (signal?.aborted) return; // bail before the Amber IPC round-trip (same as nsec path)
                 // Uncached — unwrap via Amber's silent content-resolver path.
                 // If Amber hasn't granted blanket nip44_decrypt permission,
                 // this throws PERMISSION_NOT_GRANTED and we stop iterating.

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -570,6 +570,11 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                     continue;
                   }
                   nip17Misses++;
+                  // Check abort before paying the ~25ms schnorr cost of
+                  // unwrapWrapNsec. Without this, a tab-switch mid-loop waits
+                  // until the next maybeYield() — up to DECRYPT_FRAME_BUDGET_MS
+                  // + one decrypt — before the blur handler's abort takes hold.
+                  if (signal?.aborted) return;
                   const rumor = unwrapWrapNsec(wrap, secretKey, onSkip);
                   // No per-decrypt yield here: the frame-budget scheduler
                   // at the top of the loop already yields whenever the
@@ -696,6 +701,11 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
                   continue;
                 }
                 nip17Misses++;
+                // Check abort before launching the Amber IPC call. Same
+                // rationale as the nsec path: a tab-switch during cache-hit
+                // processing shouldn't have to pay one more IPC round-trip
+                // before the abort takes hold.
+                if (signal?.aborted) return;
                 // Uncached — unwrap via Amber's silent content-resolver path.
                 // If Amber hasn't granted blanket nip44_decrypt permission,
                 // this throws PERMISSION_NOT_GRANTED and we stop iterating.

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -395,6 +395,10 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // backlog. Without it, a 200-event burst would sit in the buffer for
   // the full 100 ms even if it landed in 20 ms.
   const PENDING_FLUSH_THRESHOLD = 25;
+  // Cap the caches and events Maps so the O(N) new Map(prev) clone on
+  // every flush doesn't accumulate frame drops over long sessions.
+  // Entries beyond the cap are evicted oldest-first.
+  const MAP_MAX_SIZE = 1000;
   const flushPendingCaches = useCallback(() => {
     if (pendingCachesTimerRef.current) {
       clearTimeout(pendingCachesTimerRef.current);
@@ -416,6 +420,12 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
       for (const [coord, c] of batch) {
         const existing = next.get(coord);
         if (!existing || existing.createdAt < c.createdAt) next.set(coord, c);
+      }
+      if (next.size > MAP_MAX_SIZE) {
+        const sorted = [...next.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt);
+        for (let i = 0; i < sorted.length - MAP_MAX_SIZE; i++) {
+          next.delete(sorted[i][0]);
+        }
       }
       const __dt = performance.now() - __t0;
       if (__dt > 30) {
@@ -445,6 +455,16 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
       for (const [coord, e] of batch) {
         const existing = next.get(coord);
         if (!existing || existing.startsAt !== e.startsAt) next.set(coord, e);
+      }
+      if (next.size > MAP_MAX_SIZE) {
+        const sorted = [...next.entries()].sort((a, b) => {
+          const aTs = a[1].startsAt ?? 0;
+          const bTs = b[1].startsAt ?? 0;
+          return aTs - bTs;
+        });
+        for (let i = 0; i < sorted.length - MAP_MAX_SIZE; i++) {
+          next.delete(sorted[i][0]);
+        }
       }
       const __dt = performance.now() - __t0;
       if (__dt > 30) {

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -228,6 +228,21 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   const [legendVisible, setLegendVisible] = useState(false);
   const onTapMap = useCallback(() => navigation.navigate('Map'), [navigation]);
   const onOpenLegend = useCallback(() => setLegendVisible(true), []);
+  // Stable handlers so a parent re-render (e.g. a DM-inbox flush bubbling
+  // through useNostr()) doesn't hand ExploreMiniMap/ContentRail fresh function
+  // identities each time — inline arrows defeat LibreMiniMap's arePropsEqual
+  // memo (ExploreMiniMap renders LibreMiniMap when focused) and force a full
+  // MapLibre marker reconciliation on every render (#798).
+  const onSelectMerchant = useCallback((m: BtcMapPlace) => setSelectedMerchant(m), []);
+  const onSelectCache = useCallback((c: ParsedCache) => setSelectedCache(c), []);
+  const onSelectEvent = useCallback(
+    (e: ParsedEvent) => navigation.navigate('EventDetail', { coord: e.coord }),
+    [navigation],
+  );
+  const onSeeAllPlaces = useCallback(() => navigation.navigate('Places'), [navigation]);
+  const onSeeAllHunt = useCallback(() => navigation.navigate('Hunt'), [navigation]);
+  const onSeeAllEvents = useCallback(() => navigation.navigate('Events'), [navigation]);
+  const onSeeAllLessons = useCallback(() => navigation.navigate('Lessons'), [navigation]);
   const onCloseLegend = useCallback(() => setLegendVisible(false), []);
   // Stale-while-revalidate: `peekCachedPlacesSync()` already seeded
   // the initial `merchants` state above; the live fetch below replaces
@@ -395,10 +410,6 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // backlog. Without it, a 200-event burst would sit in the buffer for
   // the full 100 ms even if it landed in 20 ms.
   const PENDING_FLUSH_THRESHOLD = 25;
-  // Cap the caches and events Maps so the O(N) new Map(prev) clone on
-  // every flush doesn't accumulate frame drops over long sessions.
-  // Entries beyond the cap are evicted oldest-first.
-  const MAP_MAX_SIZE = 1000;
   const flushPendingCaches = useCallback(() => {
     if (pendingCachesTimerRef.current) {
       clearTimeout(pendingCachesTimerRef.current);
@@ -420,12 +431,6 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
       for (const [coord, c] of batch) {
         const existing = next.get(coord);
         if (!existing || existing.createdAt < c.createdAt) next.set(coord, c);
-      }
-      if (next.size > MAP_MAX_SIZE) {
-        const sorted = [...next.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt);
-        for (let i = 0; i < sorted.length - MAP_MAX_SIZE; i++) {
-          next.delete(sorted[i][0]);
-        }
       }
       const __dt = performance.now() - __t0;
       if (__dt > 30) {
@@ -455,16 +460,6 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
       for (const [coord, e] of batch) {
         const existing = next.get(coord);
         if (!existing || existing.startsAt !== e.startsAt) next.set(coord, e);
-      }
-      if (next.size > MAP_MAX_SIZE) {
-        const sorted = [...next.entries()].sort((a, b) => {
-          const aTs = a[1].startsAt ?? 0;
-          const bTs = b[1].startsAt ?? 0;
-          return aTs - bTs;
-        });
-        for (let i = 0; i < sorted.length - MAP_MAX_SIZE; i++) {
-          next.delete(sorted[i][0]);
-        }
       }
       const __dt = performance.now() - __t0;
       if (__dt > 30) {
@@ -528,11 +523,16 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // pubkey change but never on unrelated re-renders, and is immune to the
   // concurrent parallel-fire a component useRef suffered (#751 audit #4).
   const { pubkey: signedInPubkey, relays: userRelays } = useNostr();
+  // The user's read-relay URLs, plus a content key that only changes when the
+  // URL *set* changes — not when useNostr() hands back a new array with the same
+  // URLs (cold-start cache→network churn), which used to double-fire the
+  // by-author fetch below (#798).
+  const readRelays = userRelays.filter((r) => r.read).map((r) => r.url);
+  const readRelayKey = readRelays.join(',');
   useEffect(() => {
     if (!signedInPubkey) return;
     const fetchKey = `${signedInPubkey}:${refreshKey}`;
     let cancelled = false;
-    const readRelays = userRelays.filter((r) => r.read).map((r) => r.url);
     // Join an in-flight fetch so concurrent effect re-runs don't fire parallel
     // requests, and the current run still merges on cancel (#752 Copilot).
     joinExploreByAuthorFetch(fetchKey, () =>
@@ -567,7 +567,12 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     return () => {
       cancelled = true;
     };
-  }, [signedInPubkey, userRelays, refreshKey]);
+    // Depend on readRelayKey (the relay-URL *content*), not the userRelays array
+    // identity: a genuine relay-set change still re-fires the fetch (parity with
+    // MapScreen's by-author fetch), but the cold-start new-array-same-URLs churn
+    // no longer does — that double-fired a redundant ~20s query (#798).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signedInPubkey, refreshKey, readRelayKey]);
 
   // Write-through to AsyncStorage whenever the in-memory state grows
   // so the next cold start has fresh content to hydrate from. Debounced
@@ -778,6 +783,14 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     );
   }, [merchants, posLat, posLon, maxDistanceMetres]);
 
+  // Distinct merchant categories for the legend. Memoised so the
+  // flatMap + Set + spread over all merchants doesn't run on every render
+  // (and so LegendSheet gets a stable array reference) (#798).
+  const availableCategories = useMemo(
+    () => [...new Set(merchants.flatMap((m) => m.categories ?? []).filter(Boolean))],
+    [merchants],
+  );
+
   const sortedCaches = useMemo(() => {
     const lowerPubkey = signedInPubkey?.toLowerCase() ?? null;
     const haveFix = typeof posLat === 'number' && typeof posLon === 'number';
@@ -903,9 +916,9 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
           events={eventsArr}
           onTapMap={onTapMap}
           onOpenLegend={onOpenLegend}
-          onSelectMerchant={(m) => setSelectedMerchant(m)}
-          onSelectCache={(c) => setSelectedCache(c)}
-          onSelectEvent={(e) => navigation.navigate('EventDetail', { coord: e.coord })}
+          onSelectMerchant={onSelectMerchant}
+          onSelectCache={onSelectCache}
+          onSelectEvent={onSelectEvent}
         />
 
         <ContentRail<{ place: BtcMapPlace; distance: number }>
@@ -915,7 +928,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
           loading={merchantsLoading && sortedMerchants.length === 0 && !!pos}
           // "See all" lands on the Places list (with map button in
           // its header); the dedicated Map view is one tap away.
-          onSeeAll={() => navigation.navigate('Places')}
+          onSeeAll={onSeeAllPlaces}
           seeAllTestId="explore-card-map"
           keyExtractor={(p) => String(p.place.id)}
           emptyState={
@@ -953,7 +966,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
           // "See all" lands on the merged Geo-caches page (map + list
           // + [+] in header for the hider flow). Was a two-screen
           // Hunt/Discover split before the May 2026 UX merge.
-          onSeeAll={() => navigation.navigate('Hunt')}
+          onSeeAll={onSeeAllHunt}
           seeAllTestId="explore-card-hunt"
           keyExtractor={(c) => c.cache.coord}
           emptyState={
@@ -994,7 +1007,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
           }
           items={sortedEvents}
           loading={!!pos && events.size === 0 && false}
-          onSeeAll={() => navigation.navigate('Events')}
+          onSeeAll={onSeeAllEvents}
           seeAllTestId="explore-card-events"
           keyExtractor={(e) => e.event.coord}
           emptyState={
@@ -1017,7 +1030,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
           title="Lessons in progress"
           caption={`${progress.completedMissions.length} / ${courses.reduce((a, c) => a + c.missions.length, 0)} missions done`}
           items={courses}
-          onSeeAll={() => navigation.navigate('Lessons')}
+          onSeeAll={onSeeAllLessons}
           seeAllTestId="explore-card-lessons"
           keyExtractor={(c) => c.id}
           renderItem={(course) => (
@@ -1040,9 +1053,7 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
         visible={legendVisible}
         onClose={onCloseLegend}
         placesVisible
-        availableCategories={[
-          ...new Set(merchants.flatMap((m) => m.categories ?? []).filter(Boolean)),
-        ]}
+        availableCategories={availableCategories}
       />
       {/* Mini-map pin-tap sheets — share the components with MapScreen
           so the interaction shape (drag-to-dismiss, tap-away, View

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -524,11 +524,11 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   // concurrent parallel-fire a component useRef suffered (#751 audit #4).
   const { pubkey: signedInPubkey, relays: userRelays } = useNostr();
   // The user's read-relay URLs, plus a content key that only changes when the
-  // URL *set* changes — not when useNostr() hands back a new array with the same
-  // URLs (cold-start cache→network churn), which used to double-fire the
-  // by-author fetch below (#798).
+  // URL *set* changes (sorted so a mere reorder doesn't) — not when useNostr()
+  // hands back a new array with the same URLs (cold-start cache→network churn),
+  // which used to double-fire the by-author fetch below (#798).
   const readRelays = userRelays.filter((r) => r.read).map((r) => r.url);
-  const readRelayKey = readRelays.join(',');
+  const readRelayKey = [...readRelays].sort().join(',');
   useEffect(() => {
     if (!signedInPubkey) return;
     const fetchKey = `${signedInPubkey}:${refreshKey}`;

--- a/src/screens/MyPigletsScreen.tsx
+++ b/src/screens/MyPigletsScreen.tsx
@@ -18,6 +18,7 @@ import { useThemeColors } from '../contexts/ThemeContext';
 import { useNostr } from '../contexts/NostrContext';
 import { useTrustGraph } from '../contexts/TrustGraphContext';
 import { type ParsedCache, parseCacheCoord } from '../services/nostrPlacesService';
+import { useCoalescedMap } from '../utils/useCoalescedMap';
 import { fetchCachesByAuthor, subscribeFoundLogsByAuthors } from '../services/nostrPlacesPublisher';
 import { loadCachedCaches, peekCachedCachesSync } from '../services/nostrPlacesStorage';
 import { loadPiggies, type HiddenPiggy } from '../services/piggyStorageService';
@@ -202,28 +203,25 @@ const MyPigletsScreen: React.FC<Props> = ({ navigation }) => {
       .sort((a, b) => b.createdAt - a.createdAt);
   }, [allCaches, pubkey]);
 
-  // Found by me — kind 7516 authored by me. Sub deps are author-only;
-  // cache enrichment happens at render via `cacheByCoord`. Anything
-  // that rebuilds `cacheByCoord` (relay echo, by-author refresh, pull-
-  // to-refresh) used to restart this sub and `new Map()`-wipe the
-  // section between renders — visible as a "Found" row that flashed
-  // off and back on. See the FoundEntry comment above.
-  const [myFinds, setMyFinds] = useState<Map<string, FoundEntry>>(new Map());
+  // Found by me — kind 7516 authored by me. CoalescedMap batches the
+  // per-event `new Map(prev)` clones that otherwise cause O(N²) overhead
+  // when the relay backfills 50+ found logs in a burst.
+  const myFinds = useCoalescedMap<FoundEntry>({
+    shouldReplace: (existing, incoming) => incoming.createdAt > existing.createdAt,
+  });
   useEffect(() => {
     if (!pubkey) return undefined;
-    setMyFinds(new Map());
+    myFinds.reset();
     const close = subscribeFoundLogsByAuthors([pubkey], (e) => {
       const entry = parseFoundEvent(e);
-      setMyFinds((prev) => {
-        const next = new Map(prev);
-        const existing = next.get(entry.coord);
-        // Keep the most recent claim per cache so re-finds don't
-        // duplicate rows. created_at is unix-seconds.
-        if (!existing || entry.createdAt > existing.createdAt) next.set(entry.coord, entry);
-        return next;
-      });
+      myFinds.enqueue(entry.coord, entry);
     });
-    return () => close();
+    return () => {
+      close();
+      myFinds.flush();
+    };
+    // myFinds.reset / enqueue / flush are stable callbacks (useCallback).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pubkey]);
 
   // Friends' finds — kind 7516 authored by anyone in the trust set,
@@ -235,28 +233,30 @@ const MyPigletsScreen: React.FC<Props> = ({ navigation }) => {
     return Array.from(trustSet).filter((p) => p.toLowerCase() !== lower);
   }, [trustSet, pubkey]);
 
-  const [friendFinds, setFriendFinds] = useState<Map<string, FoundEntry>>(new Map());
+  // Friends' finds — batched with CoalescedMap so a burst of kind 7516
+  // events doesn't clone the friend-finds Map N times.
+  const friendFinds = useCoalescedMap<FoundEntry>({
+    // Keyed by event id per the social-feed convention — never replace.
+    shouldReplace: () => false,
+  });
   useEffect(() => {
-    setFriendFinds(new Map());
+    friendFinds.reset();
     if (trustedAuthors.length === 0) return undefined;
     const close = subscribeFoundLogsByAuthors(trustedAuthors, (e) => {
       const entry = parseFoundEvent(e);
-      setFriendFinds((prev) => {
-        // Key on event id — multiple friends finding the same cache
-        // should each get a row. (My-finds dedupes per-cache; here we
-        // want the social signal.)
-        if (prev.has(entry.id)) return prev;
-        const next = new Map(prev);
-        next.set(entry.id, entry);
-        return next;
-      });
+      friendFinds.enqueue(entry.id, entry);
     });
-    return () => close();
+    return () => {
+      close();
+      friendFinds.flush();
+    };
+    // friendFinds.reset / enqueue / flush are stable callbacks.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trustedAuthors]);
 
   const foundList = useMemo(
-    () => [...myFinds.values()].sort((a, b) => b.createdAt - a.createdAt),
-    [myFinds],
+    () => [...myFinds.map.values()].sort((a, b) => b.createdAt - a.createdAt),
+    [myFinds.map],
   );
   // Drop find-logs whose cache event hasn't reached local storage —
   // showing "Cache no longer on relays" for every one looks broken to
@@ -267,11 +267,11 @@ const MyPigletsScreen: React.FC<Props> = ({ navigation }) => {
   // having to restart the find-log subscription.
   const friendList = useMemo(
     () =>
-      [...friendFinds.values()]
+      [...friendFinds.map.values()]
         .filter((e) => cacheByCoord.has(e.coord))
         .sort((a, b) => b.createdAt - a.createdAt)
         .slice(0, 50),
-    [friendFinds, cacheByCoord],
+    [friendFinds.map, cacheByCoord],
   );
 
   const sections: { title: string; data: SectionRow[] }[] = useMemo(

--- a/src/screens/MyPigletsScreen.tsx
+++ b/src/screens/MyPigletsScreen.tsx
@@ -234,10 +234,15 @@ const MyPigletsScreen: React.FC<Props> = ({ navigation }) => {
   }, [trustSet, pubkey]);
 
   // Friends' finds — batched with CoalescedMap so a burst of kind 7516
-  // events doesn't clone the friend-finds Map N times.
+  // events doesn't clone the friend-finds Map N times. Keyed by event id
+  // (never replaced) so the key space is unbounded — cap it so relay history
+  // over a long session can't grow the Map (and the sort-then-slice-50 in
+  // `friendList`) without limit. 200 keeps a comfortable buffer above the 50
+  // shown and matches `subscribeFoundLogsByAuthors`'s per-query `limit`.
   const friendFinds = useCoalescedMap<FoundEntry>({
     // Keyed by event id per the social-feed convention — never replace.
     shouldReplace: () => false,
+    maxSize: 200,
   });
   useEffect(() => {
     friendFinds.reset();

--- a/src/screens/MyPigletsScreen.tsx
+++ b/src/screens/MyPigletsScreen.tsx
@@ -235,10 +235,11 @@ const MyPigletsScreen: React.FC<Props> = ({ navigation }) => {
 
   // Friends' finds — batched with CoalescedMap so a burst of kind 7516
   // events doesn't clone the friend-finds Map N times. Keyed by event id
-  // (never replaced) so the key space is unbounded — cap it so relay history
-  // over a long session can't grow the Map (and the sort-then-slice-50 in
-  // `friendList`) without limit. 200 keeps a comfortable buffer above the 50
-  // shown and matches `subscribeFoundLogsByAuthors`'s per-query `limit`.
+  // (never replaced) so the key space is unbounded — and the subscription
+  // sets no `limit` of its own, so this cap is what bounds growth: it stops
+  // relay history over a long session from ballooning the Map (and the
+  // sort-then-slice-50 in `friendList`). 200 keeps a comfortable buffer above
+  // the 50 shown.
   const friendFinds = useCoalescedMap<FoundEntry>({
     // Keyed by event id per the social-feed convention — never replace.
     shouldReplace: () => false,

--- a/src/utils/useCoalescedMap.test.ts
+++ b/src/utils/useCoalescedMap.test.ts
@@ -127,4 +127,21 @@ describe('useCoalescedMap', () => {
     });
     expect(result.current.map.size).toBe(0);
   });
+
+  it('maxSize caps the committed Map, evicting oldest-inserted entries on flush', () => {
+    const { result } = renderHook(() => useCoalescedMap<number>({ flushMs: 100, maxSize: 3 }));
+    act(() => {
+      result.current.enqueue('a', 1);
+      result.current.enqueue('b', 2);
+      result.current.enqueue('c', 3);
+      result.current.enqueue('d', 4);
+      result.current.enqueue('e', 5);
+      result.current.flush();
+    });
+    // The two oldest-inserted (a, b) are evicted; the newest three remain.
+    expect(result.current.map.size).toBe(3);
+    expect(result.current.map.has('a')).toBe(false);
+    expect(result.current.map.has('b')).toBe(false);
+    expect([...result.current.map.keys()]).toEqual(['c', 'd', 'e']);
+  });
 });

--- a/src/utils/useCoalescedMap.test.ts
+++ b/src/utils/useCoalescedMap.test.ts
@@ -144,4 +144,22 @@ describe('useCoalescedMap', () => {
     expect(result.current.map.has('b')).toBe(false);
     expect([...result.current.map.keys()]).toEqual(['c', 'd', 'e']);
   });
+
+  it('maxSize caps the initial seed too — not just flushes', () => {
+    const { result } = renderHook(() =>
+      useCoalescedMap<number>({
+        maxSize: 2,
+        initial: () =>
+          new Map([
+            ['a', 1],
+            ['b', 2],
+            ['c', 3],
+          ]),
+      }),
+    );
+    // Over-cap seed is trimmed oldest-first immediately, before any flush.
+    expect(result.current.map.size).toBe(2);
+    expect(result.current.map.has('a')).toBe(false);
+    expect([...result.current.map.keys()]).toEqual(['b', 'c']);
+  });
 });

--- a/src/utils/useCoalescedMap.ts
+++ b/src/utils/useCoalescedMap.ts
@@ -43,6 +43,16 @@ export interface CoalescedMap<V> {
   reset: () => void;
 }
 
+/** Evict oldest-inserted entries (Map preserves insertion order) down to `max`. */
+function capOldest<V>(map: Map<string, V>, max: number | undefined): void {
+  if (max === undefined || map.size <= max) return;
+  let toDelete = map.size - max;
+  for (const key of map.keys()) {
+    if (toDelete-- <= 0) break;
+    map.delete(key);
+  }
+}
+
 export function useCoalescedMap<V>(options?: {
   /** Seed the committed Map on first render (e.g. from a sync cache peek). */
   initial?: () => Map<string, V>;
@@ -73,7 +83,13 @@ export function useCoalescedMap<V>(options?: {
   const maxSizeRef = useRef(options?.maxSize);
   maxSizeRef.current = options?.maxSize;
 
-  const [map, setMap] = useState<Map<string, V>>(() => options?.initial?.() ?? new Map());
+  const [map, setMap] = useState<Map<string, V>>(() => {
+    // Cap the seed too, so a caller seeding via `initial` over the cap isn't
+    // left oversized until the first flush (Copilot review).
+    const seed = options?.initial?.() ?? new Map();
+    capOldest(seed, options?.maxSize);
+    return seed;
+  });
   const pendingRef = useRef<Map<string, V>>(new Map());
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Distinguish full unmount (React throws on setState) from a focus blur — the
@@ -110,14 +126,7 @@ export function useCoalescedMap<V>(options?: {
       }
       // Evict oldest-inserted entries once over the cap so a long-lived
       // subscription can't grow the committed Map unbounded.
-      const maxSize = maxSizeRef.current;
-      if (maxSize !== undefined && next.size > maxSize) {
-        let toDelete = next.size - maxSize;
-        for (const key of next.keys()) {
-          if (toDelete-- <= 0) break;
-          next.delete(key);
-        }
-      }
+      capOldest(next, maxSizeRef.current);
       return next;
     });
   }, []);

--- a/src/utils/useCoalescedMap.ts
+++ b/src/utils/useCoalescedMap.ts
@@ -50,6 +50,14 @@ export function useCoalescedMap<V>(options?: {
   shouldReplace?: (existing: V, incoming: V) => boolean;
   flushMs?: number;
   flushThreshold?: number;
+  /**
+   * Cap the committed Map. On each flush, once the Map exceeds this size the
+   * oldest-inserted entries are evicted (Map preserves insertion order) down to
+   * the cap. Use for a long-lived subscription whose key space grows unbounded
+   * (e.g. per-event-id feeds) so the Map can't balloon over a long session.
+   * Omit for naturally-bounded key spaces (e.g. keyed per-cache).
+   */
+  maxSize?: number;
 }): CoalescedMap<V> {
   // 100 ms feels instant (≤120 ms reads as same-frame) yet coalesces a typical
   // relay event burst into 2–3 commits. 25-item threshold flushes early when a
@@ -61,6 +69,9 @@ export function useCoalescedMap<V>(options?: {
   // stable (callers pass an inline arrow each render).
   const shouldReplaceRef = useRef(options?.shouldReplace);
   shouldReplaceRef.current = options?.shouldReplace;
+  // Held in a ref so `flush` (deps: []) stays referentially stable.
+  const maxSizeRef = useRef(options?.maxSize);
+  maxSizeRef.current = options?.maxSize;
 
   const [map, setMap] = useState<Map<string, V>>(() => options?.initial?.() ?? new Map());
   const pendingRef = useRef<Map<string, V>>(new Map());
@@ -96,6 +107,16 @@ export function useCoalescedMap<V>(options?: {
         const existing = next.get(key);
         if (existing !== undefined && replace && !replace(existing, value)) continue;
         next.set(key, value);
+      }
+      // Evict oldest-inserted entries once over the cap so a long-lived
+      // subscription can't grow the committed Map unbounded.
+      const maxSize = maxSizeRef.current;
+      if (maxSize !== undefined && next.size > maxSize) {
+        let toDelete = next.size - maxSize;
+        for (const key of next.keys()) {
+          if (toDelete-- <= 0) break;
+          next.delete(key);
+        }
       }
       return next;
     });


### PR DESCRIPTION
<!--
Title format: Conventional Commits + optional scope, optional trailing issue suffix.
  feat(scope): subject (#nnn)        feat: subject
  fix(scope): subject (#nnn)         fix: subject
  perf(scope): subject (#nnn)        refactor(scope): subject
  chore: subject     ci: subject     docs: subject     deps: subject
  test: subject      build: subject  style: subject

Body sections below are required.
- feat / fix / perf / refactor PRs MUST include a `Closes #nnn` line (one per resolved issue).
- All PRs MUST include a `## Test plan` section with steps or `N/A — <reason>`.
-->

## Summary

<!-- 1-3 bullets: what changed and why. -->
Prevents frame drops in ExploreHomeScreen and MyPigletsScreen by capping unbounded Map growth and batching
   per-event state clones. Also adds early abort checks in the DM inbox decrypt loop so tab switches stop
  immediately instead of waiting for the next frame-budget yield.
## Closes

Closes #797

<!-- One `Closes #nnn` per resolved issue. Delete this section for chore / ci / docs / deps PRs not tied to an issue. -->

## Test plan
- Open MyPigletsScreen with 50+ found piglets — verify the "Found" and "Friends' Finds" sections render   
  without disappearing or flashing even on scroll
  - Open ExploreHomeScreen and leave it running for several minutes while new caches arrive — verify the map
   doesn't grow unbounded (monitor memory) and scrolling stays smooth
  - Switch tabs rapidly between DMs and any other tab — verify the decrypt loop aborts instantly instead of 
  lagging for the full frame budget (~100ms)
  - Pull-to-refresh on MyPigletsScreen — found lists should not briefly vanish during the refresh

<!--
Step-by-step actions a reviewer or tester can follow, with expected results.
Example:
  1. Open the Messages tab.
  2. **Expected:** conversations appear immediately on cold start (no blank flash).
  3. Tap the (+) FAB.
  4. **Expected:** sheet animates up smoothly, friend list appears within ~250 ms.

For pure-refactor / docs / CI / deps PRs with no user-visible change, replace with:

  N/A — <one-line reason, e.g. "internal refactor, covered by existing perf-suite">
-->

## Screenshots (if applicable)

<!--
For UI changes, attach before/after screenshots. Use ADB to capture on Android:
  adb exec-out screencap -p > /tmp/screen.png
  convert /tmp/screen.png -resize 1200x1200\> /tmp/screen_small.png
-->

## Perf impact (if applicable)

<!--
For PRs touching list-rendering / sheet / animation surfaces, run:
  scripts/perf-suite.sh
on this branch and on `main`, then paste the median table delta. Otherwise N/A.
-->

## TestFlight "What to Test" bullet (if user-visible)
 Scroll through My Piglets and Explore screens after prolonged use — lists should feel smooth with no      
  stutter or vanishing rows. Tab switching while DMs are loading should feel instant.
<!--
For PRs that change something a beta tester would notice, append a one-line
bullet to docs/RELEASE_NOTES_NEXT.md. The release workflow auto-publishes the
file's contents to TestFlight as the build's "What to Test" notes, then resets
the file. See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".

Pure refactors / CI / docs PRs should delete this section.
-->