### PR TITLE
fix(dm): white delivery ticks + timestamp on sent bubbles (#864)

### DIFF
--- a/src/styles/MessageBubble.styles.ts
+++ b/src/styles/MessageBubble.styles.ts
@@ -72,29 +72,25 @@ export const createMessageBubbleStyles = (colors: Palette) =>
       gap: 4,
     },
     // The time inside the footer row drops its own marginTop (the row owns it)
-    // and gains a small gap before the tick.
+    // and gains a small gap before the tick. It carries no colour of its own so
+    // the composed timeStyle wins — bubbleTimeMe (white) on a sent pink bubble,
+    // bubbleTime (supplementary grey) on a received surface bubble. (#864)
     bubbleFooterTime: {
       fontSize: 10,
-      color: colors.textSupplementary,
       marginRight: 4,
       // Zero the standalone bubbleTime top margin so the tick sits level with
       // the timestamp in the footer row (the row owns vertical spacing). (#858)
       marginTop: 0,
     },
-    bubbleFooterTimeMe: {
-      color: 'rgba(255,255,255,0.85)',
-    },
-    // Delivery tick (#856, design approved 2026-06-12). WhatsApp-style
-    // single/double coverage in the payment-success green (shared with
-    // PaymentProgressOverlay so the token matches across both themes):
-    // single Check = delivered to ≥1 relay, double CheckCheck = all relays.
-    // Pending uses the faint supplementary grey; a failed send (0 relays)
-    // uses the error red.
+    // Delivery tick (#856). Ticks only ever render on a sent (pink) bubble, so
+    // they use white for contrast — green read poorly on the brand pink (#864).
+    // Glyph alone carries the meaning: single Check = delivered to ≥1 relay,
+    // double CheckCheck = all relays, Clock = pending, AlertCircle = failed.
     deliveryTickDelivered: {
-      color: colors.green,
+      color: colors.white,
     },
     deliveryTickPending: {
-      color: colors.textSupplementary,
+      color: 'rgba(255,255,255,0.7)',
     },
     deliveryTickFailed: {
       color: colors.red,


### PR DESCRIPTION
## What

On a **sent** (outgoing) DM bubble — brand-pink background — the delivery tick and the timestamp were low-contrast and hard to read. This makes them white, the way they used to be.

- The footer-row `bubbleFooterTime` carried its own `color: textSupplementary` (grey), which overrode the intended white `bubbleTimeMe`. The style meant to supply the white override (`bubbleFooterTimeMe`) was defined but never wired into the component — dead code. Dropping the colour from `bubbleFooterTime` lets the composed `timeStyle` win: **white** on a sent bubble, supplementary grey on a received one.
- Delivered ticks (single/double `Check`) and the pending `Clock` now use white. They only ever render on the pink sent bubble, so the green/grey read poorly there. The glyph alone carries the meaning (single vs double tick, clock).
- **Failed** sends keep the error red (distinct `AlertCircle` glyph) — intentional, not a readability regression.

Styles-only change in `src/styles/MessageBubble.styles.ts`; no component logic touched.

## Why standalone

Folded out of #857 (optimistic-send flow, in progress) to avoid colliding with that branch's live work — this is a pure presentation fix and has no overlap with the send-flow changes.

## Test plan

- `npx tsc --noEmit` — clean
- `npx eslint` / `npx prettier --check` — clean
- `scripts/check-file-size.sh` — clean (file shrank)
- `npx jest` — 93 suites / 1107 tests green
- **On-device verification deferred** — visual check on the emulator (sent bubble: white time + white ticks legible on pink; received bubble: grey time unchanged) once the emulator frees up from #857.

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)