### PR TITLE
chore(release): install mermaid CLI so the Technical Solution PDF generates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,7 +468,7 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Install asciidoctor-pdf + rouge + mermaid CLI
+      - name: Install asciidoctor-pdf + asciidoctor-diagram + rouge + mermaid CLI
         run: |
           gem install asciidoctor-pdf asciidoctor-diagram rouge
           # mmdc renders DATA_STORAGE.adoc's [mermaid] blocks; generate-docs.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,7 +466,7 @@ jobs:
       - name: Setup Node (for the mermaid CLI)
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: .nvmrc
 
       - name: Install asciidoctor-pdf + rouge + mermaid CLI
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,8 +474,10 @@ jobs:
           # mmdc renders DATA_STORAGE.adoc's [mermaid] blocks; generate-docs.sh
           # points its headless Chrome at docs/puppeteer-mermaid.json
           # (--no-sandbox) so it launches on the CI runner. Without this the
-          # PDF job failed every release ("mmdc is not installed").
-          npm install -g @mermaid-js/mermaid-cli
+          # PDF job failed every release ("mmdc is not installed"). Pinned (like
+          # EAS_CLI_VERSION) for reproducible release docs — 11.9.0 is the
+          # version v1.3.1's PDF was generated with.
+          npm install -g @mermaid-js/mermaid-cli@11.9.0
 
       - name: Generate PDF
         run: bash docs/generate-docs.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,9 +463,19 @@ jobs:
         with:
           ruby-version: '3.3'
 
-      - name: Install asciidoctor-pdf + rouge
+      - name: Setup Node (for the mermaid CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install asciidoctor-pdf + rouge + mermaid CLI
         run: |
           gem install asciidoctor-pdf asciidoctor-diagram rouge
+          # mmdc renders DATA_STORAGE.adoc's [mermaid] blocks; generate-docs.sh
+          # points its headless Chrome at docs/puppeteer-mermaid.json
+          # (--no-sandbox) so it launches on the CI runner. Without this the
+          # PDF job failed every release ("mmdc is not installed").
+          npm install -g @mermaid-js/mermaid-cli
 
       - name: Generate PDF
         run: bash docs/generate-docs.sh


### PR DESCRIPTION
## What

The **"Generate & attach Technical Solution PDF"** release job has failed on **every** release (confirmed v1.3.0 and v1.3.1) with:

```
Error: mermaid CLI (mmdc) is not installed (needed to render [mermaid] blocks)
```

## Cause

`docs/DATA_STORAGE.adoc` contains a `[mermaid]` block. The PDF job installed the `asciidoctor-diagram` **gem** but not the **`mmdc` binary** (`@mermaid-js/mermaid-cli`) it shells out to. `docs/generate-docs.sh` guards on `mmdc` and exits 1 when it's missing — so the PDF was never produced.

Everything else was already correct: the script passes `-a mermaid-puppeteer-config=puppeteer-mermaid.json`, and `docs/puppeteer-mermaid.json` already sets `--no-sandbox --disable-gpu --disable-dev-shm-usage` for headless Chrome on the runner.

## Fix

Add `actions/setup-node` + `npm install -g @mermaid-js/mermaid-cli` to the PDF job's install step. One missing dependency.

## Test plan

- [x] Generated the PDF **locally** with the same `docs/generate-docs.sh` (mmdc present) — succeeds, 5 MB output (non-fatal asciidoctor table-truncation warnings only).
- [x] Retrospectively attached that PDF to the **v1.3.1 Release** so 1.3.1 isn't missing it.
- [ ] Next release event: the PDF job installs mmdc, renders the mermaid block via the no-sandbox puppeteer config, and attaches the PDF automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
