### PR TITLE
fix(dm): seed live-sub knownWrapIds from file cache, not AsyncStorage (#811)

### DIFF
--- a/src/contexts/nostrLiveDmSub.ts
+++ b/src/contexts/nostrLiveDmSub.ts
@@ -86,7 +86,7 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
   // In-memory mirror of the persisted NIP-17 wrap-id cache. Backed
   // by `knownWrapIdsRef` so the Set survives this effect's re-runs
   // (relay-list change → fresh effect instance). Seeded by union
-  // below from AsyncStorage's wrap cache, but does NOT replace any
+  // below from the file-backed wrap cache, but does NOT replace any
   // entries the prior sub instance added in-memory but the deferred
   // writeChain hasn't persisted yet. Per issue #505 — the relay
   // re-streams the backlog since the last `since` cursor, and on a
@@ -513,7 +513,13 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
           : null;
     if (wrapCacheKey) {
       try {
-        const seedRaw = await AsyncStorage.getItem(wrapCacheKey);
+        // Read the file-backed wrap cache (via safeGetDmCacheItem), NOT
+        // AsyncStorage directly: writeNip17Cache persists to a file and
+        // deletes the legacy AsyncStorage row, so a raw `AsyncStorage.getItem`
+        // here returns null on every file-backed install → seeds 0 wraps →
+        // blinds the dedup → the relay's wrap re-stream re-decrypts the whole
+        // backlog on each sub-open (the freeze, #811).
+        const seedRaw = await safeGetDmCacheItem(wrapCacheKey);
         const seedCache = safeParseRecord<Nip17CacheEntry>(seedRaw);
         for (const id of Object.keys(seedCache)) knownWrapIds.add(id);
         // Also seed from persisted group messages — group-routed wraps

--- a/src/contexts/nostrLiveDmSub.ts
+++ b/src/contexts/nostrLiveDmSub.ts
@@ -438,7 +438,12 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
     writeChain = writeChain
       .then(async () => {
         if (cancelled) return;
-        const wrapRaw = await AsyncStorage.getItem(cacheKey);
+        // Read the file-backed wrap cache (NOT AsyncStorage, whose row
+        // writeNip17Cache deletes). Reading the wrong store here returned an
+        // empty `{}`, so this read→merge→write OVERWROTE the file with just
+        // this one wrap on every live arrival — clobbering the whole cache and
+        // defeating the persisted dedup (#811).
+        const wrapRaw = await safeGetDmCacheItem(cacheKey);
         const wrapCache = safeParseRecord<Nip17CacheEntry>(wrapRaw);
         if (wrapCache[wrap.id]) {
           knownWrapIds?.add(wrap.id);
@@ -549,8 +554,8 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
         //      runs unnecessarily for each cached wrap (1–3 ms each).
         // The persistent on-disk wrapCache write is idempotent —
         // it doesn't grow unboundedly. We accept this regression on
-        // the failure path because (a) AsyncStorage.getItem I/O
-        // errors are extremely rare on Android, and (b) the
+        // the failure path because (a) safeGetDmCacheItem file
+        // read/migration failures are extremely rare, and (b) the
         // alternative (resurrecting the lazy-load inside the
         // handler) would re-introduce the race + per-event prologue
         // cost that motivated #505 in the first place.


### PR DESCRIPTION
## What

The live DM subscription seeded its in-memory wrap-dedup set (`knownWrapIds`) from **AsyncStorage**, but the NIP-17 wrap cache is **file-backed** — `writeNip17Cache` writes to a file and *deletes* the legacy AsyncStorage row. So the seed read `null` on every file-backed install → seeded **0 wraps** → the early dedup short-circuit (`knownWrapIds.has(ev.id)`) was blind → the relay's kind-1059 re-stream **re-decrypted the backlog** (up to `COLD_INITIAL_WRAP_LIMIT` schnorr/NIP-44 unwraps) on **every** sub-open. That's a JS-thread freeze contributor.

The tell: `[Nostr] live DM sub: seeded knownWrapIds with 0 dm + 0 group wraps` showed up even on a **warm, non-cold device** (observed on the Pixel).

## How

`src/contexts/nostrLiveDmSub.ts` — read the seed via **`safeGetDmCacheItem`** (already imported), which resolves wrap-cache keys to the file (with one-time legacy migration). One line; identical `string | null` return, so the downstream `safeParseRecord` is unchanged. `refreshDmInbox` and `fetchConversation` already read via `safeGetDmCacheItem` — only the **live-sub seed** was on the wrong store.

Found while auditing the DM cache/decryption flow (your "are we definitely caching DMs?" question). The audit's broader conclusion: caching is otherwise complete — decrypted NIP-17 plaintext is persisted to a file and survives cold start (the old #687 re-decrypt-everything bug is fixed), DMs are **not** re-downloaded. This was the one seed-source gap.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] ESLint + Prettier clean
- [ ] On-device (Stevie, emulator): the seed log shows the **real** persisted wrap count (not `0 dm`) on a warm account, and re-streamed already-cached wraps are dedup-skipped (decrypt count → ~0 for known wraps) — _pending_

Closes #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Update — Copilot catch + validation

- **Second fix (the root data-loss bug):** the live wrap-**persist** path (`nostrLiveDmSub.ts:441`) also read the cache via `AsyncStorage.getItem(cacheKey)`. On a file-backed install that read `{}`, so the read→merge→write **overwrote the wrap-cache file with only the just-arrived wrap on every live DM** — clobbering the whole cache (the deeper reason the seed found ~0). Now reads via `safeGetDmCacheItem`. (Copilot review, commit 27103b9.)
- **Stevie (emulator `lightningpiggy_api34`):** DM regression **PASS** — Messages loads, no redbox/exception, JS thread clean 60fps. The `N>0` seed-log proof was **inconclusive** because the emulator account has no Nostr identity (seed block never runs) — best confirmed on a device with DM history (e.g. the Pixel that showed the original `0 dm` log).
