### PR TITLE
chore(send): stop NFC ring spinning when the reader can't arm

### DIFF
--- a/src/components/SendNfcPane.tsx
+++ b/src/components/SendNfcPane.tsx
@@ -109,7 +109,7 @@ const SendNfcPane: React.FC<Props> = ({ active, onContent }) => {
       {/* Spin from first paint (checking) through armed; stop only in the
           dead states (unsupported / error) where no scan can happen. */}
       <NfcScanIndicator
-        spinning={status === 'armed' || status === 'checking'}
+        spinning={status !== 'unsupported' && status !== 'error'}
         testID="send-nfc-indicator"
       />
       {status === 'unsupported' ? (

--- a/src/components/SendNfcPane.tsx
+++ b/src/components/SendNfcPane.tsx
@@ -106,7 +106,12 @@ const SendNfcPane: React.FC<Props> = ({ active, onContent }) => {
 
   return (
     <View style={styles.container} testID="send-nfc-pane">
-      <NfcScanIndicator spinning={true} testID="send-nfc-indicator" />
+      {/* Spin from first paint (checking) through armed; stop only in the
+          dead states (unsupported / error) where no scan can happen. */}
+      <NfcScanIndicator
+        spinning={status === 'armed' || status === 'checking'}
+        testID="send-nfc-indicator"
+      />
       {status === 'unsupported' ? (
         <Text style={styles.description}>NFC isn't available on this device.</Text>
       ) : status === 'error' ? (


### PR DESCRIPTION
## Summary

Follow-up to a post-merge Copilot suggestion on #838: the Send sheet's NFC scan ring was animating unconditionally, including the two dead states — NFC unsupported on the device, and error (e.g. NFC turned off) — implying an active scan that can't happen. The ring now spins from first paint (`checking`) through `armed`, and stops only in `unsupported` / `error`.

## Why no screenshot

One-line conditional on an animation's running state — the rendered layout is identical to the screenshots already on #838; only whether the ring rotates in the unsupported/error states changes, which a still image can't show.

## Test plan

- `npx tsc --noEmit`, ESLint, Prettier — clean
- Emulator (no NFC hardware): NFC mode shows the static ring with "NFC isn't available on this device"