### PR TITLE
ci(release): npm ci in sync-title job so eas build:list resolves (#791)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,13 +183,16 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         id: iosbuild
         run: |
-          # Pick the iOS build EAS just produced for this commit. buildVersion
-          # is the CFBundleVersion (the integer in parens that TestFlight shows
-          # next to the X.Y.Z marketing version).
+          # Pick the iOS build EAS just produced for this commit. The build
+          # number (CFBundleVersion — the integer in parens TestFlight shows
+          # next to the X.Y.Z marketing version) is `appBuildVersion` in
+          # eas-cli >= 18 JSON output; `.buildVersion` is kept as a fallback
+          # for older CLIs. Reading the wrong field made this step report
+          # "no build found" on every release even when the build existed.
           version=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
             --platform ios --status finished --limit 5 --json --non-interactive \
             | jq -r --arg sha "${{ github.sha }}" \
-                '[.[] | select(.gitCommitHash == $sha)][0].buildVersion // empty')
+                '[.[] | select(.gitCommitHash == $sha)][0] | (.appBuildVersion // .buildVersion) // empty')
           if [ -z "$version" ] || [ "$version" = "null" ]; then
             echo "::warning title=No iOS build resolved::Could not find a finished iOS build for commit ${{ github.sha }}. Skipping whatsNew."
             echo "version=" >> "$GITHUB_OUTPUT"
@@ -431,11 +434,11 @@ jobs:
           ios_build=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
             --platform ios --status finished --limit 5 --json --non-interactive \
             | jq -r --arg sha "${{ github.sha }}" \
-                '[.[] | select(.gitCommitHash == $sha)][0].buildVersion // empty')
+                '[.[] | select(.gitCommitHash == $sha)][0] | (.appBuildVersion // .buildVersion) // empty')
           android_build=$(npx -y -p eas-cli@${{ env.EAS_CLI_VERSION }} eas build:list \
             --platform android --status finished --limit 5 --json --non-interactive \
             | jq -r --arg sha "${{ github.sha }}" \
-                '[.[] | select(.gitCommitHash == $sha)][0].buildVersion // empty')
+                '[.[] | select(.gitCommitHash == $sha)][0] | (.appBuildVersion // .buildVersion) // empty')
 
           # Derive the original title from the release event payload.
           # Fall back to the tag name if no title was set.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.13.0'
+          cache: npm
+
+      # `eas build:list` resolves the EAS project by evaluating app.config.ts,
+      # which can't load without node_modules — same failure class as #791.
+      # This job was missed by #792 (it only fixed whats-new + attach) and
+      # broke the v1.3.2 title sync.
+      - name: Install dependencies
+        run: npm ci
 
       - name: Resolve build numbers + edit Release title
         run: |


### PR DESCRIPTION
## Summary

Two stacked defects kept the release workflow's EAS-dependent jobs broken even after #792:

1. **`npm ci` missing in the sync-title job** — `eas build:list` evaluates `app.config.ts`, which can't load without `node_modules` (#791's failure class; #792 fixed the whats-new and attach jobs but missed this fourth one). The v1.3.2 run failed here with `jq: parse error` + `build:list command failed`.
2. **All three `build:list` consumers read `.buildVersion`, a field eas-cli ≥ 18 no longer emits** (it's `appBuildVersion` now). The whats-new job therefore reported "Could not find a finished iOS build" on every release — even when the build existed and the commit hash matched — so TestFlight "What to Test" was never set and `RELEASE_NOTES_NEXT.md` never reset (stale v1.2.1 bullet shipped in three releases' notes). Verified against live output: `.appBuildVersion // .buildVersion` resolves build 28 for the v1.3.2 commit where the old expression returned empty.

The v1.3.2 release was patched by hand (title `v1.3.2 (iOS build 28 / Android build 75)`; "What to Test" needs a one-time manual paste in ASC). This PR fixes both for future releases.

## Test plan

- CI on this PR (YAML well-formedness via workflow parse)
- Reproduced both failures and verified the fixed jq against real `eas build:list --json` output for the v1.3.2 builds