### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Marketing version bump 1.3.0 → 1.3.1. `versionCode`/`buildNumber` stay EAS-managed (remote auto-increment). Merging this, then publishing the **v1.3.1** GitHub Release, triggers `release.yml` → EAS cloud builds → iOS auto-submits to TestFlight + Android APK attaches.

## What's new in 1.3.1

A performance and stability release, focused on the messaging freezes and general smoothness.

- **Messaging:** fixed the multi-second freezes when opening the Messages tab. Direct messages are now cached correctly and no longer re-decrypt the whole history on every open.
- **Smoother app:** heavy shared state was split up, so an incoming DM, a price tick, or a balance change no longer re-renders unrelated screens.
- **Leaner background work:** audited relay subscriptions and capped in-memory caches to keep long sessions light.
- **Explore:** snappier map — staggered marker rendering to reduce the stutter when opening the Explore tab.
- **Send:** fixed scanned/pasted Lightning (LNURL-pay) codes that weren't resolving.

## Test plan

- [x] Version bump only — no source changes; CI (tsc/lint/jest/file-size) gates the bump.
- [ ] Post-merge: publish the v1.3.1 Release → verify EAS iOS build submits to TestFlight and the Android APK attaches to the Release.
