### PR TITLE
fix(nav): reserve real safe-area inset on the bottom tab bar (#862)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  Linking,
-  StyleSheet,
-  ActivityIndicator,
-  View,
-  Platform,
-  useWindowDimensions,
-} from 'react-native';
+import { Linking, StyleSheet, ActivityIndicator, View, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   NavigationContainer,
   NavigationState,
@@ -289,6 +283,12 @@ function ExploreStackNavigator() {
 
 function HomeTabs() {
   const { colors } = useTheme();
+  // Reserve the *actual* system-bar height. Edge-to-edge draws the tab
+  // bar behind the nav bar, so a hardcoded inset under-reserves on
+  // Android 3-button nav (~48dp) and overlaps. The inset grows for a
+  // gesture pill or a 3-button bar on every device, and carries iOS's
+  // home-indicator inset through the same hook.
+  const insets = useSafeAreaInsets();
   return (
     <Tab.Navigator
       screenOptions={{
@@ -305,8 +305,8 @@ function HomeTabs() {
         tabBarStyle: {
           backgroundColor: colors.surface,
           borderTopColor: colors.divider,
-          height: Platform.OS === 'android' ? 80 : 70,
-          paddingBottom: Platform.OS === 'android' ? 20 : 10,
+          height: 60 + insets.bottom,
+          paddingBottom: insets.bottom,
           paddingTop: 6,
         },
         tabBarActiveTintColor: colors.brandPink,

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -283,11 +283,7 @@ function ExploreStackNavigator() {
 
 function HomeTabs() {
   const { colors } = useTheme();
-  // Reserve the *actual* system-bar height. Edge-to-edge draws the tab
-  // bar behind the nav bar, so a hardcoded inset under-reserves on
-  // Android 3-button nav (~48dp) and overlaps. The inset grows for a
-  // gesture pill or a 3-button bar on every device, and carries iOS's
-  // home-indicator inset through the same hook.
+  // Reserve the real system-bar inset so the edge-to-edge tab bar clears gesture/3-button nav (see #862).
   const insets = useSafeAreaInsets();
   return (
     <Tab.Navigator


### PR DESCRIPTION
## Root cause

The app runs edge-to-edge (`react-native-edge-to-edge`), so the bottom tab bar draws *behind* the system nav bar and must reserve the **actual** bottom inset. Instead it hardcoded the inset in `src/navigation/AppNavigator.tsx`:

```js
height: Platform.OS === 'android' ? 80 : 70,
paddingBottom: Platform.OS === 'android' ? 20 : 10,
```

`paddingBottom: 20` ≈ a gesture-nav pill's inset, which is why most users were fine. But Android **3-button nav** (triangle/circle/square) is ~48dp tall, so 20 was insufficient → the system buttons overlapped the app's tab buttons.

## The fix

`HomeTabs()` is a component and `react-native-safe-area-context` is already a dependency (`SafeAreaProvider` is already wired at the app root in `App.tsx`). Use the real inset:

```js
const insets = useSafeAreaInsets();
// ...
tabBarStyle: {
  height: 60 + insets.bottom,
  paddingBottom: insets.bottom,
  paddingTop: 6,
}
```

This reserves exactly the system-bar height — it grows for a gesture pill or a 3-button bar on every device, and carries iOS's home-indicator inset through the same hook. The now-redundant `Platform.OS` branches on `height`/`paddingBottom` are dropped (and the now-unused `Platform` import removed).

## Other bottom-anchored UI ("also check")

I grepped `src/` for other bottom-anchored surfaces with the same latent 3-button overlap. Findings:

**Already handled correctly — no change needed:**
- **`ConversationScreen` / `GroupConversationScreen` composers** — full-screen Stack routes whose input row reaches the screen edge. Both already consume `useSafeAreaInsets()` / `insets.bottom`.
- **`MessagesScreen` FAB** (`bottom: 20`) — `MessagesScreen` is a direct `Tab.Screen`, so its FAB sits **above** the (now-fixed) tab bar, not above the system nav bar. The tab-bar fix already clears it.
- **Bottom sheets** (`SendSheet`, `ReceiveSheet`, `TransferSheet`, `LnurlWithdrawSheet`, …) — `@gorhom/bottom-sheet` is wrapped in `SafeAreaProvider` and handles its own insets; the hardcoded `paddingBottom` values are inner scroll-content spacing, not screen-edge pins.

**Flagged as low-priority follow-ups (not touched — deliberately out of scope to keep the diff focused):**
- **`MapScreen.styles.ts` `recenterButton` / `legendButton`** (`bottom: 14` / `bottom: 62`) — these style entries are **not** rendered by `MapScreen.tsx`'s JSX; the live recenter/legend buttons belong to `LibreMiniMap`, positioned relative to the map view (not the screen edge). No real overlap, but the unused style entries are worth a cleanup later.
- **`HuntCreateScreen.styles.ts` `scannerHintBar`** (`bottom: 48`) — a centered, non-interactive floating hint pill over the camera scanner. `bottom: 48` already clears a 3-button bar, and the gap is a deliberate visual choice; adjusting it risks regressing the intended look for a cosmetic, non-tappable label. Left as-is.

## Device verification: deferred — both nav modes pending

This is a layout change; components are excluded from unit coverage (per `CLAUDE.md`), so no new unit test. **Must be checked on-device once the emulator frees up**, on BOTH nav modes (Settings → System → Gestures → toggle gesture-nav vs 3-button): tab buttons clear the system bar in both, with **no overlap and no excess gap**.

## Gates

- `npx tsc --noEmit` — clean
- ESLint — clean
- Prettier — clean
- `scripts/check-file-size.sh` — clean
- Jest — 93 suites / 1107 tests green

## Test plan

**Automated gates (all green locally + in CI):**
- `npx tsc --noEmit` — clean
- ESLint — 0 errors
- Prettier — changed file clean
- `bash scripts/check-file-size.sh` — clean
- Jest — 93 suites / 1107 tests green

**On-device (maintainer-deferred — single shared emulator in use):**
- Toggle Settings → System → Gestures between gesture-nav and 3-button nav.
- Confirm the bottom tab buttons clear the system nav bar with **no overlap and no excess gap** in **both** modes.

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
