### PR TITLE
perf(dm): stop cold-start backfill bypassing DM decrypt caches (#846)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/benw/GitHub/lightning-piggy-mobile/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/benw/GitHub/lightning-piggy-mobile/node_modules

--- a/src/contexts/dmColdStartBackfill.test.ts
+++ b/src/contexts/dmColdStartBackfill.test.ts
@@ -1,0 +1,66 @@
+import { InteractionManager } from 'react-native';
+import { scheduleColdStartBackfill } from './dmColdStartBackfill';
+import type { RefreshDmInboxOptions } from './nostrContextTypes';
+
+describe('scheduleColdStartBackfill', () => {
+  let runAfterInteractionsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Run the deferred callback synchronously so assertions see the call.
+    runAfterInteractionsSpy = jest
+      .spyOn(InteractionManager, 'runAfterInteractions')
+      .mockImplementation((task) => {
+        if (typeof task === 'function') task();
+        return {
+          then: () => Promise.resolve(),
+          done: () => undefined,
+          cancel: () => undefined,
+        };
+      });
+  });
+
+  afterEach(() => {
+    runAfterInteractionsSpy.mockRestore();
+  });
+
+  const makeRefreshRef = () => {
+    const refresh = jest.fn<Promise<void>, [RefreshDmInboxOptions?]>(() => Promise.resolve());
+    return { refresh, ref: { current: refresh } };
+  };
+
+  it('re-invokes the refresh as a backfill, NOT a force — force inherited the #743 skip-set bypass and caused the every-cold-start decrypt sweep (#846)', () => {
+    const { refresh, ref } = makeRefreshRef();
+    scheduleColdStartBackfill({ isColdStart: true, includeNonFollows: false, refreshRef: ref });
+    expect(refresh).toHaveBeenCalledTimes(1);
+    const opts = refresh.mock.calls[0][0]!;
+    expect(opts.backfill).toBe(true);
+    expect(opts.force).toBeUndefined();
+    expect(opts.includeNonFollows).toBe(false);
+  });
+
+  it('threads includeNonFollows through so the dev "Following only=off" pass keeps its semantics', () => {
+    const { refresh, ref } = makeRefreshRef();
+    scheduleColdStartBackfill({ isColdStart: true, includeNonFollows: true, refreshRef: ref });
+    const opts = refresh.mock.calls[0][0]!;
+    expect(opts.includeNonFollows).toBe(true);
+  });
+
+  it('does nothing when the triggering refresh was not a cold start (no recursion)', () => {
+    const { refresh, ref } = makeRefreshRef();
+    scheduleColdStartBackfill({ isColdStart: false, includeNonFollows: false, refreshRef: ref });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the signal already aborted (tab blur before scheduling)', () => {
+    const { refresh, ref } = makeRefreshRef();
+    const ctrl = new AbortController();
+    ctrl.abort();
+    scheduleColdStartBackfill({
+      isColdStart: true,
+      signal: ctrl.signal,
+      includeNonFollows: false,
+      refreshRef: ref,
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/dmColdStartBackfill.ts
+++ b/src/contexts/dmColdStartBackfill.ts
@@ -13,9 +13,14 @@ import type { RefreshDmInboxOptions } from './nostrContextTypes';
  *  - deferred via `runAfterInteractions` so it never blocks the tab transition;
  *  - carrying the original `signal`, so a tab-blur cancels it (the in-flight
  *    relay subscription closes via querySyncAbortable);
- *  - with `force: true`, which fetches the full limit, skips the `since` floor
- *    (NIP-59 wrap timestamps are randomised), and — crucially — marks this pass
- *    a non-cold-start, so it can never recurse.
+ *  - with `backfill: true`, which bypasses only the freshness TTL (the capped
+ *    first pass just stamped the cursor) and fetches the full wrap limit, but
+ *    RESPECTS the #743 skip-set and the kind-4 `since` floor. It used to run
+ *    as `force: true`, inheriting pull-to-refresh's cache bypasses — which
+ *    re-decrypted the whole skip-set (~510 wraps) plus the full kind-4 backlog
+ *    (~212 events; the NIP-04 plaintext cache is memory-only) on EVERY cold
+ *    start: the 28-30 s circuit-1 freeze (#846). The first pass stamping the
+ *    cursor is also what marks this pass non-cold, so it can never recurse.
  *
  * `refreshRef` (rather than the callback directly) keeps the caller from having
  * to list refreshDmInbox as its own dependency.
@@ -35,7 +40,7 @@ export function scheduleColdStartBackfill(args: {
     // here avoids the wasted refreshDmInbox setup entirely.
     if (args.signal?.aborted) return;
     void args.refreshRef.current?.({
-      force: true,
+      backfill: true,
       includeNonFollows: args.includeNonFollows,
       signal: args.signal,
     });

--- a/src/contexts/dmColdStartBackfill.ts
+++ b/src/contexts/dmColdStartBackfill.ts
@@ -15,7 +15,9 @@ import type { RefreshDmInboxOptions } from './nostrContextTypes';
  *    relay subscription closes via querySyncAbortable);
  *  - with `backfill: true`, which bypasses only the freshness TTL (the capped
  *    first pass just stamped the cursor) and fetches the full wrap limit, but
- *    RESPECTS the #743 skip-set and the kind-4 `since` floor. It used to run
+ *    does not itself bypass the #743 skip-set (when the dev follow gate is
+ *    off, `includeNonFollows` still bypasses it — by design, so non-followed
+ *    wraps aren't hidden) and RESPECTS the kind-4 `since` floor. It used to run
  *    as `force: true`, inheriting pull-to-refresh's cache bypasses — which
  *    re-decrypted the whole skip-set (~510 wraps) plus the full kind-4 backlog
  *    (~212 events; the NIP-04 plaintext cache is memory-only) on EVERY cold

--- a/src/contexts/dmRefreshGate.test.ts
+++ b/src/contexts/dmRefreshGate.test.ts
@@ -1,4 +1,11 @@
-import { isColdStartRefresh, shouldSkipForFreshness, shouldStampCursor } from './dmRefreshGate';
+import {
+  isColdStartRefresh,
+  shouldSkipForFreshness,
+  shouldStampCursor,
+  bypassesFreshnessTtl,
+  shouldBypassSkipSet,
+  shouldDropK4Since,
+} from './dmRefreshGate';
 import { DM_INBOX_REFRESH_TTL_MS } from './nostrDmCache';
 
 describe('dmRefreshGate', () => {
@@ -44,6 +51,60 @@ describe('dmRefreshGate', () => {
       const last = 10_000;
       const now = last + DM_INBOX_REFRESH_TTL_MS + 1;
       expect(shouldSkipForFreshness(last, false, now)).toBe(false);
+    });
+  });
+
+  describe('bypassesFreshnessTtl', () => {
+    it('bypasses for a user force (pull-to-refresh)', () => {
+      expect(bypassesFreshnessTtl({ force: true })).toBe(true);
+    });
+
+    it('bypasses for the cold-start backfill — it fires right after the first pass stamps the cursor', () => {
+      expect(bypassesFreshnessTtl({ backfill: true })).toBe(true);
+    });
+
+    it('does not bypass a default focus refresh', () => {
+      expect(bypassesFreshnessTtl(undefined)).toBe(false);
+      expect(bypassesFreshnessTtl({})).toBe(false);
+      expect(bypassesFreshnessTtl({ includeNonFollows: true })).toBe(false);
+    });
+  });
+
+  describe('shouldBypassSkipSet (regression for #846)', () => {
+    it('bypasses for a user force so newly-followed contacts re-evaluate (#743)', () => {
+      expect(shouldBypassSkipSet({ force: true })).toBe(true);
+    });
+
+    it('bypasses when the follow gate is off (includeNonFollows, #744)', () => {
+      expect(shouldBypassSkipSet({ includeNonFollows: true })).toBe(true);
+    });
+
+    it('does NOT bypass for the cold-start backfill — the every-cold-start decrypt sweep (#846)', () => {
+      expect(shouldBypassSkipSet({ backfill: true })).toBe(false);
+    });
+
+    it('does not bypass a default refresh', () => {
+      expect(shouldBypassSkipSet(undefined)).toBe(false);
+      expect(shouldBypassSkipSet({})).toBe(false);
+    });
+  });
+
+  describe('shouldDropK4Since (regression for #846)', () => {
+    it('drops the floor for a non-cold user force (re-fetch older kind-4 after a follow toggle)', () => {
+      expect(shouldDropK4Since({ force: true }, false)).toBe(true);
+    });
+
+    it('keeps the floor on cold start even under force (#751)', () => {
+      expect(shouldDropK4Since({ force: true }, true)).toBe(false);
+    });
+
+    it('keeps the floor for the backfill — the NIP-04 plaintext cache is memory-only (#846)', () => {
+      expect(shouldDropK4Since({ backfill: true }, false)).toBe(false);
+    });
+
+    it('keeps the floor for default refreshes', () => {
+      expect(shouldDropK4Since(undefined, false)).toBe(false);
+      expect(shouldDropK4Since({}, true)).toBe(false);
     });
   });
 

--- a/src/contexts/dmRefreshGate.test.ts
+++ b/src/contexts/dmRefreshGate.test.ts
@@ -83,6 +83,10 @@ describe('dmRefreshGate', () => {
       expect(shouldBypassSkipSet({ backfill: true })).toBe(false);
     });
 
+    it('still bypasses for backfill + includeNonFollows (dev follow gate off) — by design', () => {
+      expect(shouldBypassSkipSet({ backfill: true, includeNonFollows: true })).toBe(true);
+    });
+
     it('does not bypass a default refresh', () => {
       expect(shouldBypassSkipSet(undefined)).toBe(false);
       expect(shouldBypassSkipSet({})).toBe(false);

--- a/src/contexts/dmRefreshGate.ts
+++ b/src/contexts/dmRefreshGate.ts
@@ -1,4 +1,5 @@
 import { DM_INBOX_REFRESH_TTL_MS } from './nostrDmCache';
+import type { RefreshDmInboxOptions } from './nostrContextTypes';
 
 /**
  * Pure freshness-cursor logic for `refreshDmInbox` (#788). The hook holds a
@@ -38,6 +39,50 @@ export function shouldSkipForFreshness(
   if (force) return false;
   if (lastRefreshAt <= 0) return false;
   return now - lastRefreshAt < DM_INBOX_REFRESH_TTL_MS;
+}
+
+/**
+ * Whether this refresh may bypass the freshness TTL. Two callers qualify:
+ * user-intent `force` refreshes (pull-to-refresh, follow-toggle), and the
+ * automated cold-start backfill (#751) — the backfill fires immediately after
+ * the capped first pass COMPLETED and stamped the cursor, so without a TTL
+ * bypass it would be suppressed for a full window and the inbox would sit at
+ * the 200-wrap slice.
+ */
+export function bypassesFreshnessTtl(opts: RefreshDmInboxOptions | undefined): boolean {
+  return opts?.force === true || opts?.backfill === true;
+}
+
+/**
+ * Whether to bypass the #743 negative-result skip-set. ONLY user-intent
+ * refreshes qualify: `force` (a newly-followed contact's older wraps must be
+ * re-evaluated on the next pull-to-refresh) and `includeNonFollows` (the dev
+ * "Following only=off" toggle disables the follow gate, so wraps skipped as
+ * non-follows must be re-surfaced — Copilot finding on #744). The automated
+ * cold-start backfill must NOT bypass: it used to run as `force`, which
+ * re-paid the schnorr + NIP-44 decrypt for every persisted skip-set wrap
+ * (group rumors + non-followed senders — ~510 measured) on EVERY cold start,
+ * the bulk of the 28-30 s circuit-1 freeze (#846).
+ */
+export function shouldBypassSkipSet(opts: RefreshDmInboxOptions | undefined): boolean {
+  return opts?.force === true || opts?.includeNonFollows === true;
+}
+
+/**
+ * Whether the kind-4 relay fetch should drop its `since` floor. Only a
+ * NON-cold user `force` does — a follow-toggle / pull-to-refresh wants older
+ * kind-4 from the newly-followed contact back. Cold start keeps the floor
+ * even under force (the on-mount enforce-flip refresh doesn't need the full
+ * kind-4 backlog — that was the ~11 s cold remainder, #751). The backfill
+ * keeps it too: the NIP-04 plaintext cache is memory-only
+ * (nostrSecretKeyCache.ts), so refetching the kind-4 backlog re-decrypted all
+ * of it (~212 measured) on every cold start (#846).
+ */
+export function shouldDropK4Since(
+  opts: RefreshDmInboxOptions | undefined,
+  isColdStart: boolean,
+): boolean {
+  return opts?.force === true && !isColdStart;
 }
 
 /**

--- a/src/contexts/dmRefreshGate.ts
+++ b/src/contexts/dmRefreshGate.ts
@@ -59,7 +59,9 @@ export function bypassesFreshnessTtl(opts: RefreshDmInboxOptions | undefined): b
  * re-evaluated on the next pull-to-refresh) and `includeNonFollows` (the dev
  * "Following only=off" toggle disables the follow gate, so wraps skipped as
  * non-follows must be re-surfaced — Copilot finding on #744). The automated
- * cold-start backfill must NOT bypass: it used to run as `force`, which
+ * cold-start backfill does NOT bypass by itself (`includeNonFollows` still
+ * bypasses, even during a backfill — with the follow gate off, hiding
+ * non-followed wraps would be wrong): it used to run as `force`, which
  * re-paid the schnorr + NIP-44 decrypt for every persisted skip-set wrap
  * (group rumors + non-followed senders — ~510 measured) on EVERY cold start,
  * the bulk of the 28-30 s circuit-1 freeze (#846).

--- a/src/contexts/dmRefreshGate.ts
+++ b/src/contexts/dmRefreshGate.ts
@@ -27,16 +27,18 @@ export function isColdStartRefresh(lastRefreshAt: number): boolean {
 
 /**
  * Whether to skip the refresh entirely because a previous one COMPLETED within
- * the freshness TTL. `force` callers (pull-to-refresh) always bypass it; the
+ * the freshness TTL. `bypassTtl` comes from `bypassesFreshnessTtl(opts)` —
+ * true for user-intent `force` AND the cold-start `backfill`; pass that, not
+ * `opts.force`, or the backfill suppression regression (#846) comes back. The
  * Messages-tab `useFocusEffect` uses the default path so tab-bouncing doesn't
  * re-fire expensive relay+decrypt work. `now` is injected for testability.
  */
 export function shouldSkipForFreshness(
   lastRefreshAt: number,
-  force: boolean,
+  bypassTtl: boolean,
   now: number,
 ): boolean {
-  if (force) return false;
+  if (bypassTtl) return false;
   if (lastRefreshAt <= 0) return false;
   return now - lastRefreshAt < DM_INBOX_REFRESH_TTL_MS;
 }

--- a/src/contexts/nostrContextTypes.ts
+++ b/src/contexts/nostrContextTypes.ts
@@ -13,7 +13,9 @@ export interface RefreshDmInboxOptions {
   force?: boolean;
   /** Automated cold-start top-up pass (#751). Bypasses the freshness TTL
    * like `force` (it fires right after the capped first pass stamps the
-   * cursor), but — unlike `force` — RESPECTS the #743 skip-set and the
+   * cursor), but — unlike `force` — does not itself bypass the #743
+   * skip-set (`includeNonFollows`, the dev follow-gate-off path, still
+   * does — even during a backfill) and RESPECTS the
    * kind-4 `since` floor. A backfill is not a user-intent refresh, so it
    * must not re-pay decrypts the persisted caches already cover; running
    * it as `force` was the every-cold-start 28-30 s decrypt sweep (#846). */

--- a/src/contexts/nostrContextTypes.ts
+++ b/src/contexts/nostrContextTypes.ts
@@ -11,6 +11,13 @@
  * filtered cache would mask new unfollowed entries fetched this round. */
 export interface RefreshDmInboxOptions {
   force?: boolean;
+  /** Automated cold-start top-up pass (#751). Bypasses the freshness TTL
+   * like `force` (it fires right after the capped first pass stamps the
+   * cursor), but — unlike `force` — RESPECTS the #743 skip-set and the
+   * kind-4 `since` floor. A backfill is not a user-intent refresh, so it
+   * must not re-pay decrypts the persisted caches already cover; running
+   * it as `force` was the every-cold-start 28-30 s decrypt sweep (#846). */
+  backfill?: boolean;
   signal?: AbortSignal;
   includeNonFollows?: boolean;
 }

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -47,7 +47,14 @@ import {
   mergeInboxEntries,
 } from './nostrDmCache';
 import type { RefreshDmInboxOptions, ConversationMessage } from './nostrContextTypes';
-import { isColdStartRefresh, shouldSkipForFreshness, shouldStampCursor } from './dmRefreshGate';
+import {
+  isColdStartRefresh,
+  shouldSkipForFreshness,
+  shouldStampCursor,
+  bypassesFreshnessTtl,
+  shouldBypassSkipSet,
+  shouldDropK4Since,
+} from './dmRefreshGate';
 import { startLiveDmSubscription } from './nostrLiveDmSub';
 import { fetchConversationFor } from './nostrFetchConversation';
 import { scheduleColdStartBackfill } from './dmColdStartBackfill';
@@ -275,12 +282,6 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // multi-second freezes that coincide with this call. #554.
       const __perfBlockStart = performance.now();
       const signal = opts?.signal;
-      // When true, the negative-result skip-set is bypassed so wraps that
-      // were previously skipped (non-follows, group routes) get re-evaluated
-      // against the current follow set. Necessary because a user who follows
-      // a new contact should see their older wraps surface on the next
-      // pull-to-refresh, not remain silently skipped. (#743)
-      const forceRefresh = opts?.force === true;
       // Dev-only "Following only=off" bypass — read once at the top so
       // the closure captures a stable value across the async work below.
       // When true, all six follow-gate `continue`s in the decrypt loops
@@ -291,20 +292,18 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       // load is MessagesScreen's on-mount focus refresh; the cold-start wrap
       // cap + #788 macro-task yield must apply to it). See dmRefreshGate.
       const isColdStart = isColdStartRefresh(dmInboxLastRefreshAt.current);
-      // Gate for negative-result skip-set lookups (#743). Bypass when:
-      //   force=true (pull-to-refresh) — newly-followed contacts' older
-      //     wraps must surface on the next explicit refresh.
-      //   includeNonFollows=true ("All (dev)" toggle) — the follow gate is
-      //     disabled, so wraps from non-followed senders that were already
-      //     added to the skip-set must now be re-evaluated and surfaced.
-      //     Without this, "Following only=off" would silently skip them.
-      //     (Copilot review finding on #744)
-      const bypassSkipSet = forceRefresh || includeNonFollows;
-      // Freshness TTL: skip the refresh entirely if the previous one
-      // COMPLETED within DM_INBOX_REFRESH_TTL_MS, unless the caller forces it
-      // (pull-to-refresh). Messages-tab `useFocusEffect` uses the default path
-      // so tab-bouncing doesn't retrigger relay+decrypt work. See dmRefreshGate.
-      if (shouldSkipForFreshness(dmInboxLastRefreshAt.current, forceRefresh, performance.now())) {
+      // Skip-set / TTL / kind-4 `since` policies are pure functions in
+      // dmRefreshGate — the cold-start backfill (#751) bypasses only the
+      // TTL; it must NOT inherit the #743 force-refresh cache bypasses
+      // (that was the every-cold-start decrypt sweep, #846).
+      const bypassSkipSet = shouldBypassSkipSet(opts);
+      if (
+        shouldSkipForFreshness(
+          dmInboxLastRefreshAt.current,
+          bypassesFreshnessTtl(opts),
+          performance.now(),
+        )
+      ) {
         return;
       }
       // Single-flight: piggy-back on in-flight task ONLY when its includeNonFollows matches; otherwise wait then re-run with the wider option.
@@ -398,8 +397,8 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
             refreshForPubkey,
             readRelays,
             {
-              // Cold start keeps `since` for kind-4 even under force — the on-mount enforce-flip refresh is force but doesn't need the full kind-4 backlog (that was the ~11s cold remainder; #751). Non-cold force still drops it so a follow-toggle / pull-to-refresh re-fetches older kind-4. Wraps ignore `since` internally regardless (random NIP-59 ts).
-              ...(opts?.force && !isColdStart ? {} : { since: lastSeen }),
+              // kind-4 `since` floor policy → dmRefreshGate.shouldDropK4Since (#751/#846). Wraps ignore `since` internally regardless (random NIP-59 ts).
+              ...(shouldDropK4Since(opts, isColdStart) ? {} : { since: lastSeen }),
               signal,
               ...(isColdStart ? { limit: COLD_INITIAL_WRAP_LIMIT } : {}),
             },

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -294,7 +294,8 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
       const isColdStart = isColdStartRefresh(dmInboxLastRefreshAt.current);
       // Skip-set / TTL / kind-4 `since` policies are pure functions in
       // dmRefreshGate — the cold-start backfill (#751) bypasses only the
-      // TTL; it must NOT inherit the #743 force-refresh cache bypasses
+      // TTL; backfill itself must NOT inherit the #743 force-refresh cache
+      // bypasses (includeNonFollows still bypasses, see shouldBypassSkipSet)
       // (that was the every-cold-start decrypt sweep, #846).
       const bypassSkipSet = shouldBypassSkipSet(opts);
       if (


### PR DESCRIPTION
## Root cause

Every cold start re-ran the full DM decrypt sweep (28–30 s on the JS thread) **because the automated cold-start backfill masquerades as a user pull-to-refresh**:

1. `src/contexts/dmColdStartBackfill.ts` — after the capped first pass (#751), the backfill re-invoked `refreshDmInbox({ force: true })`.
2. `useDmInbox.ts` — `force` bundles three unrelated semantics, two of which are cache bypasses designed for *user-intent* refreshes (#743):
   - **kind-4 `since` floor dropped** (`opts?.force && !isColdStart`): the backfill refetched the entire kind-4 backlog (measured `sentK4=115 recvK4=98` → 213 events) and, because the NIP-04 plaintext cache is memory-only (`nostrSecretKeyCache.ts:17`), re-paid **212 fresh NIP-04 decrypts on every cold start**. This is the bulk of the JS-thread sweep on the measured inbox.
   - **#743 skip-set bypassed** (`bypassSkipSet = forceRefresh || includeNonFollows`): every persisted skip-set wrap (group rumors + non-followed senders) re-pays the schnorr + NIP-44 unwrap. On the emulator fixture inbox the skip-set happens to be empty (all 510 wraps are message-bearing, follow-gated entries in the positive wrap cache, which `force` does *not* bypass) — but on inboxes with group/non-follow traffic (the Pixel's real inbox, 52 s sweep) this bypass re-decrypts those wraps forever.
3. Warm refreshes are non-force, so they hit the very same persisted caches perfectly (`fresh=0`, zero >1 s gaps from circuit 2 onward) — proving the caches work and the **bypass** is the bug, not missing persistence.

### Answers to the investigation questions in #846

- **Why "fresh" on every cold start despite the persistent store?** The backfill's inherited `force` semantics (above). One measurement correction: the issue's "k1059 fresh=510" read the `[Perf] refreshDmInbox: fresh=` counter, which counts *entries assembled* (cache hits included), not decrypts — the same-cache A/B below shows `nip17 misses=0` even on main for this inbox. The real per-cold-start decrypt cost here is the 212 kind-4 NIP-04 decrypts.
- **The #695 SQLite store** (`dmDb.ts` / `dmIngest.ts` / `dmStoreMigration.ts`) is **not wired into the app** — those modules are imported only by their own tests. The live persistence layer is the file-backed wrap cache + skip-set (#687/#689/#743), and it demonstrably works. Wiring the encrypted store (#695/#697) remains open and is *not* claimed by this PR.
- **Does the skip-set leave message-bearing wraps to re-decrypt forever?** No — message-bearing followed wraps live in the positive wrap cache, which is checked before the skip-set and is never bypassed by `force`.

## Fix

New `backfill: true` option on `RefreshDmInboxOptions`: it bypasses **only the freshness TTL** (the capped first pass just stamped the cursor, so without a TTL bypass the backfill would be suppressed) while **respecting the #743 skip-set and the kind-4 `since` floor**. The policy decisions are pure, unit-tested functions in `dmRefreshGate.ts` (`bypassesFreshnessTtl` / `shouldBypassSkipSet` / `shouldDropK4Since`); user `force` (pull-to-refresh / follow-toggle) semantics are unchanged.

`useDmInbox.ts` shrinks 999 → 998 lines (policy + rationale moved to the gate module).

## Measurements

Protocol: emulator dev client, warm on-device caches, Maestro cold-start + circuit-1 stress flow (Home → Send open/close → Map → Hunt → Events → Messages → Friends → Home), `[Perf]` log + heartbeat-gap instrumentation. The main baseline was re-run today on the **identical cache state** as the fix runs.

| | main (today, same caches) | fix — cold start 1 | fix — cold start 2 (gate) |
|---|---|---|---|
| backfill k4 fetched | 213 (`sentK4=115 recvK4=98`) | 1 | 1 |
| fresh NIP-04 decrypts | **212** | 1 | 1 |
| NIP-17 unwraps (misses) | 0 | 0 | 0 |
| backfill `refreshDmInbox` wall | **28,115 ms** | 22,004 ms | 15,771 ms |
| max heartbeat gap | **4,998 ms** | 1,420 ms | 1,473 ms |
| gaps >1 s in circuit 1 | 3 (incl. ~14 ticks of 500–1100 ms during the decrypt burst) | 2 | 1 |

- Second-cold-start gate: **fresh ≈ 0** (1 genuinely-new since-cursor kind-4 event), and the JS-thread decrypt work is gone. Remaining wall-clock is dominated by the relay EOSE wait (`fetchInboxDmEvents` 10 s, async — it doesn't block the thread).
- Residual: one ~1.4–1.5 s gap appears on *both* main and fix runs (Hunt/Events first-mount cost) — that's the candidate-direction-3 territory of #846 (yield granularity / mount overlap), not DM decrypt, and is not claimed here.

## Known limitations / follow-ups

- A *user* pull-to-refresh (`force: true`) still intentionally re-decrypts skip-set wraps + kind-4 backlog per #743 — on a big inbox that's still a multi-second sweep, but it's user-initiated and bounded by the 30 s TTL.
- `GroupsScreen` focus and `useFriendsLiveLocations` still pass `force`/`includeNonFollows` and inherit the same bypass cost (throttled to 30 s). Worth migrating to narrower semantics in a follow-up.
- Wiring the #695 encrypted SQLite store (and persisting NIP-04 plaintext somewhere encrypted, so even a genuine backlog refetch is decrypt-once) remains tracked by #695/#697.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Test plan

- `npx jest` — full suite green (1057 tests), incl. new `dmRefreshGate.test.ts` + `dmColdStartBackfill.test.ts`
- `npx tsc --noEmit`, ESLint, Prettier, `scripts/check-file-size.sh` — clean
- Emulator (steps to reproduce the verification above): cold-start the dev client twice on this branch with warm on-device caches; from `[Perf]` logs confirm second cold start shows fresh decrypts ≈ 0 and backfill wall-time collapsed; run the circuit-1 navigation stress flow and confirm max heartbeat gap < 1.5 s (full numbers in **Measurements** above)