### PR TITLE
chore(perf): audit relay-subscription lifecycle + cap knownWrapIds (#804)

### DIFF
--- a/src/contexts/knownWrapIdsCap.test.ts
+++ b/src/contexts/knownWrapIdsCap.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Backpressure cap for the in-memory NIP-17 wrap-id dedup set (#804).
+ *
+ * `knownWrapIds` previously grew for the whole session — a busy account could
+ * accumulate tens of thousands of ids (MBs of RAM). `capKnownWrapIds` bounds it
+ * by evicting the oldest-inserted ids (Set preserves insertion order) once it
+ * exceeds the cap, down to 75% so it isn't re-triggered on every add.
+ */
+import { capKnownWrapIds, KNOWN_WRAP_IDS_CAP } from './knownWrapIdsCap';
+
+describe('capKnownWrapIds', () => {
+  it('is a no-op while at or under the cap', () => {
+    const set = new Set<string>(['a', 'b', 'c']);
+    capKnownWrapIds(set);
+    expect(set.size).toBe(3);
+    expect([...set]).toEqual(['a', 'b', 'c']);
+  });
+
+  it('evicts down to 75% of the cap when exceeded', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < KNOWN_WRAP_IDS_CAP + 500; i++) set.add(`id-${i}`);
+    capKnownWrapIds(set);
+    expect(set.size).toBe(Math.floor(KNOWN_WRAP_IDS_CAP * 0.75));
+  });
+
+  it('drops the OLDEST-inserted ids and keeps the newest', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < KNOWN_WRAP_IDS_CAP + 1; i++) set.add(`id-${i}`);
+    capKnownWrapIds(set);
+    // Oldest (id-0) is gone; the most-recent id survives.
+    expect(set.has('id-0')).toBe(false);
+    expect(set.has(`id-${KNOWN_WRAP_IDS_CAP}`)).toBe(true);
+  });
+
+  it('caps exactly at the boundary (no eviction at size === cap)', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < KNOWN_WRAP_IDS_CAP; i++) set.add(`id-${i}`);
+    capKnownWrapIds(set);
+    expect(set.size).toBe(KNOWN_WRAP_IDS_CAP);
+  });
+});

--- a/src/contexts/knownWrapIdsCap.ts
+++ b/src/contexts/knownWrapIdsCap.ts
@@ -1,0 +1,26 @@
+/**
+ * Backpressure cap for the in-memory NIP-17 wrap-id dedup set (#804).
+ *
+ * `knownWrapIds` (in `nostrLiveDmSub`) mirrors the persisted wrap cache so the
+ * live sub can skip already-seen wraps without a disk read. Without a bound it
+ * grows for the whole session — a busy account re-streams + accumulates
+ * thousands of ids (MBs of RAM). A `Set` preserves insertion order, so evicting
+ * from the front drops the oldest-seen wraps. Dedup is an optimization, not
+ * correctness: an evicted-then-reseen wrap is just re-decrypted once and
+ * re-caught by the persisted cache downstream, so eviction is safe (mirrors the
+ * existing `seen` Set cap in the same file).
+ *
+ * Pure + dependency-free so it's unit-testable without the live-sub machinery.
+ */
+export const KNOWN_WRAP_IDS_CAP = 8000;
+
+export function capKnownWrapIds(set: Set<string>): void {
+  if (set.size <= KNOWN_WRAP_IDS_CAP) return;
+  const target = Math.floor(KNOWN_WRAP_IDS_CAP * 0.75);
+  const it = set.values();
+  while (set.size > target) {
+    const next = it.next();
+    if (next.done) break;
+    set.delete(next.value);
+  }
+}

--- a/src/contexts/nostrLiveDmSub.ts
+++ b/src/contexts/nostrLiveDmSub.ts
@@ -19,6 +19,7 @@ import { tryRouteGroupRumor } from './nostrGroupRouting';
 import { fireMessageNotification } from '../services/notificationService';
 import { subscribeInboxDmsForViewer } from '../services/dmLiveSubscription';
 import { yieldToEventLoop } from './nostrDecryptPacing';
+import { capKnownWrapIds } from './knownWrapIdsCap';
 import {
   AMBER_NIP17_CACHE_KEY_BASE,
   NSEC_NIP17_CACHE_KEY_BASE,
@@ -155,7 +156,10 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
     // the early-return because the Set hasn't been updated yet.
     // Set.add is idempotent so the trailing writeChain add becomes
     // a no-op. kind 4 has its own `seen` Set below.
-    if (ev.kind === 1059) knownWrapIds.add(ev.id);
+    if (ev.kind === 1059) {
+      knownWrapIds.add(ev.id);
+      capKnownWrapIds(knownWrapIds);
+    }
     if (__DEV__) console.log(`[Nostr] live evt kind=${ev.kind} recv ${ev.id.slice(0, 8)}`);
     if (cancelled) return;
     if (seen.has(ev.id)) {
@@ -525,6 +529,7 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
             `[Nostr] live DM sub: seeded knownWrapIds with ${dmCount} dm + ${knownWrapIds.size - dmCount} group wraps`,
           );
         }
+        capKnownWrapIds(knownWrapIds);
       } catch (e) {
         // Seed-from-disk failed — leave knownWrapIds as the empty
         // Set we initialised at outer-scope. Cached wraps re-stream


### PR DESCRIPTION
## What

Issue #804 — audit the relay-subscription lifecycle and backpressure (5th step of the perf-and-state epic). Audited **all 43 files** with relay-subscription or per-event-collection code for (a) subscriptions never closed on teardown and (b) Sets/Maps that grow unbounded per session.

## Audit result

**Subscription leaks: 0.** Every relay subscription returns an unsubscribe handle and closes it — on `useEffect`/`useFocusEffect` cleanup, an AbortSignal, or in a `finally`. The `useEffect`-vs-`useFocusEffect` choices are deliberate and documented (e.g. `ExploreHomeScreen` keeps subs open across focus to avoid a ~15s relay backlog re-emit per tab return; `HuntScreen`/`EventsScreen` scope to focus because they freeze on blur). The codebase is disciplined here — nothing to fix.

**Unbounded growth: 1** (the only real defect):
- `knownWrapIds` — the in-memory NIP-17 wrap-dedup mirror in `nostrLiveDmSub.ts` — grew for the entire session with no cap. A busy account (100+ wraps/week, months of uptime) could accumulate tens of thousands of 64-char ids → several MB of RAM that's never reclaimed until logout.
- Everything else checked is already bounded: the `seen` Set caps at 4096, `nip04PlaintextCache` is LRU-1000, the Explore/Hunt coalesced maps flush every 100ms, `friendFinds` is `maxSize: 200`, etc.

## Fix

Extract a pure, dependency-free `capKnownWrapIds` (`src/contexts/knownWrapIdsCap.ts`) that evicts the **oldest-inserted** ids (a `Set` preserves insertion order) down to 75% once it exceeds an **8000** cap, and apply it after the live `onevent` add and the cold-start disk seed. Dedup is an optimization, not correctness — an evicted-then-reseen wrap is just re-decrypted once and re-caught by the persisted cache downstream — so eviction is safe. Mirrors the existing `seen` Set cap in the same file.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] ESLint (0 errors) + Prettier clean
- [x] `scripts/check-file-size.sh` passes
- [x] New unit test `knownWrapIdsCap.test.ts` (4 cases: no-op under cap, evict-to-75%, oldest-first eviction, exact-boundary) + existing DM/context suites green (26 tests)
- [x] Pixel regression smoke (Stevie): DM inbox + conversations still load/decrypt normally with the cap in place — _pending, see Stevie comment_

Closes #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
