### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,5 +14,4 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### Fixed
 
-- **Zap (⚡) buttons work again.** On the Friends list the zap button now appears for any contact who has a Lightning address and sends sats when tapped. On a contact's profile the zap button is **always shown** — and if you can't zap yet (no wallet connected, or that person hasn't published a Lightning address) tapping it now tells you **why** instead of doing nothing.
 - **Fixed-amount payment codes no longer ask for an amount.** Scanning or pasting an LNURL pay code whose minimum and maximum are the same (a fixed price) now fills the amount in automatically and shows it read-only — just tap Send.

--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -15,3 +15,4 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 ### Fixed
 
 - **Zap (⚡) buttons work again.** On the Friends list the zap button now appears for any contact who has a Lightning address and sends sats when tapped. On a contact's profile the zap button is **always shown** — and if you can't zap yet (no wallet connected, or that person hasn't published a Lightning address) tapping it now tells you **why** instead of doing nothing.
+- **Fixed-amount payment codes no longer ask for an amount.** Scanning or pasting an LNURL pay code whose minimum and maximum are the same (a fixed price) now fills the amount in automatically and shows it read-only — just tap Send.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Summary

Release prep for v1.3.2:
- bump `package.json` to 1.3.2 (`npm version patch`)
- TestFlight "What to Test" notes: add the fixed-amount LNURL bullet (#833), and drop the stale zap bullet that shipped with v1.2.1 — it survived three releases because the whats-new job's reset step was failing on `eas build:list` (#791, fixed by #792)

After merge: publish GitHub Release `v1.3.2` targeting `main` — the Release workflow cloud-builds both platforms, auto-submits iOS to TestFlight, and attaches the Android APK.

## Test plan

- CI gates (typecheck / lint / format / coverage) on this PR
- Release workflow run after publishing the v1.3.2 Release