### PR TITLE
perf(dm): drop redundant verify + bind rumor↔seal on nsec decrypt (#829, #830)

### DIFF
--- a/src/utils/nip17Unwrap.test.ts
+++ b/src/utils/nip17Unwrap.test.ts
@@ -145,10 +145,12 @@ describe('textForRumor (kind-15 → bubble text)', () => {
 
 /**
  * Security characterisation for the #802 change: the gift-wrap schnorr
- * verify was dropped from the nsec decrypt path. These tests prove the
- * security model is unchanged — integrity is still enforced by the NIP-44
- * MAC, and authenticity by the seal ECDH — while the (redundant, expensive)
- * signature verify no longer gates the hot loop.
+ * verify was dropped from the nsec decrypt path. These tests prove what
+ * that path actually guarantees — the wrap signature no longer gates
+ * decryption, and the NIP-44 MAC still rejects a tampered ciphertext —
+ * while the (redundant, expensive) signature verify no longer runs in the
+ * hot loop. (Full rumor↔seal sender binding is a separate concern handled
+ * in `unwrapWrapViaNip44`, not asserted here — see #830.)
  */
 describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
   // Build a real NIP-17 gift wrap from `sender` to `recipient`.
@@ -175,7 +177,9 @@ describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
     expect(rumor).not.toBeNull();
     expect(rumor?.content).toBe('hello piggy');
     expect(rumor?.kind).toBe(14);
-    // Sender identity comes from the seal ECDH, surfaced as rumor.pubkey.
+    // `unwrapEvent` returns the inner rumor's own pubkey field. For a
+    // well-formed wrap from `wrapEvent` that equals the sender; this path
+    // does not itself bind it to the seal key (#830).
     expect(rumor?.pubkey).toBe(senderPk);
   });
 
@@ -194,7 +198,10 @@ describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
     // Flip one base64 char inside the wrap ciphertext → NIP-44 MAC mismatch
     // → decrypt throws → unwrapWrapNsec skips (returns null). This is the
     // guarantee that replaced the schnorr verify: integrity is preserved.
-    const i = 60;
+    // Index is relative to the payload length (mid-ciphertext) so it stays
+    // in-bounds if nostr-tools' payload format/size changes.
+    expect(wrap.content.length).toBeGreaterThan(100);
+    const i = Math.floor(wrap.content.length / 2);
     const swapped = wrap.content[i] === 'A' ? 'B' : 'A';
     const tampered = wrap.content.slice(0, i) + swapped + wrap.content.slice(i + 1);
     const onSkip = jest.fn();

--- a/src/utils/nip17Unwrap.test.ts
+++ b/src/utils/nip17Unwrap.test.ts
@@ -5,8 +5,9 @@
  * Issue #271.
  */
 
-import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { wrapEvent } from 'nostr-tools/nip59';
+import * as nip44 from 'nostr-tools/nip44';
 import {
   subjectFromRumor,
   textForRumor,
@@ -144,13 +145,13 @@ describe('textForRumor (kind-15 → bubble text)', () => {
 });
 
 /**
- * Security characterisation for the #802 change: the gift-wrap schnorr
- * verify was dropped from the nsec decrypt path. These tests prove what
- * that path actually guarantees — the wrap signature no longer gates
- * decryption, and the NIP-44 MAC still rejects a tampered ciphertext —
- * while the (redundant, expensive) signature verify no longer runs in the
- * hot loop. (Full rumor↔seal sender binding is a separate concern handled
- * in `unwrapWrapViaNip44`, not asserted here — see #830.)
+ * Security characterisation for the nsec decrypt path. Proves the guarantees
+ * after #802 (the redundant gift-wrap schnorr verify no longer gates
+ * decryption) and #830 (the path now binds `rumor.pubkey === seal.pubkey`):
+ *   - a wrap with an invalid signature still decrypts (verify is gone),
+ *   - a tampered ciphertext is still rejected by the NIP-44 MAC,
+ *   - a rumor claiming a different pubkey than its seal is rejected
+ *     (sender-spoofing blocked).
  */
 describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
   // Build a real NIP-17 gift wrap from `sender` to `recipient`.
@@ -177,9 +178,8 @@ describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
     expect(rumor).not.toBeNull();
     expect(rumor?.content).toBe('hello piggy');
     expect(rumor?.kind).toBe(14);
-    // `unwrapEvent` returns the inner rumor's own pubkey field. For a
-    // well-formed wrap from `wrapEvent` that equals the sender; this path
-    // does not itself bind it to the seal key (#830).
+    // For a well-formed wrap, rumor.pubkey == seal.pubkey == sender, so the
+    // #830 binding passes and the sender is surfaced as rumor.pubkey.
     expect(rumor?.pubkey).toBe(senderPk);
   });
 
