### PR TITLE
fix(dm): render conversation from ingested store + abort/single-flight refresh (#868)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -203,17 +203,20 @@ interface NostrContextType {
     name: string;
     memberPubkeys: string[];
   }) => Promise<{ success: boolean; error?: string }>;
-  fetchConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  fetchConversation: (
+    otherPubkey: string,
+    opts?: { signal?: AbortSignal },
+  ) => Promise<ConversationMessage[]>;
   /**
-   * Read the persisted per-peer conversation cache synchronously-ish
-   * (AsyncStorage is actually async but single `getItem` is fast).
-   * Returns `[]` when no cache exists. Use this to paint a thread's
-   * cached messages instantly on mount, *before* awaiting the slower
-   * `fetchConversation` relay round-trip — Arcade's `db_only=true`
-   * pattern. The user sees the thread fill immediately, then a fresh
-   * merge replaces it once relay returns.
+   * Read-through (#868): the instant-paint set for a thread open — the union of
+   * the per-conversation cache and the SAME encrypted-store rows the Messages
+   * inbox preview is built from. Paint a thread from this on mount BEFORE the
+   * slower `fetchConversation` relay round-trip (Arcade's `db_only=true`
+   * pattern). Reading the store directly — not just the per-conversation cache
+   * blob — is what stops the thread lagging the inbox for a DM an inbox-wide
+   * refresh ingested (it writes the store, not the per-conv blob).
    */
-  getCachedConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  loadInitialConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
   /**
    * Tri-state for the NIP-17 silent-decrypt fast path.
    *  - 'unknown': haven't tried yet in this session
@@ -387,7 +390,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     dmInboxLoading,
     refreshDmInbox,
     fetchConversation,
-    getCachedConversation,
+    loadInitialConversation,
     appendLocalDmMessage,
     persistDeliveryStatuses,
     armLiveDmSub,
@@ -1749,7 +1752,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       sendGroupMessage,
       publishGroupState,
       fetchConversation,
-      getCachedConversation,
+      loadInitialConversation,
       appendLocalDmMessage,
       persistDeliveryStatuses,
       amberNip44Permission,
@@ -1780,7 +1783,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       sendGroupMessage,
       publishGroupState,
       fetchConversation,
-      getCachedConversation,
+      loadInitialConversation,
       appendLocalDmMessage,
       persistDeliveryStatuses,
       amberNip44Permission,

--- a/src/contexts/conversationReadThrough.test.ts
+++ b/src/contexts/conversationReadThrough.test.ts
@@ -1,0 +1,103 @@
+import {
+  mapStoredRowsToMessages,
+  loadInitialConversation,
+  type InitialConversationDeps,
+} from './conversationReadThrough';
+import type { DmMessageRow } from '../services/dmDb';
+import type { ConversationMessage } from './nostrContextTypes';
+
+const PEER = 'a'.repeat(64);
+
+const row = (over: Partial<DmMessageRow> = {}): DmMessageRow => ({
+  owner: 'b'.repeat(64),
+  eventId: 'evt-1',
+  conversation: PEER,
+  createdAt: 100,
+  sender: PEER,
+  content: 'hello from the inbox',
+  fromMe: false,
+  wireKind: 14,
+  ...over,
+});
+
+describe('mapStoredRowsToMessages', () => {
+  it('projects store rows to the thread message shape', () => {
+    const out = mapStoredRowsToMessages([row({ eventId: 'x', content: 'hi', createdAt: 7 })]);
+    expect(out).toEqual([{ id: 'x', fromMe: false, text: 'hi', createdAt: 7, wireKind: 14 }]);
+  });
+
+  it('returns [] for no rows', () => {
+    expect(mapStoredRowsToMessages([])).toEqual([]);
+  });
+});
+
+describe('loadInitialConversation (read-through #868)', () => {
+  it('returns the ingested store message even when the per-conversation cache is empty', async () => {
+    // This is the bug: the inbox already has the message in the store, but the
+    // conversation cache blob is empty, so the thread used to paint nothing.
+    const deps: InitialConversationDeps = {
+      getCachedConversation: async () => [],
+      getStoredRows: async () => [row({ eventId: 'ingested', content: 'the preview message' })],
+    };
+    const out = await loadInitialConversation(PEER, deps);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ id: 'ingested', text: 'the preview message' });
+  });
+
+  it('resolves from the store BEFORE any relay fetch — no relay dependency', async () => {
+    // The relay fetch is modelled here as a promise that never resolves; the
+    // read-through must not await it. If loadInitialConversation awaited a relay
+    // round-trip this test would hang and time out.
+    const neverResolves = new Promise<ConversationMessage[]>(() => {});
+    const deps: InitialConversationDeps = {
+      getCachedConversation: async () => [],
+      getStoredRows: async () => [row({ eventId: 'fromStore' })],
+    };
+    const out = await Promise.race([
+      loadInitialConversation(PEER, deps),
+      neverResolves.then(() => 'RELAY' as const),
+    ]);
+    expect(out).not.toBe('RELAY');
+    expect((out as ConversationMessage[])[0].id).toBe('fromStore');
+  });
+
+  it('unions cache (optimistic local- row) with the store, deduping the echo', async () => {
+    // Cache carries an optimistic local- send; the store carries the relay echo
+    // of the same text. mergeConversationMessages collapses them to one bubble.
+    const deps: InitialConversationDeps = {
+      getCachedConversation: async () => [
+        { id: 'local-1', fromMe: true, text: 'gm', createdAt: 200 },
+      ],
+      getStoredRows: async () => [
+        row({ eventId: 'echo-1', content: 'gm', fromMe: true, createdAt: 201 }),
+      ],
+    };
+    const out = await loadInitialConversation(PEER, deps);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('echo-1');
+  });
+
+  it('degrades to the store when the cache read throws', async () => {
+    const deps: InitialConversationDeps = {
+      getCachedConversation: async () => {
+        throw new Error('cache unavailable');
+      },
+      getStoredRows: async () => [row({ eventId: 'still-here' })],
+    };
+    const out = await loadInitialConversation(PEER, deps);
+    expect(out[0].id).toBe('still-here');
+  });
+
+  it('degrades to the cache when the store read throws', async () => {
+    const deps: InitialConversationDeps = {
+      getCachedConversation: async () => [
+        { id: 'cache-only', fromMe: false, text: 'x', createdAt: 1 },
+      ],
+      getStoredRows: async () => {
+        throw new Error('db unavailable');
+      },
+    };
+    const out = await loadInitialConversation(PEER, deps);
+    expect(out[0].id).toBe('cache-only');
+  });
+});

--- a/src/contexts/conversationReadThrough.ts
+++ b/src/contexts/conversationReadThrough.ts
@@ -1,0 +1,59 @@
+import type { DmMessageRow } from '../services/dmDb';
+import { DM_CONV_CAP, mergeConversationMessages } from './nostrDmCache';
+import type { ConversationMessage } from './nostrContextTypes';
+
+// Read-through for the conversation thread (#868). The Messages inbox preview
+// is fed from the encrypted `dm_messages` table (via getInboxLatest), but the
+// thread historically only painted from the per-conversation AsyncStorage cache
+// blob (convCacheKey). That blob is written by a thread open / send — NOT by an
+// inbox-wide refresh — so a message the inbox already ingested can be absent
+// from the blob, leaving the thread emptier than the preview until a second
+// relay-fetch+decrypt commits. This module reads the SAME rows the inbox holds
+// (getConversationMessages) and merges them with the cache so the thread paints
+// immediately and is never behind the preview. The relay fetch becomes a
+// background top-up, not a precondition for showing anything.
+
+// Map encrypted-store rows (DmMessageRow) to the thread's ConversationMessage
+// shape. Pure. Used by the read-through here; nostrFetchConversation builds its
+// thread slice from decrypted relay events (a different input), so it keeps its
+// own projection rather than sharing this one.
+export function mapStoredRowsToMessages(rows: DmMessageRow[]): ConversationMessage[] {
+  return rows.map((r) => ({
+    id: r.eventId,
+    fromMe: r.fromMe,
+    text: r.content,
+    createdAt: r.createdAt,
+    wireKind: r.wireKind,
+  }));
+}
+
+export interface InitialConversationDeps {
+  /** Per-conversation AsyncStorage cache blob (optimistic local- rows +
+   * previously-merged thread). May lag the inbox for inbox-ingested messages. */
+  getCachedConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  /** The SAME encrypted-store rows the inbox preview is built from, peer-scoped.
+   * Guarantees the thread can't be emptier than the inbox for ingested DMs. */
+  getStoredRows: (otherPubkey: string) => Promise<DmMessageRow[]>;
+}
+
+/**
+ * The instant-paint set for a thread open: the union of the per-conversation
+ * cache (carries optimistic local- rows + ticks) and the ingested store rows
+ * (carries everything the inbox already decrypted). Merged via
+ * `mergeConversationMessages` so local- echo dedup + delivery/rumorId carry-over
+ * behave exactly as the relay-fetch merge does. Reads run in parallel; a failure
+ * of either source degrades to the other rather than throwing.
+ */
+export async function loadInitialConversation(
+  otherPubkey: string,
+  deps: InitialConversationDeps,
+): Promise<ConversationMessage[]> {
+  const [cached, rows] = await Promise.all([
+    deps.getCachedConversation(otherPubkey).catch(() => [] as ConversationMessage[]),
+    deps.getStoredRows(otherPubkey).catch(() => [] as DmMessageRow[]),
+  ]);
+  const stored = mapStoredRowsToMessages(rows);
+  // Cache first so its optimistic local- rows and persisted ticks are the base;
+  // stored rows merge on top (real-id echoes dedup the local- rows).
+  return mergeConversationMessages(cached, stored, DM_CONV_CAP);
+}

