### PR TITLE
chore(release): npm ci before eas build:list (fixes Android-APK + TestFlight-notes jobs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Install dependencies (eas build:list needs app.config.ts)
+        run: npm ci
+
       - name: Verify ASC API key is wired
         env:
           # The ASC API key is stored under the EXPO_ASC_* secret names (the
@@ -267,6 +270,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+
+      # eas build:list resolves the project via app.config.ts, which imports
+      # from node_modules — without `npm ci` the CLI errors out and the jq
+      # parse fails. This job (and the two below) failed every release for
+      # this reason; the working build-and-submit job already does npm ci.
+      - name: Install dependencies (eas build:list needs app.config.ts)
+        run: npm ci
 
       - name: Resolve latest finished Android APK URL
         id: find
@@ -395,6 +405,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+
+      - name: Install dependencies (eas build:list needs app.config.ts)
+        run: npm ci
 
       - name: Resolve build numbers + edit Release title
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: npm
 
       - name: Install dependencies (eas build:list needs app.config.ts)
         run: npm ci
@@ -270,6 +271,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+          cache: npm
 
       # eas build:list resolves the project via app.config.ts, which imports
       # from node_modules — without `npm ci` the CLI errors out and the jq
@@ -405,6 +407,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+          cache: npm
 
       - name: Install dependencies (eas build:list needs app.config.ts)
         run: npm ci


### PR DESCRIPTION
## What

Three release jobs — **`attach-android-apk`**, **`set-testflight-whats-new`**, **`sync-release-identifiers`** — have failed on **every** release (confirmed v1.3.0 and v1.3.1):
- The **Android APK never attached** to the GitHub Release (no Android download artifact).
- TestFlight **"What to Test"** notes never populated.
- Build-number sync into the Release title was skipped.

## Cause

Each runs `eas build:list`, which resolves the project via **`app.config.ts`** — and that imports from `node_modules`. None of these jobs ran `npm ci`, so the CLI errored and the downstream `jq` parse failed (`Invalid numeric literal…`). The only EAS job that works (`build-and-submit`) already does `npm ci`.

## Fix

Add `npm ci` after Setup Node in the three jobs, mirroring `build-and-submit`. Same class of fix as #792.

## Test plan

- [x] YAML validates (`yaml.safe_load`).
- [x] v1.3.1's Android APK attached to the Release manually so 1.3.1 has its artifact now.
- [ ] Next release: the three jobs install deps, `eas build:list` resolves, the Android APK auto-attaches, and TestFlight notes populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)