### PR TITLE
perf(map): seed pins from cache + coalesce subscription bursts (#823, #824)

### DIFF
--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -295,6 +295,10 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
       .then((mine) => {
         if (cancelled || mine.length === 0) return;
         for (const c of mine) caches.enqueue(c.coord, c);
+        // One-shot fetch — flush now so the author's own pins commit on this
+        // frame instead of waiting on the coalesce debounce (~100ms) when the
+        // batch is under the flush threshold (Copilot review on #825).
+        caches.flush();
       })
       .catch(() => {
         // Best-effort — the nearby subscription will fill the gap if the
@@ -314,6 +318,18 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
     for (const p of places) for (const c of p.categories ?? []) seen.add(c);
     return [...seen].sort();
   }, [places]);
+
+  // Single-pass Piglet / non-Piglet tally for the footer — avoids spreading +
+  // filtering `caches.map.values()` twice every render (Copilot review on #825).
+  const cacheCounts = useMemo(() => {
+    let piglets = 0;
+    let others = 0;
+    for (const c of caches.map.values()) {
+      if (c.isLpPiggy) piglets++;
+      else others++;
+    }
+    return { piglets, others };
+  }, [caches.map]);
 
   // Filtered arrays for LibreMiniMap. Same predicates the WebView path
   // used to send across the bridge — now plain memoised derived state.
@@ -477,9 +493,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
           <Text style={styles.footerText}>
             {places.length} merchants
             {caches.map.size > 0
-              ? ` · ${[...caches.map.values()].filter((c) => c.isLpPiggy).length} Piglets · ${
-                  [...caches.map.values()].filter((c) => !c.isLpPiggy).length
-                } caches`
+              ? ` · ${cacheCounts.piglets} Piglets · ${cacheCounts.others} caches`
               : ''}
           </Text>
         )}

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -9,6 +9,7 @@ import {
   Animated,
   PanResponder,
   Dimensions,
+  InteractionManager,
 } from 'react-native';
 import * as Location from 'expo-location';
 import {
@@ -42,11 +43,13 @@ import {
   btcMapVerifyUrl,
   daysSinceVerified,
   fetchPlacesInBbox,
+  peekCachedPlacesSync,
   formatAddress,
   isBoosted,
   lightningAddressOf,
 } from '../services/btcMapService';
 import type { ParsedCache } from '../services/nostrPlacesService';
+import { useCoalescedMap } from '../utils/useCoalescedMap';
 import { fetchCachesByAuthor, subscribeNearbyCaches } from '../services/nostrPlacesPublisher';
 import { useNostr } from '../contexts/NostrContext';
 import { decodeGeohash, encodeGeohash, geohashNeighbours } from '../utils/geohash';
@@ -93,7 +96,19 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
   // kind-20069 ping subscriptions go quiet when a detail sheet/screen
   // covers the map or we navigate away (no background battery cost).
   const isFocused = useIsFocused();
-  const friends = useFriendsLiveLocations({ enabled: isFocused });
+  // Defer enabling the live-location subscription until the tab transition
+  // settles (#824) — its backlog replay otherwise lands as a second setState
+  // burst that competes with the navigation animation. Disables on blur.
+  const [friendsEnabled, setFriendsEnabled] = useState(false);
+  useEffect(() => {
+    if (!isFocused) {
+      setFriendsEnabled(false);
+      return;
+    }
+    const task = InteractionManager.runAfterInteractions(() => setFriendsEnabled(true));
+    return () => task.cancel();
+  }, [isFocused]);
+  const friends = useFriendsLiveLocations({ enabled: friendsEnabled });
   const friendMarkers = useMemo(
     () => friends.map((f) => ({ key: f.pubkey, lat: f.lat, lon: f.lon, avatarUri: f.avatarUri })),
     [friends],
@@ -133,8 +148,18 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
   // around without re-centring the map (the camera stays anchored to
   // the user's initial pos so panning behaviour isn't fighting GPS).
   const { pos: livePos } = useUserLocation();
-  const [places, setPlaces] = useState<BtcMapPlace[]>([]);
-  const [caches, setCaches] = useState<Map<string, ParsedCache>>(new Map());
+  // Seed synchronously from the warm BTC Map cache (#823) so the map paints
+  // pins on the first frame instead of a blank map until the viewport fetch
+  // returns — matches ExploreHomeScreen/PlacesScreen. The bbox fetch below
+  // then refreshes them (stale-while-revalidate).
+  const [places, setPlaces] = useState<BtcMapPlace[]>(() => peekCachedPlacesSync());
+  // Coalesced (#824): a relay backlog flushed on (re)focus commits as ONE
+  // setState per flush window instead of one Map-clone + render per event —
+  // the per-event burst that froze the tab transition. `shouldReplace` keeps
+  // the newest entry per coord (same rule the inline merges used).
+  const caches = useCoalescedMap<ParsedCache>({
+    shouldReplace: (existing, incoming) => incoming.createdAt > existing.createdAt,
+  });
   const [selected, setSelected] = useState<BtcMapPlace | null>(null);
   const [selectedCache, setSelectedCache] = useState<ParsedCache | null>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -238,13 +263,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
         const prefixes = geohashNeighbours(myTile);
         cachesCloserRef.current?.();
         cachesCloserRef.current = subscribeNearbyCaches(prefixes, (cache) => {
-          setCaches((prev) => {
-            const existing = prev.get(cache.coord);
-            if (existing && existing.createdAt >= cache.createdAt) return prev;
-            const next = new Map(prev);
-            next.set(cache.coord, cache);
-            return next;
-          });
+          caches.enqueue(cache.coord, cache);
         });
       } catch (e) {
         if (!cancelled) setError((e as Error).message);
@@ -253,6 +272,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
     return () => {
       cancelled = true;
       cachesCloserRef.current?.();
+      caches.flush();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -274,14 +294,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
     fetchCachesByAuthor(signedInPubkey, readRelays.length > 0 ? readRelays : undefined)
       .then((mine) => {
         if (cancelled || mine.length === 0) return;
-        setCaches((prev) => {
-          const next = new Map(prev);
-          for (const c of mine) {
-            const existing = next.get(c.coord);
-            if (!existing || c.createdAt > existing.createdAt) next.set(c.coord, c);
-          }
-          return next;
-        });
+        for (const c of mine) caches.enqueue(c.coord, c);
       })
       .catch(() => {
         // Best-effort — the nearby subscription will fill the gap if the
@@ -290,6 +303,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- caches.enqueue is stable; one-shot per (signedInPubkey, userRelays)
   }, [signedInPubkey, userRelays]);
 
   // Distinct categories across the currently-loaded places — fed into
@@ -333,13 +347,13 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
     // serving them, so the client filters them out. The Geo-caches list
     // (HuntScreen) already does this; the map must too, else an expired Piglet
     // lingers on the map after it's gone from the list (#762).
-    return [...caches.values()].filter(
+    return [...caches.map.values()].filter(
       (c) =>
         (c.isLpPiggy ? filters.piglet : filters.nipgcCache) &&
         isTrusted(c.hiderPubkey) &&
         (c.expiresAt === null || c.expiresAt > nowSec),
     );
-  }, [caches, filters.piglet, filters.nipgcCache, isTrusted, nowSec]);
+  }, [caches.map, filters.piglet, filters.nipgcCache, isTrusted, nowSec]);
 
   const refreshPlaces = useCallback(async (bbox: Bbox) => {
     try {
@@ -462,9 +476,9 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
         ) : (
           <Text style={styles.footerText}>
             {places.length} merchants
-            {caches.size > 0
-              ? ` · ${[...caches.values()].filter((c) => c.isLpPiggy).length} Piglets · ${
-                  [...caches.values()].filter((c) => !c.isLpPiggy).length
+            {caches.map.size > 0
+              ? ` · ${[...caches.map.values()].filter((c) => c.isLpPiggy).length} Piglets · ${
+                  [...caches.map.values()].filter((c) => !c.isLpPiggy).length
                 } caches`
               : ''}
           </Text>
@@ -511,7 +525,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
           untrustedCacheCount={
             // Caches that would render if the WoT filter were "All".
             // Computed each render; cheap because `caches` is small.
-            [...caches.values()].filter(
+            [...caches.map.values()].filter(
               (c) =>
                 (c.isLpPiggy ? filters.piglet : filters.nipgcCache) && !isTrusted(c.hiderPubkey),
             ).length


### PR DESCRIPTION
Implements **#823** and **#824** (and supersedes **#813**) — both MapScreen-local, so one PR avoids same-file churn.

## #823 — map no longer blank until the network fetch
`MapScreen` started `places` empty and only filled via the viewport-driven `fetchPlacesInBbox`, so every open showed a blank map until the network returned (ExploreHomeScreen/PlacesScreen don't — they seed from the cache). Now `places` seeds synchronously from `peekCachedPlacesSync()`; the existing bbox fetch becomes stale-while-revalidate.

## #824 — tab-switch freeze
Two unbatched `setState` bursts landed during the tab transition:
1. `subscribeNearbyCaches` cloned the whole `Map` + `setState` **per event** — a relay backlog = N clones + N GL pin re-diffs, synchronously.
2. `useFriendsLiveLocations({ enabled: isFocused })` re-enabled on focus and replayed a location backlog as a second burst.

Fixes:
- **Coalesce** the cache state via the existing `useCoalescedMap` hook (one `setState` per flush window; `shouldReplace` keeps newest-per-coord). This is #813's fix, done via the shared hook.
- **Defer** the live-location enable past the transition with `InteractionManager.runAfterInteractions`.

## Test plan
- [x] `npx tsc --noEmit` clean · ESLint (0 errors) · Prettier · file-size (MapScreen 1151/1562)
- [x] `useCoalescedMap` unit tests pass
- [ ] On-device: open the Map — cached pins paint on the first frame; rapid Explore↔Map / tab switching no longer freezes; pins still update as the camera settles _(pending — held off to avoid interrupting v1.3.1 prod testing on the Pixel)_

Closes #823, #824, #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Performance validation (Stevie, emulator `lightningpiggy_api34`, mock GPS London)

| Fix | Before | After |
|---|---|---|
| **#823** map open | blank map until the bbox network fetch returned | cached merchant pins paint on the **first frame** — "19 merchants" footer at ~**600ms** on re-open, no blank-then-fill |
| **#824** tab switching | per-event `Map`-clone + GL re-diff burst froze the transition | rapid Explore↔Messages↔Home↔Map switching stayed smooth: **tab transitions 91–114ms**, **no multi-second freeze, no crash, no JS exception** |

`useCoalescedMap` state persisted correctly across teardown/remount cycles; the `caches.map` accessor rendered cleanly. Only logcat noise was pre-existing MapLibre native teardown warnings + emulator EGL — none introduced by this PR. (One ~1s pause during the run traced to an Android permission dialog pausing the JS thread, not the coalesce path.)


## Measurements (Stevie, emulator-5554 dev client)

`scripts/perf-explore-cold-start.sh` (n=5/side; this flow exercises the shared Explore cold-start path, NOT MapScreen itself): main p50 **25,927 ms** vs PR p50 **25,900 ms** — Δ≈0%, confirming **no regression on the shared path**; the PR-branch distribution is notably tighter (max 26,417 ms vs 55,206 ms on main). The map-specific claims (first-frame cached pins ~600 ms; 91–114 ms tab transitions with no freeze) remain evidenced by the on-device run in the table above. Full per-run data: [Stevie's measurements](https://github.com/BenGWeeks/lightning-piggy-mobile/pull/825#issuecomment-4684024607).