@@ -212,5 +212,52 @@ describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
     );
     expect(rumor).toBeNull();
     expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('REJECTS a wrap whose rumor.pubkey != seal.pubkey (sender spoofing, #830)', () => {
+    // Hand-craft a malicious wrap: the seal is sealed (and ECDH-authenticated)
+    // by the *attacker*, but the inner rumor claims it was sent by a different
+    // pubkey (the victim being impersonated). `wrapEvent` can't produce this —
+    // it always sets rumor.pubkey == seal sender — so we build the two NIP-44
+    // layers by hand.
+    const recipientSk = generateSecretKey();
+    const recipientPk = getPublicKey(recipientSk);
+    const attackerSk = generateSecretKey(); // the key that actually seals
+    const victimPk = 'd'.repeat(64); // the pubkey the rumor falsely claims
+
+    const rumor = {
+      pubkey: victimPk,
+      created_at: 1,
+      kind: 14,
+      content: 'transfer 1000 sats, trust me',
+      tags: [['p', recipientPk]],
+    };
+    const sealKey = nip44.v2.utils.getConversationKey(attackerSk, recipientPk);
+    const seal = finalizeEvent(
+      {
+        kind: 13,
+        content: nip44.v2.encrypt(JSON.stringify(rumor), sealKey),
+        created_at: 1,
+        tags: [],
+      },
+      attackerSk,
+    );
+    const ephemeralSk = generateSecretKey();
+    const wrapKey = nip44.v2.utils.getConversationKey(ephemeralSk, recipientPk);
+    const wrap = finalizeEvent(
+      {
+        kind: 1059,
+        content: nip44.v2.encrypt(JSON.stringify(seal), wrapKey),
+        created_at: 1,
+        tags: [['p', recipientPk]],
+      },
+      ephemeralSk,
+    );
+
+    const onSkip = jest.fn();
+    const out = unwrapWrapNsec(wrap as unknown as WrapArg, recipientSk, onSkip);
+    expect(out).toBeNull();
+    // Skipped specifically for the pubkey-binding mismatch, not a decrypt error.
+    expect(onSkip).toHaveBeenCalledWith(expect.stringContaining('!='), expect.any(String));
   });
 });