--- a/src/contexts/nostrFetchConversation.ts
+++ b/src/contexts/nostrFetchConversation.ts
@@ -40,14 +40,27 @@ export interface FetchConversationParams {
   getReadRelays: () => string[];
   decryptNip04ViaSigner: (counterpartyPubkey: string, ciphertext: string) => Promise<string | null>;
   otherPubkey: string;
+  // Cancels the relay fetch + decrypt loop when the user navigates away (#868).
+  // Mirrors refreshDmInbox's opts.signal: the loop bails at its yield points so
+  // a back-press mid-fetch stops chewing the JS thread, and re-entering can
+  // abort-and-replace an in-flight fetch instead of stacking a second loop.
+  signal?: AbortSignal;
 }
 
 export async function fetchConversationFor(
   params: FetchConversationParams,
 ): Promise<ConversationMessage[]> {
-  const { pubkey, isLoggedIn, signerType, getReadRelays, decryptNip04ViaSigner, otherPubkey } =
-    params;
+  const {
+    pubkey,
+    isLoggedIn,
+    signerType,
+    getReadRelays,
+    decryptNip04ViaSigner,
+    otherPubkey,
+    signal,
+  } = params;
   if (!pubkey || !isLoggedIn) return [];
+  if (signal?.aborted) return [];
   const normalized = otherPubkey.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(normalized)) return [];
 
