### PR TITLE
chore(release): v1.3.3

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -12,6 +12,6 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ## What to test in the next release
 
-### Fixed
+### New
 
-- **Fixed-amount payment codes no longer ask for an amount.** Scanning or pasting an LNURL pay code whose minimum and maximum are the same (a fixed price) now fills the amount in automatically and shows it read-only — just tap Send.
+- **Pay by NFC from the Send sheet.** Send now has three modes — QR scan, paste, and NFC — switched with icon toggles. Pick the NFC waves, hold your phone against a Lightning payment tag (invoice, Lightning address or LNURL), and the payment details fill in just like scanning a QR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Summary

Release prep for v1.3.3:

- **Fix the release notes**: `docs/RELEASE_NOTES_NEXT.md` still contained the fixed-amount-LNURL bullet that already shipped in v1.3.2 (the auto-reset never ran — the whats-new job was broken until #837). Replaced with the v1.3.3 content: the new NFC send mode (#838 / #839).
- Bump `package.json` to 1.3.3 (`npm version patch`; the local tag is deliberately NOT pushed — the GitHub Release creates it server-side at the merged main commit, avoiding the v1.3.2 follow-tags mishap where the tag pointed at the pre-squash branch commit).

Merge order: after #838 (the NFC feature this release ships) and #837 (so the release run publishes "What to Test" automatically).

## Test plan

- CI gates on this PR
- v1.3.3 Release run: verify "What to Test" auto-publishes and this file auto-resets (first release with #837 in)