### PR TITLE
refactor(wallet): split btcPrice + lastIncomingPayment into WalletLiveContext (#801)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { WalletProvider, useWallet } from './src/contexts/WalletContext';
+import { WalletProvider, useWalletLive } from './src/contexts/WalletContext';
 import { NostrProvider } from './src/contexts/NostrContext';
 import { TrustGraphProvider } from './src/contexts/TrustGraphContext';
 import { GroupsProvider } from './src/contexts/GroupsContext';
@@ -52,7 +52,7 @@ import OfflineBanner from './src/components/OfflineBanner';
 // context's incoming-payment event bus, and above any screen so the
 // confetti pops no matter where the user is when a payment lands.
 function GlobalIncomingPaymentOverlay() {
-  const { lastIncomingPayment, clearLastIncomingPayment } = useWallet();
+  const { lastIncomingPayment, clearLastIncomingPayment } = useWalletLive();
   // Key on the event timestamp so a second payment arriving while the
   // overlay is still visible remounts the component and re-arms the
   // confetti animation. Without this, a second `success` in a row

--- a/src/components/AmountEntryScreen.tsx
+++ b/src/components/AmountEntryScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { ChevronLeft, Delete, ArrowUpDown } from 'lucide-react-native';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { createAmountEntryStyles } from '../styles/AmountEntryScreen.styles';
 import { satsToFiat, formatFiat } from '../services/fiatService';
@@ -60,7 +60,8 @@ const AmountEntryScreen: React.FC<Props> = ({
 }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createAmountEntryStyles(colors), [colors]);
-  const { btcPrice, currency } = useWallet();
+  const { currency } = useWallet();
+  const { btcPrice } = useWalletLive();
   const [memo, setMemo] = useState(initialMemo);
 
   const [primaryUnit, setPrimaryUnit] = useState<Unit>('sats');

--- a/src/components/LnurlWithdrawSheet.tsx
+++ b/src/components/LnurlWithdrawSheet.tsx
@@ -27,7 +27,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import { Gift, PartyPopper } from 'lucide-react-native';
 import { useThemeColors } from '../contexts/ThemeContext';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import {
   LnurlWithdrawError,
   LnurlWithdrawParams,
@@ -75,8 +75,8 @@ type Stage =
 export function LnurlWithdrawHost(): React.ReactElement {
   const colors = useThemeColors();
   const styles = useMemo(() => createLnurlWithdrawSheetStyles(colors), [colors]);
-  const { wallets, makeInvoiceForWallet, btcPrice, currency, expectPayment, lastIncomingPayment } =
-    useWallet();
+  const { wallets, makeInvoiceForWallet, currency, expectPayment } = useWallet();
+  const { btcPrice, lastIncomingPayment } = useWalletLive();
 
   const sheetRef = useRef<BottomSheetModal>(null);
   // Untyped like NostrLoginSheet's scrollRef — the gorhom ScrollView ref methods

--- a/src/components/NfcReadSheet.tsx
+++ b/src/components/NfcReadSheet.tsx
@@ -27,7 +27,7 @@ import { recordClaim } from '../services/claimHistoryService';
 import { friendlyClaimError } from '../utils/claimErrorMessage';
 import { SLEEPING_PATTERN, parseCooldownSeconds, formatCountdown } from '../utils/lnurlCooldown';
 import { useThemeColors } from '../contexts/ThemeContext';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import type { Palette } from '../styles/palettes';
 import PrizeWalletPicker from './PrizeWalletPicker';
 import ScanRingSpinner from './ScanRingSpinner';
@@ -54,7 +54,8 @@ type SheetStage = 'ready' | 'reading' | 'claiming' | 'claimed' | 'sleeping' | 'e
 const NfcReadSheet: React.FC<Props> = ({ visible, onClose, expectedCoord }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const { wallets, makeInvoiceForWallet, lastIncomingPayment, expectPayment } = useWallet();
+  const { wallets, makeInvoiceForWallet, expectPayment } = useWallet();
+  const { lastIncomingPayment } = useWalletLive();
   const [stage, setStage] = useState<SheetStage>('ready');
   const [errorMessage, setErrorMessage] = useState('');
   const [claimedSats, setClaimedSats] = useState<number | null>(null);

--- a/src/components/PaymentNotifier.tsx
+++ b/src/components/PaymentNotifier.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { firePaymentNotification } from '../services/notificationService';
 
 /**
@@ -24,7 +24,8 @@ import { firePaymentNotification } from '../services/notificationService';
 const TX_SETTLE_GRACE_MS = 5000;
 
 export default function PaymentNotifier(): null {
-  const { wallets, lastIncomingPayment } = useWallet();
+  const { wallets } = useWallet();
+  const { lastIncomingPayment } = useWalletLive();
   // Hashes we've already fired for — guarantees once-per-payment across both
   // the immediate path and the deferred (tx-arrived / timeout) paths.
   const announced = useRef<Set<string>>(new Set());

--- a/src/components/ReceiveSheet.tsx
+++ b/src/components/ReceiveSheet.tsx
@@ -22,7 +22,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { buildBip21 } from '../utils/bip21';
 import { paymentHashFromBolt11 } from '../utils/bolt11';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useNostr, useNostrContacts } from '../contexts/NostrContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { walletLabel } from '../types/wallet';
@@ -77,12 +77,11 @@ const ReceiveSheet: React.FC<Props> = ({
     activeWalletId,
     activeWallet,
     wallets,
-    btcPrice,
     currency,
     getReceiveAddress,
     expectPayment,
-    lastIncomingPayment,
   } = useWallet();
+  const { btcPrice, lastIncomingPayment } = useWalletLive();
   const [capturedWalletId, setCapturedWalletId] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [mode, setMode] = useState<Mode>('address');

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -23,7 +23,7 @@ import { CameraView, useCameraPermissions } from 'expo-camera';
 import * as Clipboard from 'expo-clipboard';
 import { decode as bolt11Decode } from 'light-bolt11-decoder';
 import { parseBip21 } from '../utils/bip21';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { walletLabel } from '../types/wallet';
 import { useNostr, useNostrContacts } from '../contexts/NostrContext';
 import { useThemeColors } from '../contexts/ThemeContext';
@@ -93,9 +93,9 @@ const SendSheet: React.FC<Props> = ({
     addPendingTransaction,
     activeWalletId,
     wallets,
-    btcPrice,
     currency,
   } = useWallet();
+  const { btcPrice } = useWalletLive();
   const { signZapRequest } = useNostr();
   const { contacts } = useNostrContacts();
   const [capturedWalletId, setCapturedWalletId] = useState<string | null>(null);

--- a/src/components/TipSheet.tsx
+++ b/src/components/TipSheet.tsx
@@ -17,7 +17,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import QRCode from 'react-native-qrcode-svg';
 import { Check } from 'lucide-react-native';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { satsToFiatString } from '../services/fiatService';
 import { Course } from '../data/learnContent';
@@ -32,7 +32,8 @@ interface Props {
 const TipSheet: React.FC<Props> = ({ visible, onClose, course }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createTipSheetStyles(colors), [colors]);
-  const { makeInvoice, refreshActiveBalance, balance, btcPrice, currency } = useWallet();
+  const { makeInvoice, refreshActiveBalance, balance, currency } = useWallet();
+  const { btcPrice } = useWalletLive();
   const [invoice, setInvoice] = useState('');
   const [loading, setLoading] = useState(false);
   const [paymentReceived, setPaymentReceived] = useState(false);

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -11,7 +11,7 @@ import * as SecureStore from 'expo-secure-store';
 import * as Clipboard from 'expo-clipboard';
 import Toast from './BrandedToast';
 import { satsToFiatString } from '../services/fiatService';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useNostr, useNostrContacts } from '../contexts/NostrContext';
 import * as swapRecoveryService from '../services/swapRecoveryService';
 import * as nwcService from '../services/nwcService';
@@ -131,7 +131,8 @@ const TransactionDetailSheet: React.FC<Props> = ({
       </View>
     </TouchableOpacity>
   );
-  const { btcPrice, currency, activeWallet } = useWallet();
+  const { currency, activeWallet } = useWallet();
+  const { btcPrice } = useWalletLive();
   const { isLoggedIn, signerType, sendDirectMessage } = useNostr();
   const { contacts } = useNostrContacts();
   const sheetRef = useRef<BottomSheetModal>(null);

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -6,7 +6,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useThemeColors } from '../contexts/ThemeContext';
 import type { Palette } from '../styles/palettes';
 import { satsToFiatString } from '../services/fiatService';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useNostrContacts } from '../contexts/NostrContext';
 import ContactProfileSheet from './ContactProfileSheet';
 import type { ContactProfileBodyData } from './ContactProfileBody';
@@ -104,7 +104,8 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
   }
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const { btcPrice, currency, activeWalletId } = useWallet();
+  const { currency, activeWalletId } = useWallet();
+  const { btcPrice } = useWalletLive();
   const { contacts } = useNostrContacts();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   // When contacts' profiles refresh, we want transaction rows to pick up

--- a/src/components/TransferSheet.tsx
+++ b/src/components/TransferSheet.tsx
@@ -22,7 +22,7 @@ import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Toast from './BrandedToast';
 import * as swapRecoveryService from '../services/swapRecoveryService';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useNostr, OWN_PROFILE_CACHE_KEY_BASE } from '../contexts/NostrContext';
 import { perAccountKey } from '../services/perAccountStorage';
 import type { NostrProfile } from '../types/nostr';
@@ -51,7 +51,6 @@ const TransferSheet: React.FC<Props> = ({ visible, onClose }) => {
   const {
     wallets,
     activeWalletId,
-    btcPrice,
     currency,
     makeInvoiceForWallet,
     payInvoiceForWallet,
@@ -59,6 +58,7 @@ const TransferSheet: React.FC<Props> = ({ visible, onClose }) => {
     fetchTransactionsForWallet,
     addPendingTransaction,
   } = useWallet();
+  const { btcPrice } = useWalletLive();
   const { identities, pubkey: activePubkey } = useNostr();
 
   const [sourceId, setSourceId] = useState<string | null>(null);

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -28,6 +28,7 @@ import * as swapRecoveryService from '../services/swapRecoveryService';
 import * as onchainService from '../services/onchainService';
 import * as walletStorage from '../services/walletStorageService';
 import { CURRENCIES, FiatCurrency, getBtcPrice } from '../services/fiatService';
+import { WalletLiveContext } from './WalletLiveContext';
 import {
   CardTheme,
   WalletMetadata,
@@ -110,7 +111,6 @@ interface WalletContextType {
   // User prefs
   currency: FiatCurrency;
   setCurrency: (currency: FiatCurrency) => Promise<void>;
-  btcPrice: number | null;
 
   // Wallet actions
   addNwcWallet: (
@@ -167,12 +167,6 @@ interface WalletContextType {
   // On-chain actions
   getReceiveAddress: (walletId: string) => Promise<string>;
 
-  // Incoming payment event bus. Set whenever any connected wallet's
-  // balance goes UP; consumed by the app-root PaymentProgressOverlay
-  // so the celebration appears regardless of which screen is active.
-  lastIncomingPayment: IncomingPayment | null;
-  clearLastIncomingPayment: () => void;
-
   /**
    * Kick off aggressive 1 s polling for a specific NWC invoice for up
    * to `durationMs` (default 3 min). Called by ReceiveSheet when an
@@ -224,6 +218,10 @@ interface WalletContextType {
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+// Live price/receive slices (#801) live in their own module; re-export the
+// consumer hook so the public surface stays at one path, like `useWallet`.
+export { useWalletLive } from './WalletLiveContext';
 
 // Persist a wallet's announced-receipt hashes so a payment is announced once,
 // EVER — not once per JS session. The in-memory set resets on every cold start
@@ -2088,7 +2086,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       walletsHydrated,
       currency,
       setCurrency,
-      btcPrice,
       addNwcWallet,
       addOnchainWallet,
       addHotWallet,
@@ -2106,8 +2103,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       fetchTransactionsForWallet,
       addPendingTransaction,
       getReceiveAddress,
-      lastIncomingPayment,
-      clearLastIncomingPayment,
       expectPayment,
       requestBalancePoll,
       isConnected,
@@ -2127,7 +2122,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       walletsHydrated,
       currency,
       setCurrency,
-      btcPrice,
       addNwcWallet,
       addOnchainWallet,
       addHotWallet,
@@ -2145,14 +2139,24 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       fetchTransactionsForWallet,
       addPendingTransaction,
       getReceiveAddress,
-      lastIncomingPayment,
-      clearLastIncomingPayment,
       expectPayment,
       requestBalancePoll,
     ],
   );
 
-  return <WalletContext.Provider value={contextValue}>{children}</WalletContext.Provider>;
+  // Sibling value carrying the high-frequency price/receive slices (#801).
+  // Memoised separately so a fiat-price poll or a settled receive rebuilds only
+  // this — not `contextValue` — and only `useWalletLive()` consumers re-render.
+  const walletLiveValue = useMemo(
+    () => ({ btcPrice, lastIncomingPayment, clearLastIncomingPayment }),
+    [btcPrice, lastIncomingPayment, clearLastIncomingPayment],
+  );
+
+  return (
+    <WalletContext.Provider value={contextValue}>
+      <WalletLiveContext.Provider value={walletLiveValue}>{children}</WalletLiveContext.Provider>
+    </WalletContext.Provider>
+  );
 };
 
 export function useWallet() {

--- a/src/contexts/WalletLiveContext.tsx
+++ b/src/contexts/WalletLiveContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext } from 'react';
+import type { IncomingPayment } from './WalletContext';
+
+/**
+ * The high-frequency "live" wallet slices (#801). Split out of `WalletContext`
+ * because these change far more often than the wallet list / actions:
+ *
+ *  - `btcPrice` — re-`setState`'d on every fiat-price poll (~30 s), read by
+ *    ~11 consumers (every screen that shows a sats↔fiat amount).
+ *  - `lastIncomingPayment` — fires on every settled receive, read by ~4
+ *    (PaymentNotifier, ReceiveSheet, LnurlWithdrawSheet, NfcReadSheet).
+ *
+ * Left in the same `useWallet()` value they re-rendered all ~24 consumers on
+ * every poll/receive. Served from a sibling provider (mirrors the #806
+ * `dmInbox` split) so only consumers that actually read price/receive state
+ * re-render. The wallet list / balance churn (`wallets`) is NOT split here —
+ * it's derived state most consumers read together, so it needs the selector
+ * store in #803, not a sibling context.
+ *
+ * The provider is wired in `WalletProvider` (which owns the underlying state);
+ * this module owns only the context object, its type, and the consumer hook.
+ */
+export interface WalletLiveContextType {
+  btcPrice: number | null;
+  lastIncomingPayment: IncomingPayment | null;
+  clearLastIncomingPayment: () => void;
+}
+
+export const WalletLiveContext = createContext<WalletLiveContextType | undefined>(undefined);
+
+/**
+ * Access the live wallet slices (`btcPrice`, `lastIncomingPayment`) (#801).
+ * Served from a sibling provider so consumers of this hook re-render on
+ * price/receive updates while plain `useWallet()` consumers do not.
+ */
+export function useWalletLive() {
+  const context = useContext(WalletLiveContext);
+  if (!context) {
+    throw new Error('useWalletLive must be used within a WalletProvider');
+  }
+  return context;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -12,7 +12,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import { useNostr } from '../contexts/NostrContext';
 import { Home } from 'lucide-react-native';
 import { useThemeColors } from '../contexts/ThemeContext';
@@ -50,10 +50,10 @@ const HomeScreen: React.FC = () => {
     refreshActiveBalance,
     fetchTransactionsForWallet,
     setActiveWallet,
-    btcPrice,
     currency,
     requestBalancePoll,
   } = useWallet();
+  const { btcPrice } = useWalletLive();
   const { isLoggedIn, profile, refreshProfile } = useNostr();
   const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList, 'Home'>>();
   const route = useRoute<RouteProp<MainTabParamList, 'Home'>>();

--- a/src/screens/HuntFoundScreen.tsx
+++ b/src/screens/HuntFoundScreen.tsx
@@ -10,7 +10,7 @@ import {
 import Slider from '@react-native-community/slider';
 import { ChevronLeft, Gift, PartyPopper, PiggyBank } from 'lucide-react-native';
 import { useThemeColors } from '../contexts/ThemeContext';
-import { useWallet } from '../contexts/WalletContext';
+import { useWallet, useWalletLive } from '../contexts/WalletContext';
 import type { Palette } from '../styles/palettes';
 import { ExploreNavigation, ExploreStackParamList } from '../navigation/types';
 import {
@@ -84,7 +84,8 @@ const HuntFoundScreen: React.FC<Props> = ({ navigation, route }) => {
   const colors = useThemeColors();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const { lnurl, coord } = route.params;
-  const { activeWalletId, makeInvoice, btcPrice, currency } = useWallet();
+  const { activeWalletId, makeInvoice, currency } = useWallet();
+  const { btcPrice } = useWalletLive();
 
   const [stage, setStage] = useState<Stage>({ kind: 'resolving' });
   // Chosen claim amount (sats) for variable-amount tags. Defaults to max


### PR DESCRIPTION
## What

Splits the two high-frequency "live" wallet slices — `btcPrice` (fiat-price poll, ~30s) and `lastIncomingPayment` (settled receive) — out of `WalletContext` into a sibling `WalletLiveContext`. Second step of the context/state remediation in `docs/architecture/perf-and-state.adoc`, mirroring the #806 `dmInbox` split.

Left in the shared `useWallet()` value, every price poll and every receive re-rendered **all ~24 `useWallet()` consumers** — the same render-storm class #806 fixed for DMs. `btcPrice` alone is read by ~11 screens (every sats↔fiat amount) and re-set every ~30s.

## How

- New `src/contexts/WalletLiveContext.tsx` owns the context, its type, and the `useWalletLive()` consumer hook (re-exported from `WalletContext` so the import path stays at one place, like #806's `useNostrDmInbox`).
- `WalletProvider` builds a sibling `walletLiveValue` memo (`{ btcPrice, lastIncomingPayment, clearLastIncomingPayment }`) and nests `<WalletLiveContext.Provider>`. The three slices leave the main `contextValue`, so a poll/receive no longer churns it.
- Migrated all **13 consumers** (12 components/screens + `App.tsx`'s payment overlay) from `useWallet()` to `useWalletLive()` for those fields — mechanical destructure splits, no behaviour change.

### Scope note
The `wallets`/`balance` churn is **deliberately not split here**. `balance`/`activeWallet`/`isConnected` are *derived* from `wallets`, which most consumers read together with actions — so a sibling context wouldn't help (they'd subscribe to it anyway). That churn needs the selector store in #803, per Archie's diagnosis and the per-consumer usage map.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] ESLint (0 errors) + Prettier clean
- [x] `scripts/check-file-size.sh` passes (over-cap SendSheet/TransferSheet unchanged; net-zero destructure edits)
- [x] 76 wallet/fiat unit tests pass (`fiatService`, `nwcService`)
- [x] Pixel smoke-test: Home renders balance **and the US$ fiat value** (`btcPrice` via the new context) with no provider redbox; transaction-list fiat amounts render; `logcat` shows no `useWalletLive`/provider error

Closes #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Performance validation (Stevie, on-device)

Clean before/after on the Pixel 8 (n=5 price polls, 20s interval). **Probe:** `WalletsScreen` — uses `useWallet()` for wallets/actions, **not** `btcPrice` (and is identical on both branches). **Control:** `HomeScreen` — reads `btcPrice` via `useWalletLive()`.

| Screen | Before (`main`) | After (this PR) | Reduction |
|---|---|---|---|
| `WalletsScreen` (non-price consumer) | 1 re-render / poll (5/5) | **0 / poll (0/5)** | **100%** |
| `HomeScreen` (control — reads `btcPrice`) | 1 / poll (5/5) | 1 / poll (5/5) | 0% (expected) |

Every price poll on `main` re-rendered `WalletsScreen` (1:1, zero misses); after the split, **zero** across all 5 polls. The control re-renders in both — confirming the polls actually fired and the fix is *surgical*, not accidentally suppressing all renders. Mechanism: on `main`, `btcPrice` is in the single `contextValue` memo dep array, so `setBtcPrice()` invalidates the whole shared object and cascades to all ~11 `useWallet()` consumers; on this branch it's in a separate `walletLiveValue`/`WalletLiveContext`, leaving `WalletContext`'s value untouched on a poll.