@@ -131,6 +144,10 @@ export async function fetchConversationFor(
     ev: (typeof kind4Events)[0];
   } | null)[] = [];
   for (let i = 0; i < freshDecryptTargets.length; i += DECRYPT_YIELD_EVERY) {
+    // Bail between batches once the caller aborts (#868) — same yield-point
+    // cancellation refreshDmInbox/ingestInboxWraps already do. Stops a back-
+    // press mid-fetch from draining the rest of the decrypt loop.
+    if (signal?.aborted) break;
     const batch = freshDecryptTargets.slice(i, i + DECRYPT_YIELD_EVERY);
     const batchResults = await Promise.all(
       batch.map(async (t) => {
@@ -226,10 +243,14 @@ export async function fetchConversationFor(
     // Store unavailable — fall back to the relay path below.
     if (__DEV__) console.warn('[DmStore] thread slice read failed:', e);
   }
-  const inboxLastSeenForWraps = skippedInboxFetch
+  // Aborted mid-fetch (back-press during the kind-4 decrypt) — skip the
+  // inbox-wide wrap fetch entirely and return what the store already gave us
+  // (#868). The store rows above are already pushed into `decrypted`.
+  const skipWrapFetch = skippedInboxFetch || (signal?.aborted ?? false);
+  const inboxLastSeenForWraps = skipWrapFetch
     ? undefined
     : await loadLastSeen(inboxLastSeenKey(pubkey));
-  const { kind1059 } = skippedInboxFetch
+  const { kind1059 } = skipWrapFetch
     ? {
         kind1059: [] as Awaited<ReturnType<typeof nostrService.fetchInboxDmEvents>>['kind1059'],
       }
@@ -265,6 +286,7 @@ export async function fetchConversationFor(
         unwrap,
         passesFollowGate: () => true,
         onSkip,
+        signal,
       });
       nip17CacheHits += r.alreadyKnown;
       nip17FreshDecrypts += r.misses;
@@ -288,6 +310,15 @@ export async function fetchConversationFor(
   // from previous opens. Fresh takes precedence via `mergeConversationMessages`
   // Map semantics so re-ordered or edited events (rare) land right.
   const merged = mergeConversationMessages(cachedConv, decrypted, DM_CONV_CAP);
+
+  // Aborted mid-fetch (Copilot #869): the kind-4 decrypt loop bails between
+  // batches, so `decrypted` may omit events the abort skipped — but
+  // `kind4Events` still holds them all. Persisting `convLastSeen` from the full
+  // `kind4Events` set would advance the per-peer `since` cursor PAST those
+  // never-decrypted events, permanently skipping them on the next open. Return
+  // the store-backed `merged` (already painted) WITHOUT any cache/cursor write,
+  // so an aborted run has no durable side effects.
+  if (signal?.aborted) return merged;
 
   // Single-line perf summary — grep `[Perf] fetchConversation` out
   // of logcat to compare cold-store vs warm-store thread opens.

--- a/src/contexts/nostrFetchConversationAbort.test.ts
+++ b/src/contexts/nostrFetchConversationAbort.test.ts
@@ -1,0 +1,125 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { fetchConversationFor, type FetchConversationParams } from './nostrFetchConversation';
+import * as nostrService from '../services/nostrService';
+import { getConversationMessages, hasStoredWraps } from '../services/dmDb';
+import { ensureDmStoreMigrated } from './dmStoreMigrationRunner';
+
+// Abort + single-flight coverage for the conversation fetch (#868). We mock the
+// relay + DB + migration boundary so the test exercises the control flow around
+// the AbortSignal without any real crypto / network / SQLite.
+
+jest.mock('../services/nostrService', () => ({
+  fetchDirectMessageEvents: jest.fn(async () => []),
+  fetchInboxDmEvents: jest.fn(async () => ({ kind1059: [] })),
+}));
+
+jest.mock('../services/amberService', () => ({
+  requestNip44Decrypt: jest.fn(async () => null),
+}));
+
+jest.mock('../services/dmDb', () => ({
+  getConversationMessages: jest.fn(async () => []),
+  hasStoredWraps: jest.fn(async () => false),
+  upsertDmMessages: jest.fn(async () => undefined),
+}));
+
+jest.mock('./dmStoreMigrationRunner', () => ({
+  ensureDmStoreMigrated: jest.fn(async () => undefined),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: { getItem: jest.fn(async () => null), setItem: jest.fn(async () => undefined) },
+}));
+
+const PEER = 'a'.repeat(64);
+const ME = 'b'.repeat(64);
+
+const baseParams = (over: Partial<FetchConversationParams> = {}): FetchConversationParams => ({
+  pubkey: ME,
+  isLoggedIn: true,
+  signerType: 'nsec',
+  getReadRelays: () => ['wss://relay.example'],
+  decryptNip04ViaSigner: jest.fn(async () => 'plaintext'),
+  otherPubkey: PEER,
+  ...over,
+});
+
+describe('fetchConversationFor abort (#868)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns [] immediately when the signal is already aborted (no relay query)', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const out = await fetchConversationFor(baseParams({ signal: controller.signal }));
+    expect(out).toEqual([]);
+    expect(ensureDmStoreMigrated).not.toHaveBeenCalled();
+    expect(nostrService.fetchDirectMessageEvents).not.toHaveBeenCalled();
+    expect(nostrService.fetchInboxDmEvents).not.toHaveBeenCalled();
+  });
+
+  it('skips the inbox-wide wrap fetch when aborted mid-flight', async () => {
+    // Store read returns nothing and hasStoredWraps is false, so WITHOUT the
+    // abort the code would hit fetchInboxDmEvents. Aborting after the store read
+    // must short-circuit that inbox-wide relay fetch + decrypt loop.
+    const controller = new AbortController();
+    (getConversationMessages as jest.Mock).mockImplementation(async () => {
+      controller.abort();
+      return [];
+    });
+    (hasStoredWraps as jest.Mock).mockResolvedValue(false);
+
+    await fetchConversationFor(baseParams({ signal: controller.signal }));
+
+    expect(nostrService.fetchInboxDmEvents).not.toHaveBeenCalled();
+  });
+
+  it('runs the inbox-wide wrap fetch when NOT aborted (control)', async () => {
+    (getConversationMessages as jest.Mock).mockResolvedValue([]);
+    (hasStoredWraps as jest.Mock).mockResolvedValue(false);
+
+    await fetchConversationFor(baseParams());
+
+    expect(nostrService.fetchInboxDmEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT advance the convLastSeen cursor when aborted mid-flight (Copilot #869)', async () => {
+    // Relay returns kind-4 events, but the fetch is aborted after the store
+    // read. Persisting convLastSeen from these events would skip them on the
+    // next open (they were never decrypted). An aborted run must write nothing.
+    const setItem = AsyncStorage.setItem as jest.Mock;
+    (nostrService.fetchDirectMessageEvents as jest.Mock).mockResolvedValue([
+      { id: 'e1', pubkey: PEER, content: 'ct', created_at: 1000 },
+      { id: 'e2', pubkey: PEER, content: 'ct', created_at: 2000 },
+    ]);
+    const controller = new AbortController();
+    (getConversationMessages as jest.Mock).mockImplementation(async () => {
+      controller.abort();
+      return [];
+    });
+
+    await fetchConversationFor(baseParams({ signal: controller.signal }));
+
+    // No cache blob and no cursor advance — zero AsyncStorage writes.
+    expect(setItem).not.toHaveBeenCalled();
+    expect(nostrService.fetchInboxDmEvents).not.toHaveBeenCalled();
+  });
+
+  it('persists the convLastSeen cursor on a normal (non-aborted) run', async () => {
+    // Control: the same kind-4 events, no abort → the cursor IS written.
+    const setItem = AsyncStorage.setItem as jest.Mock;
+    (nostrService.fetchDirectMessageEvents as jest.Mock).mockResolvedValue([
+      { id: 'e1', pubkey: PEER, content: 'ct', created_at: 1000 },
+      { id: 'e2', pubkey: PEER, content: 'ct', created_at: 2000 },
+    ]);
+    (getConversationMessages as jest.Mock).mockResolvedValue([]);
+    (hasStoredWraps as jest.Mock).mockResolvedValue(true);
+
+    await fetchConversationFor(baseParams());
+
+    const wroteCursor = setItem.mock.calls.some(([key]: [string]) =>
+      key.includes('conv_last_seen'),
+    );
+    expect(wroteCursor).toBe(true);
+  });
+});

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -10,6 +10,7 @@ import {
   selectKnownEventIds,
   upsertDmMessages,
   hasStoredWraps,
+  getConversationMessages,
   type DmMessageRow,
 } from '../services/dmDb';
 import { loadInboxEntries } from '../services/dmInbox';
@@ -47,6 +48,7 @@ import {
 } from './dmRefreshGate';
 import { startLiveDmSubscription } from './nostrLiveDmSub';
 import { fetchConversationFor } from './nostrFetchConversation';
+import { loadInitialConversation as loadInitialConversationFor } from './conversationReadThrough';
 import { scheduleColdStartBackfill } from './dmColdStartBackfill';
 import { bindDmDeliveryStorePersistence } from './dmDeliveryStorePersistence';
 
@@ -78,8 +80,15 @@ export interface UseDmInboxResult {
   dmInbox: DmInboxEntry[];
   dmInboxLoading: boolean;
   refreshDmInbox: (opts?: RefreshDmInboxOptions) => Promise<void>;
-  fetchConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  fetchConversation: (
+    otherPubkey: string,
+    opts?: { signal?: AbortSignal },
+  ) => Promise<ConversationMessage[]>;
   getCachedConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  // Read-through (#868): the instant-paint set for a thread open — the union of
+  // the per-conversation cache and the SAME encrypted-store rows the inbox
+  // preview is built from. Guarantees the thread is never behind the preview.
+  loadInitialConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
   appendLocalDmMessage: (otherPubkey: string, msg: ConversationMessage) => Promise<void>;
   persistDeliveryStatuses: (
     otherPubkey: string,
@@ -334,7 +343,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
   // hook threads in the identity + relay + NIP-04 decrypt dependencies it
   // closes over; the body is unchanged.
   const fetchConversation = useCallback(
-    (otherPubkey: string): Promise<ConversationMessage[]> =>
+    (otherPubkey: string, opts?: { signal?: AbortSignal }): Promise<ConversationMessage[]> =>
       fetchConversationFor({
         pubkey,
         isLoggedIn,
@@ -342,8 +351,28 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
         getReadRelays,
         decryptNip04ViaSigner,
         otherPubkey,
+        signal: opts?.signal,
       }),
     [pubkey, isLoggedIn, signerType, getReadRelays, decryptNip04ViaSigner],
+  );
+
+  // Read-through (#868): paint the thread from the union of the per-conversation
+  // cache and the encrypted store BEFORE the relay fetch resolves, so a DM the
+  // inbox already ingested shows immediately and the thread is never behind the
+  // preview. Reads the SAME rows the inbox list is built from (getInboxLatest /
+  // getConversationMessages both read dm_messages), so they can't disagree.
+  const loadInitialConversation = useCallback(
+    (otherPubkey: string): Promise<ConversationMessage[]> =>
+      loadInitialConversationFor(otherPubkey, {
+        getCachedConversation,
+        getStoredRows: (peer) => {
+          if (!pubkey) return Promise.resolve([] as DmMessageRow[]);
+          const normalized = peer.trim().toLowerCase();
+          if (!/^[0-9a-f]{64}$/.test(normalized)) return Promise.resolve([] as DmMessageRow[]);
+          return getConversationMessages(pubkey, normalized, { limit: DM_CONV_CAP });
+        },
+      }),
+    [pubkey, getCachedConversation],
   );
 
   // Stable self-reference so the cold-start backfill can re-invoke
@@ -930,6 +959,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
     refreshDmInbox,
     fetchConversation,
     getCachedConversation,
+    loadInitialConversation,
     appendLocalDmMessage,
     persistDeliveryStatuses,
     armLiveDmSub,

--- a/src/hooks/useConversationLoader.ts
+++ b/src/hooks/useConversationLoader.ts
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { subscribeDmMessages } from '../contexts/nostrEventBus';
+import { reconcileDeliveryStatus } from '../contexts/nostrDmCache';
+import type { ConversationMessage } from '../contexts/nostrContextTypes';
+import type { ConversationMessageInput } from '../utils/conversationItems';
+import type { DeliveryStatus } from '../utils/dmDeliveryStatus';
+import { createAbortReplacer } from '../utils/abortReplace';
+
+// Owns the conversation thread's data lifecycle (#868): read-through paint from
+// the ingested store, the background relay top-up, abort-on-unmount, and
+// single-flight of re-entrant refreshes. Lifted out of ConversationScreen so the
+// screen is composition — and so the load orchestration is independently
+// readable. State (`messages`, `loading`, `refreshing`) lives here because the
+// load loop and the live-sub effect are the only writers; the screen consumes
+// the result and the composer hook still appends optimistic rows via setMessages.
+
+export interface UseConversationLoaderParams {
+  pubkey: string;
+  isLoggedIn: boolean;
+  fetchConversation: (
+    otherPubkey: string,
+    opts?: { signal?: AbortSignal },
+  ) => Promise<ConversationMessage[]>;
+  loadInitialConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
+  persistDeliveryStatuses: (
+    otherPubkey: string,
+    statusById: Record<string, DeliveryStatus>,
+  ) => Promise<void>;
+}
+
+export interface UseConversationLoaderResult {
+  messages: ConversationMessageInput[];
+  setMessages: React.Dispatch<React.SetStateAction<ConversationMessageInput[]>>;
+  loading: boolean;
+  refreshing: boolean;
+  handleRefresh: () => Promise<void>;
+}
+
+export function useConversationLoader({
+  pubkey,
+  isLoggedIn,
+  fetchConversation,
+  loadInitialConversation,
+  persistDeliveryStatuses,
+}: UseConversationLoaderParams): UseConversationLoaderResult {
+  const [messages, setMessages] = useState<ConversationMessageInput[]>([]);
+  // Mirror of `messages` for reads outside render (e.g. the delivery-tick
+  // reconcile in `load`, so persistence runs as a side-effect rather than
+  // inside a setMessages updater — Copilot #858).
+  const messagesRef = useRef<ConversationMessageInput[]>([]);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Mount/unmount tracker so the async `load()` below can bail when the user
+  // navigates back mid-fetch. Without this, every back-press during the 6-12 s
+  // cold fetchConversation still runs the full decrypt + persist chain on the
+  // unmounted component, wasting JS thread time that could have been responding
+  // to input. Declared BEFORE `load` because `load`'s body closes over it.
+  const isMountedRef = useRef(true);
+  // Single-flight + abort (#868): the controller for the in-flight conversation
+  // fetch. `load` aborts-and-replaces it on every call, so a re-entry (the mount
+  // effect firing again, a live-sub re-fetch, or a second pull) can't stack a
+  // second decrypt loop on the JS thread; the unmount cleanup aborts it so a
+  // back-press mid-fetch cancels the relay query + decrypt instead of letting it
+  // drain. At most one in-flight conversation fetch per screen instance.
+  // Lazily created on first access so the factory doesn't run on every render
+  // (and only once under StrictMode's double-invoke). Stable for the instance.
+  const fetchAbortRef = useRef<ReturnType<typeof createAbortReplacer> | null>(null);
+  if (fetchAbortRef.current === null) {
+    fetchAbortRef.current = createAbortReplacer();
+  }
+  useEffect(() => {
+    isMountedRef.current = true;
+    // Snapshot the replacer for the cleanup closure — it's created once and
+    // never reassigned, but copying it satisfies react-hooks/exhaustive-deps.
+    const replacer = fetchAbortRef.current;
+    return () => {
+      isMountedRef.current = false;
+      replacer?.abort();
+    };
+  }, []);
+
+  const load = useCallback(
+    async (showSpinner: boolean) => {
+      if (!isLoggedIn) {
+        setLoading(false);
+        return;
+      }
+      // Single-flight: cancel any in-flight fetch and replace it with this one,
+      // so a re-entrant load can never run two decrypt loops at once (#868).
+      // Non-null: the ref is initialized during render before any load can run.
+      const signal = fetchAbortRef.current!.begin();
+      // Read-through (#868): paint from the union of the per-conversation cache
+      // AND the encrypted store the inbox is built from — so a DM the inbox
+      // already ingested shows within one frame and the thread is never behind
+      // the preview. The relay fetch below is a background top-up, not a
+      // precondition for showing anything. Only show the spinner if BOTH are
+      // empty (a true cold open with nothing ingested yet).
+      const initial = await loadInitialConversation(pubkey);
+      if (signal.aborted || !isMountedRef.current) return;
+      if (initial.length > 0) {
+        setMessages(initial);
+        setLoading(false);
+      } else if (showSpinner) {
+        setLoading(true);
+      }
+      try {
+        const conv = await fetchConversation(pubkey, { signal });
+        // A superseding load (or unmount) aborted this fetch — drop the result
+        // so we don't setState on a cancelled / stale pass.
+        if (signal.aborted) return;
+        // If the user navigated away while the fetch was in flight, don't fire
+        // state updates — those would either trigger a re-render on an unmounted
+        // component (React warning) or land on the *next* thread that inherits
+        // this instance. Check the ref and bail.
+        if (isMountedRef.current) {
+          // Carry any delivery tick (#856) from the current in-memory rows onto
+          // the fetched list, so a just-sent bubble keeps its tick even when the
+          // relay echo lands before the optimistic row's async cache write
+          // commits (the on-disk merge would miss it in that race). Computed
+          // against messagesRef (not inside the setMessages updater) so the
+          // AsyncStorage write is a plain side-effect — keeps the updater pure
+          // and StrictMode-safe (Copilot #858).
+          const reconciled = reconcileDeliveryStatus(messagesRef.current, conv);
+          // Durably write the reconciled ticks back to the conv cache, keyed by
+          // the (now real-id) row id, so the tick survives a cold restart —
+          // fetchConversation persisted the echo rows WITHOUT delivery when it
+          // won the race against the optimistic local- write.
+          const statusById: Record<string, DeliveryStatus> = {};
+          for (const m of reconciled) {
+            if (m.deliveryStatus && !m.id.startsWith('local-')) {
+              statusById[m.id] = m.deliveryStatus;
+            }
+          }
+          void persistDeliveryStatuses(pubkey, statusById);
+          setMessages(reconciled);
+        }
+      } finally {
+        // Leave the spinner state to whichever load is current — an aborted /
+        // superseded pass must not clear a spinner the replacing load owns.
+        if (isMountedRef.current && !signal.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    [isLoggedIn, fetchConversation, loadInitialConversation, persistDeliveryStatuses, pubkey],
+  );
+
+  useEffect(() => {
+    load(true);
+  }, [load]);
+
+  // Live updates: NostrContext fires `subscribeDmMessages` after a kind-1059
+  // wrap arrives via the long-lived relay sub and decrypts to a 1:1 rumor for
+  // this thread's peer (#349). Re-fetching the conversation is cheap because the
+  // new wrap is now in the persistent NIP-17 cache, so fetchConversation
+  // short-circuits the relay round-trip and the thread re-renders within a tick.
+  useEffect(() => {
+    if (!pubkey) return;
+    const target = pubkey.toLowerCase();
+    const unsubscribe = subscribeDmMessages((partnerPubkey) => {
+      if (partnerPubkey !== target) return;
+      load(false);
+    });
+    return unsubscribe;
+  }, [pubkey, load]);
+
+  // Generation guard so overlapping pull-to-refreshes don't drop the spinner
+  // early (Copilot #869): `load` is single-flight and aborts the previous
+  // fetch, so an earlier call resolves as soon as it's superseded. Only the
+  // newest refresh clears `refreshing`; superseded ones leave it to the winner.
+  const refreshGenRef = useRef(0);
+  const handleRefresh = useCallback(async () => {
+    const gen = ++refreshGenRef.current;
+    setRefreshing(true);
+    try {
+      await load(false);
+    } finally {
+      if (refreshGenRef.current === gen) {
+        setRefreshing(false);
+      }
+    }
+  }, [load]);
+
+  return { messages, setMessages, loading, refreshing, handleRefresh };
+}

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -24,12 +24,7 @@ import { Image as ExpoImage } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  useNostr,
-  useNostrContacts,
-  useNostrDmInbox,
-  subscribeDmMessages,
-} from '../contexts/NostrContext';
+import { useNostr, useNostrContacts, useNostrDmInbox } from '../contexts/NostrContext';
 import { useWallet } from '../contexts/WalletContext';
 import { useThemeColors } from '../contexts/ThemeContext';
 import SendSheet from '../components/SendSheet';
@@ -65,12 +60,10 @@ import { useConversationLiveLocation } from '../hooks/useConversationLiveLocatio
 import {
   type Item,
   type TimedItem,
-  type ConversationMessageInput,
   buildZapItems,
   buildConversationItems,
 } from '../utils/conversationItems';
-import type { DeliveryStatus } from '../utils/dmDeliveryStatus';
-import { reconcileDeliveryStatus } from '../contexts/nostrDmCache';
+import { useConversationLoader } from '../hooks/useConversationLoader';
 import DeliveryDetailSheet from '../components/DeliveryDetailSheet';
 import { createConversationScreenStyles } from '../styles/ConversationScreen.styles';
 
@@ -103,7 +96,7 @@ const ConversationScreen: React.FC = () => {
   const {
     isLoggedIn,
     fetchConversation,
-    getCachedConversation,
+    loadInitialConversation,
     persistDeliveryStatuses,
     signerType,
     pubkey: myPubkey,
@@ -120,16 +113,15 @@ const ConversationScreen: React.FC = () => {
   const { wallets } = useWallet();
   const { startShare, stopShare } = useLiveLocation();
 
-  const [messages, setMessages] = useState<ConversationMessageInput[]>([]);
-  // Mirror of `messages` for reads outside render (e.g. the delivery-tick
-  // reconcile in `load`, so persistence runs as a side-effect rather than
-  // inside a setMessages updater — Copilot #858).
-  const messagesRef = useRef<ConversationMessageInput[]>([]);
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  // Thread data lifecycle — read-through paint, background relay top-up,
+  // abort-on-unmount, single-flight refresh (#868) — lives in this hook.
+  const { messages, setMessages, loading, refreshing, handleRefresh } = useConversationLoader({
+    pubkey,
+    isLoggedIn,
+    fetchConversation,
+    loadInitialConversation,
+    persistDeliveryStatuses,
+  });
   const [draft, setDraft] = useState('');
   const [sendSheetOpen, setSendSheetOpen] = useState(false);
   const [invoiceToPay, setInvoiceToPay] = useState<string | null>(null);
@@ -214,95 +206,6 @@ const ConversationScreen: React.FC = () => {
     () => buildConversationItems(resolvedMessages, zapItems),
     [resolvedMessages, zapItems],
   );
-
-  // Mount/unmount tracker so the async `load()` below can bail when
-  // the user navigates back mid-fetch. Without this, every back-press
-  // during the 6-12 s cold fetchConversation still runs the full
-  // decrypt + persist chain on the unmounted component, wasting JS
-  // thread time that could have been responding to input.
-  // Declared BEFORE `load` because `load`'s body closes over it.
-  const isMountedRef = useRef(true);
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  const load = useCallback(
-    async (showSpinner: boolean) => {
-      if (!isLoggedIn) {
-        setLoading(false);
-        return;
-      }
-      // Paint cached messages instantly if we have any — user sees a
-      // populated thread within one frame instead of "Loading…" for
-      // the 6-8 s relay round-trip. Arcade `db_only=true` pattern.
-      // Only show the spinner if the cache was empty (true cold open).
-      const cached = await getCachedConversation(pubkey);
-      if (isMountedRef.current && cached.length > 0) {
-        setMessages(cached);
-        setLoading(false);
-      } else if (isMountedRef.current && showSpinner) {
-        setLoading(true);
-      }
-      try {
-        const conv = await fetchConversation(pubkey);
-        // If the user navigated away while the fetch was in flight,
-        // don't fire state updates — those would either trigger a
-        // re-render on an unmounted component (React warning) or land
-        // on the *next* thread that inherits this instance. Check the
-        // ref and bail.
-        if (isMountedRef.current) {
-          // Carry any delivery tick (#856) from the current in-memory rows
-          // onto the fetched list, so a just-sent bubble keeps its tick even
-          // when the relay echo lands before the optimistic row's async cache
-          // write commits (the on-disk merge would miss it in that race).
-          // Computed against messagesRef (not inside the setMessages updater)
-          // so the AsyncStorage write is a plain side-effect — keeps the
-          // updater pure and StrictMode-safe (Copilot #858).
-          const reconciled = reconcileDeliveryStatus(messagesRef.current, conv);
-          // Durably write the reconciled ticks back to the conv cache, keyed
-          // by the (now real-id) row id, so the tick survives a cold restart
-          // — fetchConversation persisted the echo rows WITHOUT delivery when
-          // it won the race against the optimistic local- write.
-          const statusById: Record<string, DeliveryStatus> = {};
-          for (const m of reconciled) {
-            if (m.deliveryStatus && !m.id.startsWith('local-')) {
-              statusById[m.id] = m.deliveryStatus;
-            }
-          }
-          void persistDeliveryStatuses(pubkey, statusById);
-          setMessages(reconciled);
-        }
-      } finally {
-        if (isMountedRef.current) {
-          setLoading(false);
-        }
-      }
-    },
-    [isLoggedIn, fetchConversation, getCachedConversation, persistDeliveryStatuses, pubkey],
-  );
-
-  useEffect(() => {
-    load(true);
-  }, [load]);
-
-  // Live updates: NostrContext fires `subscribeDmMessages` after a
-  // kind-1059 wrap arrives via the long-lived relay sub and decrypts
-  // to a 1:1 rumor for this thread's peer (#349). Re-fetching the
-  // conversation is cheap because the new wrap is now in the
-  // persistent NIP-17 cache, so fetchConversation short-circuits the
-  // relay round-trip and the thread re-renders within one tick.
-  useEffect(() => {
-    if (!pubkey) return;
-    const target = pubkey.toLowerCase();
-    const unsubscribe = subscribeDmMessages((partnerPubkey) => {
-      if (partnerPubkey !== target) return;
-      load(false);
-    });
-    return unsubscribe;
-  }, [pubkey, load]);
 
   // Jump to the newest message on first content load, and when the user is
   // already near the bottom and a new message arrives. The list is
@@ -411,15 +314,6 @@ const ConversationScreen: React.FC = () => {
     },
     [presentContactSheet],
   );
-
-  const handleRefresh = useCallback(async () => {
-    setRefreshing(true);
-    try {
-      await load(false);
-    } finally {
-      setRefreshing(false);
-    }
-  }, [load]);
 
   // Append an optimistic local- message to BOTH React state (instant
   // paint) AND the per-conversation cache on disk (survives back-then-

--- a/src/utils/abortReplace.test.ts
+++ b/src/utils/abortReplace.test.ts
@@ -1,0 +1,53 @@
+import { createAbortReplacer } from './abortReplace';
+
+describe('createAbortReplacer (#868 single-flight)', () => {
+  it('begin() returns a live, un-aborted signal', () => {
+    const r = createAbortReplacer();
+    const sig = r.begin();
+    expect(sig.aborted).toBe(false);
+    expect(r.current).toBe(sig);
+  });
+
+  it('a second begin() aborts the previous run (replace, not stack)', () => {
+    const r = createAbortReplacer();
+    const first = r.begin();
+    const second = r.begin();
+    // The superseded run is cancelled so its decrypt loop bails at the next
+    // yield point instead of running concurrently with the replacement.
+    expect(first.aborted).toBe(true);
+    expect(second.aborted).toBe(false);
+    expect(r.current).toBe(second);
+  });
+
+  it('only ever exposes one in-flight signal', () => {
+    const r = createAbortReplacer();
+    r.begin();
+    r.begin();
+    const third = r.begin();
+    expect(r.current).toBe(third);
+    expect(third.aborted).toBe(false);
+  });
+
+  it('abort() cancels the current run and clears it (unmount)', () => {
+    const r = createAbortReplacer();
+    const sig = r.begin();
+    r.abort();
+    expect(sig.aborted).toBe(true);
+    expect(r.current).toBeNull();
+  });
+
+  it('abort() on an empty replacer is a no-op', () => {
+    const r = createAbortReplacer();
+    expect(() => r.abort()).not.toThrow();
+    expect(r.current).toBeNull();
+  });
+
+  it('begin() after abort() starts a fresh, un-aborted run', () => {
+    const r = createAbortReplacer();
+    r.begin();
+    r.abort();
+    const fresh = r.begin();
+    expect(fresh.aborted).toBe(false);
+    expect(r.current).toBe(fresh);
+  });
+});

--- a/src/utils/abortReplace.ts
+++ b/src/utils/abortReplace.ts
@@ -1,0 +1,36 @@
+// Abort-and-replace single-flight controller (#868). Holds at most one live
+// AbortController. Each `begin()` aborts the previous one and installs a fresh
+// controller, returning its signal — so a re-entrant caller (the conversation
+// screen's mount effect re-firing, a live-sub re-fetch, or a second
+// pull-to-refresh) supersedes the in-flight run instead of stacking a second
+// concurrent decrypt loop. `abort()` cancels the current run (unmount cleanup).
+//
+// This is the conversation-path analogue of refreshDmInbox's single-flight: the
+// inbox coalesces onto one in-flight promise; the thread, which must always
+// reflect the LATEST open, replaces rather than coalesces.
+export interface AbortReplacer {
+  /** Abort the previous run (if any) and start a new one. Returns its signal. */
+  begin: () => AbortSignal;
+  /** Abort the current run without starting a new one (e.g. on unmount). */
+  abort: () => void;
+  /** The current signal, or null if nothing is in flight. */
+  readonly current: AbortSignal | null;
+}
+
+export function createAbortReplacer(): AbortReplacer {
+  let controller: AbortController | null = null;
+  return {
+    begin() {
+      controller?.abort();
+      controller = new AbortController();
+      return controller.signal;
+    },
+    abort() {
+      controller?.abort();
+      controller = null;
+    },
+    get current() {
+      return controller?.signal ?? null;
+    },
+  };
+}


### PR DESCRIPTION
## What & why

Reported on v1.3.3 (Android). Opening a conversation showed the thread **empty/behind the inbox preview** until a second relay-fetch+decrypt completed, because the conversation screen re-fetched and re-decrypted the DM the inbox had **already ingested** instead of reading it through. Compounding it, conversation pull-to-refresh had **no AbortController and no re-entry guard**: navigating back mid-refresh left the decrypt loop running, and re-entering stacked a **second** decrypt loop on the JS thread — so the app locked until both drained.

This PR applies the three fixes the issue calls for, all in the DM conversation path.

### 1. Read-through the ingested store first
`loadInitialConversation` unions the per-conversation cache with `getConversationMessages` — the **same `dm_messages` rows the inbox preview is built from** (`getInboxLatest` and `getConversationMessages` both read that table, so they can't disagree). The thread now paints immediately and is **never emptier than the inbox preview**. The relay fetch becomes a background top-up, merged via the existing `mergeConversationMessages` (so local- echo dedup + delivery/rumorId carry-over behave exactly as before) — not a precondition for showing anything.

### 2. AbortSignal through the conversation fetch
`load` → `fetchConversation` → the relay query + decrypt loops now thread an `AbortSignal`. `fetchConversationFor` returns early when pre-aborted, **bails between NIP-04 decrypt batches** on abort (at the existing `nostrDecryptPacing` yield points), and skips the inbox-wide wrap fetch when aborted; `ingestInboxWraps` already honours the signal. The screen aborts on unmount. Mirrors the pattern `refreshDmInbox` already uses via `opts.signal`.

### 3. Single-flight / coalesce concurrent refreshes
`createAbortReplacer` (new, tested util) holds at most one live controller: each `load` aborts-and-replaces the in-flight one, so a re-entry (mount effect re-firing, live-sub re-fetch, or a second pull) **cannot stack a second concurrent decrypt loop**. Invariant: at most one in-flight conversation fetch per partner.

### Refactor (to respect the file-size cap)
The load/refresh/live-sub orchestration moved into **`useConversationLoader`**, so `ConversationScreen.tsx` drops from 982 → **876** lines (under the 1,000 cap). The now-dead `getCachedConversation` context surface was removed (its only remaining use is internal to `useDmInbox`, which the read-through composes), so **`NostrContext.tsx` shrank** (1838 → 1837, below baseline).

`GroupConversationScreen` loads from local group storage (`loadGroupMessages`) with no relay re-fetch/decrypt loop, so it does **not** share this `load`/refresh shape and needs no change.

## Stacking

**Stacked on #866** (which threads `rumorId` through `nostrFetchConversation`/`useDmInbox`/`ConversationScreen`) — this PR is based on `feat/dm-optimistic-send`, not `main`, because #868 touches the same files. **Rebase onto `main` after #866 merges.**

## Test plan

Unit tests (gates all green):
- `conversationReadThrough.test.ts` — read-through returns the ingested store message **before any relay fetch resolves** (modelled as a never-resolving promise; the read-through must not await it), unions cache + store deduping the echo, and degrades to whichever source survives.
- `nostrFetchConversationAbort.test.ts` — pre-aborted signal returns `[]` with **no relay query**; abort mid-flight **skips the inbox-wide wrap fetch**; control case runs it.
- `abortReplace.test.ts` — a second `begin()` **aborts the previous run** (replace, not stack); only one in-flight signal is ever exposed; `abort()` cancels + clears.

```
npx tsc --noEmit              # pass
npx eslint <changed files>    # 0 errors (no new warnings)
npx prettier --check          # all files use Prettier style
bash scripts/check-file-size.sh  # pass
npx jest                      # 99 suites, 1155 tests pass
```

**On-device repro verification deferred** (emulator in use elsewhere for unrelated screenshot work). The fix is covered by the unit tests above; manual Pixel/emulator verification of the repro steps (open → message present immediately; pull-to-refresh → back → re-enter → no lock) to follow.

Closes #868