--- a/src/utils/nip17Unwrap.test.ts
+++ b/src/utils/nip17Unwrap.test.ts
@@ -195,12 +195,10 @@ describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
 
   it('still REJECTS a wrap whose ciphertext was tampered (MAC enforces integrity)', () => {
     const { wrap, recipientSk } = makeWrap('tamper me');
-    // Flip one base64 char inside the wrap ciphertext → NIP-44 MAC mismatch
-    // → decrypt throws → unwrapWrapNsec skips (returns null). This is the
-    // guarantee that replaced the schnorr verify: integrity is preserved.
-    // Index is relative to the payload length (mid-ciphertext) so it stays
-    // in-bounds if nostr-tools' payload format/size changes.
-    expect(wrap.content.length).toBeGreaterThan(100);
+    // Flip one base64 char mid-payload → NIP-44 MAC mismatch → decrypt throws
+    // → unwrapWrapNsec skips (returns null). This is the guarantee that
+    // replaced the schnorr verify: integrity is preserved. The midpoint is
+    // always in-bounds (a valid NIP-44 payload is ≥132 chars).
     const i = Math.floor(wrap.content.length / 2);
     const swapped = wrap.content[i] === 'A' ? 'B' : 'A';
     const tampered = wrap.content.slice(0, i) + swapped + wrap.content.slice(i + 1);

--- a/src/utils/nip17Unwrap.test.ts
+++ b/src/utils/nip17Unwrap.test.ts
@@ -5,7 +5,15 @@
  * Issue #271.
  */
 
-import { subjectFromRumor, textForRumor, partnerFromRumor, type DecodedRumor } from './nip17Unwrap';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { wrapEvent } from 'nostr-tools/nip59';
+import {
+  subjectFromRumor,
+  textForRumor,
+  partnerFromRumor,
+  unwrapWrapNsec,
+  type DecodedRumor,
+} from './nip17Unwrap';
 
 const PK_A = 'a'.repeat(64);
 const PK_B = 'b'.repeat(64);
@@ -132,5 +140,70 @@ describe('textForRumor (kind-15 → bubble text)', () => {
     expect(
       textForRumor({ pubkey: PK_A, created_at: 0, kind: 14, content: 'hi there', tags: [] }),
     ).toBe('hi there');
+  });
+});
+
+/**
+ * Security characterisation for the #802 change: the gift-wrap schnorr
+ * verify was dropped from the nsec decrypt path. These tests prove the
+ * security model is unchanged — integrity is still enforced by the NIP-44
+ * MAC, and authenticity by the seal ECDH — while the (redundant, expensive)
+ * signature verify no longer gates the hot loop.
+ */
+describe('unwrapWrapNsec (NIP-17 nsec decrypt, post-#802)', () => {
+  // Build a real NIP-17 gift wrap from `sender` to `recipient`.
+  function makeWrap(content: string) {
+    const senderSk = generateSecretKey();
+    const recipientSk = generateSecretKey();
+    const recipientPk = getPublicKey(recipientSk);
+    const senderPk = getPublicKey(senderSk);
+    const wrap = wrapEvent(
+      { kind: 14, content, tags: [['p', recipientPk]] },
+      senderSk,
+      recipientPk,
+    );
+    return { wrap, recipientSk, senderPk };
+  }
+
+  // Cast helper — `wrapEvent` returns a fully-typed VerifiedEvent; the
+  // unwrap function takes the looser RawGiftWrapEvent shape.
+  type WrapArg = Parameters<typeof unwrapWrapNsec>[0];
+
+  it('round-trips a kind-14 rumor (decrypt works without a sig verify)', () => {
+    const { wrap, recipientSk, senderPk } = makeWrap('hello piggy');
+    const rumor = unwrapWrapNsec(wrap as unknown as WrapArg, recipientSk);
+    expect(rumor).not.toBeNull();
+    expect(rumor?.content).toBe('hello piggy');
+    expect(rumor?.kind).toBe(14);
+    // Sender identity comes from the seal ECDH, surfaced as rumor.pubkey.
+    expect(rumor?.pubkey).toBe(senderPk);
+  });
+
+  it('STILL decrypts when the wrap signature is invalid (verify is gone, #802)', () => {
+    const { wrap, recipientSk } = makeWrap('sig should not matter');
+    // Corrupt the ephemeral-key signature. Pre-#802 this returned null
+    // ('wrap signature invalid'); now the sig is never consulted, so the
+    // NIP-44 layers decrypt regardless — that's the whole point.
+    (wrap as unknown as { sig: string }).sig = 'f'.repeat(128);
+    const rumor = unwrapWrapNsec(wrap as unknown as WrapArg, recipientSk);
+    expect(rumor?.content).toBe('sig should not matter');
+  });
+
+  it('still REJECTS a wrap whose ciphertext was tampered (MAC enforces integrity)', () => {
+    const { wrap, recipientSk } = makeWrap('tamper me');
+    // Flip one base64 char inside the wrap ciphertext → NIP-44 MAC mismatch
+    // → decrypt throws → unwrapWrapNsec skips (returns null). This is the
+    // guarantee that replaced the schnorr verify: integrity is preserved.
+    const i = 60;
+    const swapped = wrap.content[i] === 'A' ? 'B' : 'A';
+    const tampered = wrap.content.slice(0, i) + swapped + wrap.content.slice(i + 1);
+    const onSkip = jest.fn();
+    const rumor = unwrapWrapNsec(
+      { ...wrap, content: tampered } as unknown as WrapArg,
+      recipientSk,
+      onSkip,
+    );
+    expect(rumor).toBeNull();
+    expect(onSkip).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/nip17Unwrap.ts
+++ b/src/utils/nip17Unwrap.ts
@@ -1,5 +1,4 @@
-import * as nip59 from 'nostr-tools/nip59';
-import type { NostrEvent } from 'nostr-tools/pure';
+import * as nip44 from 'nostr-tools/nip44';
 import type { RawGiftWrapEvent } from '../services/nostrService';
 import { encodeEncryptedFileUrl } from './encryptedFileUrl';
 
@@ -84,8 +83,8 @@ function parseRumor(raw: string): DecodedRumor | null {
  * A NIP-59 gift wrap (kind 1059) is signed by a **throwaway ephemeral
  * key** the sender generates per-wrap — so the signature authenticates
  * *nothing* about who sent the message: anyone can mint a valid ephemeral
- * key and sign a wrap. nostr-tools' `nip59.unwrapEvent` doesn't even
- * consult the signature; it just performs the two NIP-44 decrypts.
+ * key and sign a wrap. The signature plays no part in NIP-17 security; the
+ * two NIP-44 decrypts carry all of it.
  *
  * What the schnorr verify provided is supplied (better) by those decrypts:
  *   - **Integrity** ("not mutated in transit") — each NIP-44 layer carries
@@ -95,13 +94,11 @@ function parseRumor(raw: string): DecodedRumor | null {
  *     ECDH(viewerPriv, sealPubkey) = ECDH(senderPriv, viewerPub); only the
  *     holder of `sealPubkey`'s secret can produce a seal that decrypts, so
  *     a successful decrypt authenticates the *seal sender key*.
- *
- * NOTE — *full* sender binding (the inner `rumor.pubkey` actually equals the
- * authenticated `seal.pubkey`) is a *separate* check, enforced only in
- * `unwrapWrapViaNip44` (Amber path) below. The nsec path here delegates to
- * nostr-tools' `unwrapEvent`, which does not expose the seal and does not
- * bind the two — a pre-existing gap tracked in #830, orthogonal to this
- * change (the ephemeral wrap-sig verify never bound them either).
+ *   - **Sender binding** — both unwrap paths then assert `rumor.pubkey ===
+ *     seal.pubkey` (the shared `bindRumor` helper), so the message's claimed
+ *     sender is exactly the key the seal ECDH just authenticated. Without it,
+ *     a valid peer could embed a rumor attributing the message to a *different*
+ *     pubkey (sender spoofing — gap #830, now closed on both paths).
  *
  * The wrap-sig `verifyEvent` was therefore pure defense-in-depth — and an
  * expensive one: a full schnorr verify (~25 ms/wrap) that dominated
@@ -112,6 +109,39 @@ function parseRumor(raw: string): DecodedRumor | null {
  */
 
 type Nip44Decrypt = (ciphertext: string, counterpartyPubkey: string) => Promise<string>;
+
+/** A `skip` closure: logs the reason via the caller's `onSkip` and returns null. */
+type Skip = (reason: string) => null;
+
+/**
+ * Parse a decrypted layer-1 payload and assert it's a kind-13 seal. Shared by
+ * both unwrap paths so they validate the seal identically.
+ */
+function parseValidSeal(sealJson: string, skip: Skip) {
+  const seal = parseSeal(sealJson);
+  if (!seal) return skip('seal JSON malformed or wrong shape');
+  if (seal.kind !== 13) return skip(`seal kind is ${seal.kind}, expected 13`);
+  return seal;
+}
+
+/**
+ * Parse a decrypted layer-2 payload into a rumor and enforce the NIP-17
+ * requirement that the rumor's claimed `pubkey` equals `sealPubkey` — i.e.
+ * the message's stated sender is exactly the key the seal ECDH authenticated.
+ * Without this bind a valid peer could embed a rumor attributing the message
+ * to a *different* pubkey (sender spoofing). Both unwrap paths call this one
+ * implementation so they can't drift — the divergence that was gap #830.
+ */
+function bindRumor(rumorJson: string, sealPubkey: string, skip: Skip): DecodedRumor | null {
+  const rumor = parseRumor(rumorJson);
+  if (!rumor) return skip('rumor JSON malformed or wrong shape');
+  if (rumor.pubkey !== sealPubkey) {
+    return skip(
+      `rumor pubkey ${rumor.pubkey.slice(0, 8)}… != seal pubkey ${sealPubkey.slice(0, 8)}…`,
+    );
+  }
+  return rumor;
+}
 
 /**
  * Two-layer NIP-17 unwrap: wrap → seal → rumor. Takes a `decryptNip44`
@@ -127,23 +157,22 @@ export async function unwrapWrapViaNip44(
   decryptNip44: Nip44Decrypt,
   onSkip?: (reason: string, wrapId: string) => void,
 ): Promise<DecodedRumor | null> {
-  const skip = (reason: string): null => {
+  const skip: Skip = (reason) => {
     onSkip?.(reason, wrap.id);
     return null;
   };
 
-  // No wrap-sig verify — see the note above `Nip44Decrypt`. The MAC on the
-  // decrypt below rejects a tampered wrap; authenticity comes from the seal
-  // ECDH + the `rumor.pubkey === seal.pubkey` check.
+  // No wrap-sig verify — see the note above `Nip44Decrypt`. The MAC on each
+  // decrypt rejects a tampered wrap; authenticity comes from the seal ECDH
+  // plus the `bindRumor` `rumor.pubkey === seal.pubkey` check.
   let sealJson: string;
   try {
     sealJson = await decryptNip44(wrap.content, wrap.pubkey);
   } catch (error) {
     return skip(`wrap decrypt failed: ${(error as Error)?.message ?? 'unknown'}`);
   }
-  const seal = parseSeal(sealJson);
-  if (!seal) return skip('seal JSON malformed or wrong shape');
-  if (seal.kind !== 13) return skip(`seal kind is ${seal.kind}, expected 13`);
+  const seal = parseValidSeal(sealJson, skip);
+  if (!seal) return null;
 
   let rumorJson: string;
   try {
@@ -151,60 +180,57 @@ export async function unwrapWrapViaNip44(
   } catch (error) {
     return skip(`seal decrypt failed: ${(error as Error)?.message ?? 'unknown'}`);
   }
-  const rumor = parseRumor(rumorJson);
-  if (!rumor) return skip('rumor JSON malformed or wrong shape');
-
-  // NIP-17 spec requirement: rumor.pubkey MUST equal seal.pubkey. Bail on
-  // any mismatch — a tampered rumor is indistinguishable from someone
-  // spoofing a sender identity.
-  if (rumor.pubkey !== seal.pubkey) {
-    return skip(
-      `rumor pubkey ${rumor.pubkey.slice(0, 8)}… != seal pubkey ${seal.pubkey.slice(0, 8)}…`,
-    );
-  }
-
-  return rumor;
+  return bindRumor(rumorJson, seal.pubkey, skip);
 }
 
 /**
- * Convenience wrapper for the nsec path: invokes nostr-tools' nip59
- * unwrapEvent directly. We deliberately do NOT schnorr-verify the wrap
- * signature first — see the note above `Nip44Decrypt` for why that verify
- * was redundant: the ephemeral wrap key authenticates nothing, the NIP-44
- * MAC enforces integrity, and the seal ECDH authenticates the seal sender
- * key. Dropping it is the #802 cold-start freeze fix. `nip59.unwrapEvent`
- * throws on a malformed or tampered payload (MAC failure), which we catch
- * and skip below. (Unlike `unwrapWrapViaNip44`, this path does NOT bind
- * `rumor.pubkey` to `seal.pubkey` — pre-existing gap #830, unaffected here.)
+ * nsec path: the two NIP-44 decrypts run synchronously in-process via
+ * nostr-tools' `nip44`. We do this manually (rather than nostr-tools'
+ * `nip59.unwrapEvent`) so the seal is exposed and `bindRumor` can enforce
+ * `rumor.pubkey === seal.pubkey` — the same sender-binding the Amber path
+ * does. Routing through `unwrapEvent` (which hides the seal and skips that
+ * bind) was gap #830; this is its fix.
+ *
+ * No wrap-sig verify first — see the note above `Nip44Decrypt`: the ephemeral
+ * wrap key authenticates nothing, the NIP-44 MAC enforces integrity, and the
+ * seal ECDH authenticates the seal sender key. Dropping it is the #802
+ * cold-start freeze fix. `nip44.v2.decrypt` throws on a malformed or tampered
+ * payload (MAC failure), which we catch and skip.
+ *
+ * Stays synchronous: all three callers (`useDmInbox`, `nostrLiveDmSub`,
+ * `nostrFetchConversation`) invoke it inside tight, pacing-yielded loops and
+ * do not await it.
  */
 export function unwrapWrapNsec(
   wrap: RawGiftWrapEvent,
   secretKey: Uint8Array,
   onSkip?: (reason: string, wrapId: string) => void,
 ): DecodedRumor | null {
-  try {
-    const rumor = nip59.unwrapEvent(wrap as unknown as NostrEvent, secretKey);
-    const r: unknown = rumor;
-    if (!r || typeof r !== 'object') {
-      onSkip?.('rumor not an object', wrap.id);
-      return null;
-    }
-    const casted = r as DecodedRumor;
-    if (typeof casted.pubkey !== 'string' || !HEX64.test(casted.pubkey.toLowerCase())) {
-      onSkip?.('rumor pubkey malformed', wrap.id);
-      return null;
-    }
-    return {
-      pubkey: casted.pubkey.toLowerCase(),
-      created_at: casted.created_at,
-      kind: casted.kind,
-      content: casted.content,
-      tags: casted.tags,
-    };
-  } catch (error) {
-    onSkip?.(`nsec unwrap failed: ${(error as Error)?.message ?? 'unknown'}`, wrap.id);
+  const skip: Skip = (reason) => {
+    onSkip?.(reason, wrap.id);
     return null;
+  };
+
+  // Layer 1: wrap.content → seal, keyed by the ephemeral wrap pubkey.
+  let sealJson: string;
+  try {
+    const wrapKey = nip44.v2.utils.getConversationKey(secretKey, wrap.pubkey);
+    sealJson = nip44.v2.decrypt(wrap.content, wrapKey);
+  } catch (error) {
+    return skip(`wrap decrypt failed: ${(error as Error)?.message ?? 'unknown'}`);
   }
+  const seal = parseValidSeal(sealJson, skip);
+  if (!seal) return null;
+
+  // Layer 2: seal.content → rumor, keyed by the seal (sender) pubkey.
+  let rumorJson: string;
+  try {
+    const sealKey = nip44.v2.utils.getConversationKey(secretKey, seal.pubkey);
+    rumorJson = nip44.v2.decrypt(seal.content, sealKey);
+  } catch (error) {
+    return skip(`seal decrypt failed: ${(error as Error)?.message ?? 'unknown'}`);
+  }
+  return bindRumor(rumorJson, seal.pubkey, skip);
 }
 
 /**

--- a/src/utils/nip17Unwrap.ts
+++ b/src/utils/nip17Unwrap.ts
@@ -87,16 +87,21 @@ function parseRumor(raw: string): DecodedRumor | null {
  * key and sign a wrap. nostr-tools' `nip59.unwrapEvent` doesn't even
  * consult the signature; it just performs the two NIP-44 decrypts.
  *
- * Integrity and authenticity are both supplied by those decrypts, not by
- * the schnorr verify:
+ * What the schnorr verify provided is supplied (better) by those decrypts:
  *   - **Integrity** ("not mutated in transit") — each NIP-44 layer carries
  *     an HMAC-SHA256 over the ciphertext; a tampered wrap fails the MAC
  *     and the decrypt throws (we skip it).
- *   - **Authenticity** — the seal layer's conversation key is
+ *   - **Seal-key authentication** — the seal layer's conversation key is
  *     ECDH(viewerPriv, sealPubkey) = ECDH(senderPriv, viewerPub); only the
- *     real sender's secret key can produce a seal that decrypts. The
- *     `rumor.pubkey === seal.pubkey` check (below, Amber path) binds the
- *     claimed sender to that ECDH-authenticated key.
+ *     holder of `sealPubkey`'s secret can produce a seal that decrypts, so
+ *     a successful decrypt authenticates the *seal sender key*.
+ *
+ * NOTE — *full* sender binding (the inner `rumor.pubkey` actually equals the
+ * authenticated `seal.pubkey`) is a *separate* check, enforced only in
+ * `unwrapWrapViaNip44` (Amber path) below. The nsec path here delegates to
+ * nostr-tools' `unwrapEvent`, which does not expose the seal and does not
+ * bind the two — a pre-existing gap tracked in #830, orthogonal to this
+ * change (the ephemeral wrap-sig verify never bound them either).
  *
  * The wrap-sig `verifyEvent` was therefore pure defense-in-depth — and an
  * expensive one: a full schnorr verify (~25 ms/wrap) that dominated
@@ -165,10 +170,12 @@ export async function unwrapWrapViaNip44(
  * Convenience wrapper for the nsec path: invokes nostr-tools' nip59
  * unwrapEvent directly. We deliberately do NOT schnorr-verify the wrap
  * signature first — see the note above `Nip44Decrypt` for why that verify
- * was redundant (the ephemeral wrap key authenticates nothing; the NIP-44
- * MAC + seal ECDH carry the real integrity/authenticity). Dropping it is
- * the #802 cold-start freeze fix. `nip59.unwrapEvent` throws on a malformed
- * or tampered payload (MAC failure), which we catch and skip below.
+ * was redundant: the ephemeral wrap key authenticates nothing, the NIP-44
+ * MAC enforces integrity, and the seal ECDH authenticates the seal sender
+ * key. Dropping it is the #802 cold-start freeze fix. `nip59.unwrapEvent`
+ * throws on a malformed or tampered payload (MAC failure), which we catch
+ * and skip below. (Unlike `unwrapWrapViaNip44`, this path does NOT bind
+ * `rumor.pubkey` to `seal.pubkey` — pre-existing gap #830, unaffected here.)
  */
 export function unwrapWrapNsec(
   wrap: RawGiftWrapEvent,

--- a/src/utils/nip17Unwrap.ts
+++ b/src/utils/nip17Unwrap.ts
@@ -1,5 +1,5 @@
 import * as nip59 from 'nostr-tools/nip59';
-import { verifyEvent, type NostrEvent } from 'nostr-tools/pure';
+import type { NostrEvent } from 'nostr-tools/pure';
 import type { RawGiftWrapEvent } from '../services/nostrService';
 import { encodeEncryptedFileUrl } from './encryptedFileUrl';
 
@@ -79,18 +79,32 @@ function parseRumor(raw: string): DecodedRumor | null {
 }
 
 /**
- * Asserts the wrap event's signature before we trust its `pubkey` /
- * `content`. The wrap is signed by a random ephemeral key per the spec —
- * we don't care who the ephemeral key belongs to, only that the payload
- * wasn't mutated in transit. Returns true on valid sig.
+ * Why we do NOT schnorr-verify the gift-wrap signature
+ * ----------------------------------------------------
+ * A NIP-59 gift wrap (kind 1059) is signed by a **throwaway ephemeral
+ * key** the sender generates per-wrap — so the signature authenticates
+ * *nothing* about who sent the message: anyone can mint a valid ephemeral
+ * key and sign a wrap. nostr-tools' `nip59.unwrapEvent` doesn't even
+ * consult the signature; it just performs the two NIP-44 decrypts.
+ *
+ * Integrity and authenticity are both supplied by those decrypts, not by
+ * the schnorr verify:
+ *   - **Integrity** ("not mutated in transit") — each NIP-44 layer carries
+ *     an HMAC-SHA256 over the ciphertext; a tampered wrap fails the MAC
+ *     and the decrypt throws (we skip it).
+ *   - **Authenticity** — the seal layer's conversation key is
+ *     ECDH(viewerPriv, sealPubkey) = ECDH(senderPriv, viewerPub); only the
+ *     real sender's secret key can produce a seal that decrypts. The
+ *     `rumor.pubkey === seal.pubkey` check (below, Amber path) binds the
+ *     claimed sender to that ECDH-authenticated key.
+ *
+ * The wrap-sig `verifyEvent` was therefore pure defense-in-depth — and an
+ * expensive one: a full schnorr verify (~25 ms/wrap) that dominated
+ * cold-start inbox drain and froze the JS thread on a large backlog
+ * (#802). Every failure mode it caught (mutated content / pubkey / id) is
+ * *also* caught one step later by the cheaper MAC check, so dropping it
+ * removes the freeze without weakening the security model.
  */
-export function verifyWrapSig(wrap: RawGiftWrapEvent): boolean {
-  try {
-    return verifyEvent(wrap as unknown as NostrEvent);
-  } catch {
-    return false;
-  }
-}
 
 type Nip44Decrypt = (ciphertext: string, counterpartyPubkey: string) => Promise<string>;
 
@@ -113,8 +127,9 @@ export async function unwrapWrapViaNip44(
     return null;
   };
 
-  if (!verifyWrapSig(wrap)) return skip('wrap signature invalid');
-
+  // No wrap-sig verify — see the note above `Nip44Decrypt`. The MAC on the
+  // decrypt below rejects a tampered wrap; authenticity comes from the seal
+  // ECDH + the `rumor.pubkey === seal.pubkey` check.
   let sealJson: string;
   try {
     sealJson = await decryptNip44(wrap.content, wrap.pubkey);
@@ -148,19 +163,18 @@ export async function unwrapWrapViaNip44(
 
 /**
  * Convenience wrapper for the nsec path: invokes nostr-tools' nip59
- * unwrapEvent directly. Still runs verifyWrapSig for parity with the
- * Amber path (nostr-tools' unwrap will throw if the payload is malformed
- * but doesn't re-verify the sig — that's the caller's job per NIP-01).
+ * unwrapEvent directly. We deliberately do NOT schnorr-verify the wrap
+ * signature first — see the note above `Nip44Decrypt` for why that verify
+ * was redundant (the ephemeral wrap key authenticates nothing; the NIP-44
+ * MAC + seal ECDH carry the real integrity/authenticity). Dropping it is
+ * the #802 cold-start freeze fix. `nip59.unwrapEvent` throws on a malformed
+ * or tampered payload (MAC failure), which we catch and skip below.
  */
 export function unwrapWrapNsec(
   wrap: RawGiftWrapEvent,
   secretKey: Uint8Array,
   onSkip?: (reason: string, wrapId: string) => void,
 ): DecodedRumor | null {
-  if (!verifyWrapSig(wrap)) {
-    onSkip?.('wrap signature invalid', wrap.id);
-    return null;
-  }
   try {
     const rumor = nip59.unwrapEvent(wrap as unknown as NostrEvent, secretKey);
     const r: unknown = rumor;


### PR DESCRIPTION
## What

Hardens **and** speeds up the NIP-17 **nsec** DM decrypt path:

1. **#829 (perf)** — removes the per-wrap schnorr `verifyEvent` (~25 ms/wrap), the dominant cost that froze the JS thread draining a cold-start inbox backlog (the on-thread half of #802; likely also #828's stuck popup).
2. **#830 (security)** — the nsec path went through nostr-tools' `nip59.unwrapEvent`, which hides the seal and never checks `rumor.pubkey === seal.pubkey`, so a valid peer could embed a rumor attributing the message to a **different** pubkey (DM sender-spoofing). The Amber path already enforced this; the nsec path had diverged. Now both bind via a shared `bindRumor` helper.

These ship together because the #830 fix **requires** the #829 refactor: to enforce the bind we rewrote `unwrapWrapNsec` to do the two NIP-44 decrypts manually (exposing the seal) instead of `unwrapEvent`. Same function, one cohesive change.

## Why dropping the verify is safe

A NIP-59 gift wrap is signed by a **throwaway ephemeral key** that authenticates nothing about the sender (anyone can mint one); `nip59.unwrapEvent` doesn't even consult it. The two NIP-44 decrypts carry all the security:

- **Integrity** — each layer's HMAC-SHA256 rejects a tampered wrap (decrypt throws → skip).
- **Seal-key authentication** — the seal conversation key is `ECDH(viewerPriv, sealPubkey)`; only the real sender's key produces a seal that decrypts.
- **Sender binding** (#830) — `bindRumor` asserts `rumor.pubkey === seal.pubkey` on **both** paths, so the claimed sender is exactly the ECDH-authenticated key.

Every failure mode the schnorr verify caught is also caught one step later by the cheaper MAC.

## Changes

- `src/utils/nip17Unwrap.ts` — drop `verifyWrapSig` + the `nip59`/`NostrEvent`/`verifyEvent` imports; rewrite `unwrapWrapNsec` to manual synchronous two-layer `nip44` decrypt; extract shared `parseValidSeal` + `bindRumor` helpers used by both unwrap paths so they can't drift again.
- `src/contexts/useDmInbox.ts` — refresh stale "~25 ms schnorr" comments.
- `src/utils/nip17Unwrap.test.ts` — 4 characterisation tests (see below).

## Test plan

- [x] `npx jest src/utils/nip17Unwrap.test.ts` — green. Tests: real wrap **round-trips** (manual decrypt matches nostr-tools); an **invalid signature** now decrypts (verify gone, #829); a **tampered ciphertext** is rejected by the MAC; a **rumor.pubkey ≠ seal.pubkey** wrap is rejected (spoofing blocked, #830).
- [x] Full suite: **1043 passed**.
- [x] `npx tsc --noEmit` + eslint + prettier clean.
- [x] On-device: cold-start inbox drain measured (Stevie, emulator-5554 dev client, 225-wrap forced backlog, n=3/side): median **28,263 ms (main) → 26,113 ms (PR)**, −2.2 s / −7.6% — right direction, though within relay-variance noise at n=3; per-run numbers + methodology in [Stevie's measurements](https://github.com/BenGWeeks/lightning-piggy-mobile/pull/831#issuecomment-4684021880). Bundle verified serving the PR (6× bindRumor, 0× verifyWrapSig).

Closes #829
Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)