### PR TITLE
perf(profiles): seed usePubkeyProfile avatar from cache synchronously

### DIFF
--- a/src/hooks/usePubkeyProfile.ts
+++ b/src/hooks/usePubkeyProfile.ts
@@ -113,7 +113,20 @@ export const usePubkeyProfile = (pubkey: string | null | undefined): PubkeyProfi
     }
     // Re-seed synchronously from the in-memory cache so a pubkey change paints
     // the cached avatar immediately, before the async get / relay fetch (#388).
-    setSlice(peekSlice(pubkey));
+    // Functional + equality-gated: this effect also re-fires on a relay-list
+    // (`readRelaysKey`) change for the SAME pubkey, where the seeded values are
+    // unchanged — keep `prev` then so we don't churn a re-render in list-heavy
+    // surfaces (Copilot review on #826).
+    setSlice((prev) => {
+      const seeded = peekSlice(pubkey);
+      return prev.name === seeded.name &&
+        prev.picture === seeded.picture &&
+        prev.banner === seeded.banner &&
+        prev.lud16 === seeded.lud16 &&
+        prev.loading === seeded.loading
+        ? prev
+        : seeded;
+    });
     let cancelled = false;
     (async () => {
       // Cache hit — sync-fast, no relay round-trip.

--- a/src/hooks/usePubkeyProfile.ts
+++ b/src/hooks/usePubkeyProfile.ts
@@ -54,6 +54,24 @@ const empty: PubkeyProfileSlice = {
   loading: false,
 };
 
+// Build the slice synchronously from the in-memory profile cache so a warm
+// avatar (its `picture`) paints on the FIRST frame instead of after the async
+// `get` resolves (the "avatars load late" symptom, #388). `loading` stays true
+// when the cache lacks `lud16`, so the effect still fetches the remaining
+// fields — but the picture is already on screen.
+function peekSlice(pubkey: string | null | undefined): PubkeyProfileSlice {
+  if (!pubkey) return empty;
+  const cached = zapSenderProfileStorage.peekSync(pubkey);
+  if (!cached) return empty;
+  return {
+    name: cached.displayName ?? cached.name ?? null,
+    picture: cached.picture ?? null,
+    banner: null,
+    lud16: cached.lud16 ?? null,
+    loading: cached.lud16 === undefined,
+  };
+}
+
 // In-flight de-duplication: concurrent consumers asking for the same
 // pubkey share one fetch. Cleared when the promise settles so a later
 // remount triggers a fresh fetch if the cache has aged past TTL.
@@ -86,13 +104,16 @@ export const usePubkeyProfile = (pubkey: string | null | undefined): PubkeyProfi
     .map((r) => r.url)
     .sort()
     .join('|');
-  const [slice, setSlice] = useState<PubkeyProfileSlice>(empty);
+  const [slice, setSlice] = useState<PubkeyProfileSlice>(() => peekSlice(pubkey));
 
   useEffect(() => {
     if (!pubkey) {
       setSlice(empty);
       return;
     }
+    // Re-seed synchronously from the in-memory cache so a pubkey change paints
+    // the cached avatar immediately, before the async get / relay fetch (#388).
+    setSlice(peekSlice(pubkey));
     let cancelled = false;
     (async () => {
       // Cache hit — sync-fast, no relay round-trip.

--- a/src/services/zapSenderProfileStorage.test.ts
+++ b/src/services/zapSenderProfileStorage.test.ts
@@ -15,6 +15,7 @@ import {
   __resetForTests,
   get,
   getMany,
+  peekSync,
   setMany,
   type CachedZapSenderProfile,
 } from './zapSenderProfileStorage';
@@ -52,6 +53,36 @@ describe('zapSenderProfileStorage', () => {
 
   it('returns null for an unknown pubkey', async () => {
     expect(await get('z'.repeat(64))).toBeNull();
+  });
+
+  describe('peekSync (synchronous seed for avatar URLs)', () => {
+    it('returns null when the in-memory mirror has not loaded yet', () => {
+      // Cold: no get/getMany/setMany has populated memoryCache.
+      expect(peekSync('a'.repeat(64))).toBeNull();
+    });
+
+    it('returns the cached profile synchronously once the mirror is warm', async () => {
+      const pk = 'a'.repeat(64);
+      await setMany(new Map([[pk, profile({ picture: 'https://x/me.png' })]]));
+      // No await — must come straight from the warm in-memory mirror.
+      const hit = peekSync(pk);
+      expect(hit?.picture).toBe('https://x/me.png');
+    });
+
+    it('returns null for a missing pubkey and for a TTL-expired entry', async () => {
+      const pk = 'a'.repeat(64);
+      await setMany(new Map([[pk, profile()]]));
+      expect(peekSync('b'.repeat(64))).toBeNull();
+      // Roll the clock past TTL — peekSync must then treat the entry as a miss
+      // (same mechanism as the get/getMany TTL test above).
+      const realNow = Date.now;
+      try {
+        jest.spyOn(Date, 'now').mockImplementation(() => realNow() + __TEST__.TTL_MS + 1);
+        expect(peekSync(pk)).toBeNull();
+      } finally {
+        (Date.now as jest.Mock).mockRestore?.();
+      }
+    });
   });
 
   it('getMany returns only the pubkeys present in cache', async () => {

--- a/src/services/zapSenderProfileStorage.ts
+++ b/src/services/zapSenderProfileStorage.ts
@@ -102,6 +102,22 @@ export async function getMany(pubkeys: string[]): Promise<Map<string, CachedZapS
 }
 
 /**
+ * Synchronous peek into the in-memory mirror — used to SEED a consumer's
+ * initial state so a warm profile (its avatar URL) paints on the FIRST frame
+ * instead of after the async `get` resolves (the "avatars load late" symptom).
+ * Returns null until the mirror has been loaded once this session (`get` /
+ * `getMany` populate it — the common case, since the surfaces using this peek
+ * also call `get`). TTL-aware, same as `get`.
+ */
+export function peekSync(pubkey: string): CachedZapSenderProfile | null {
+  if (!pubkey || !memoryCache) return null;
+  const entry = memoryCache[pubkey];
+  if (!entry) return null;
+  if (Date.now() - entry.savedAt > TTL_MS) return null;
+  return entry.profile;
+}
+
+/**
  * Write-through after a successful relay resolution. Evicts the
  * oldest entries when the cache crosses `MAX_ENTRIES`.
  */


### PR DESCRIPTION
## What

Fixes the user-reported "profile images don't load straight away, as if the cache isn't used" on the contact-profile / Hunt surfaces.

## Diagnosis (the image cache is fine — the URL arrives late)
Every avatar renders with `expo-image` + `cachePolicy="memory-disk"` and a stable key, so bytes paint instantly once there's a URL. The blank window is purely where the Nostr profile's `picture` is still `null`. `usePubkeyProfile` (`hooks/usePubkeyProfile.ts:89`) started at the `empty` constant and only read the cache via `await zapSenderProfileStorage.get()` inside an async effect — so a **warm cache hit still couldn't paint on the first frame**.

## Fix
- `zapSenderProfileStorage.peekSync(pubkey)` — synchronous, TTL-aware read of the in-memory mirror.
- Seed `usePubkeyProfile`'s initial `useState(() => peekSlice(pubkey))` and re-seed on pubkey change from it. The async `get`/relay path is unchanged (refresh). Mirrors #823's `peekCachedPlacesSync`.

## Scope (honest)
This covers the **`usePubkeyProfile`** consumers (contact-profile sheet, Hunt rows). The **Messages/Friends** rows draw avatars from the **contacts cache** (`NostrContext` → AsyncStorage), which **can't be read synchronously** — that's the **#388** cold-start surface and needs a different fix (placeholder initials, or a sync-readable store like MMKV). Not in this PR.

## Test plan
- [x] `tsc` clean · ESLint 0 errors · Prettier
- [x] New `peekSync` unit tests (cold→null, warm→sync hit, missing/TTL-expired→null) + existing suite green (10/10)
- [ ] On-device: open a contact profile / Hunt avatar — the cached avatar paints on the first frame (no blank-then-fill)

Closes #827

Relates to #388 (the Messages/Friends contacts-cache surface, not fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Performance improvement

- **Before:** `usePubkeyProfile` consumers (contact-profile sheet, Hunt rows) rendered with `picture: null` on the first frame even for a warm profile, then re-rendered with the avatar after the `await zapSenderProfileStorage.get()` resolved — a visible blank-then-pop.
- **After:** the cached avatar URL is read **synchronously** via `peekSync` and seeded into the initial `useState`, so the avatar paints on the **first frame** (no extra async round-trip, no blank-then-pop). The async `get`/relay path remains as the refresh.
- The re-seed is equality-gated, so a relay-list change for the same pubkey does **not** churn an extra re-render (Copilot review).
