### PR TITLE
fix(payments): keep success/receive overlay dismissable — defer post-payment refresh off the JS thread (#859, #828)

### DIFF
--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -51,6 +51,7 @@ import { npubEncode } from '../services/nostrService';
 import { recordOutgoing as recordOutgoingCounterparty } from '../services/zapCounterpartyStorage';
 import { isReplyTimeoutError, isConnectionError } from '../services/nwcService';
 import PaymentProgressOverlay, { PaymentProgressState } from './PaymentProgressOverlay';
+import { deferPostPaymentRefresh } from '../utils/deferPostPaymentRefresh';
 import AmountEntryScreen from './AmountEntryScreen';
 import SendAmountSection from './SendAmountSection';
 import SendModeTabs, { type SendInputMode } from './SendModeTabs';
@@ -682,7 +683,10 @@ const SendSheet: React.FC<Props> = ({
         // We also refetch a second time in case the first call raced.
         await refreshBalanceForWallet(walletId);
         const capturedWalletId = walletId;
-        (async () => {
+        // Defer the heavy tx-list refresh (JSON.stringify + zap resolver)
+        // off the interaction path so the success overlay's OK tap is
+        // serviced immediately rather than blocked behind it (#859, #828).
+        deferPostPaymentRefresh(async () => {
           try {
             await new Promise((r) => setTimeout(r, 600));
             await fetchTransactionsForWallet(capturedWalletId);
@@ -692,7 +696,7 @@ const SendSheet: React.FC<Props> = ({
             // Refresh failures are non-fatal — a manual pull-to-refresh
             // or the next natural refresh will pick the tx up.
           }
-        })();
+        });
       }
       if (signal.aborted) return;
       if (dismissedInFlightRef.current) return;

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -20,8 +20,10 @@ import { computePendingHash, shouldSkipResolve } from '../utils/zapResolverGuard
 import { singleFlight } from '../utils/singleFlight';
 import {
   pickNewReceipts,
+  pickNewerReceipt,
   settledIncomingHashes,
   shouldSeedBaseline,
+  type AnnouncedReceipt,
 } from '../utils/incomingReceipts';
 import { mapNwcTransactions, type NwcRawTransaction } from '../utils/nwcTransactions';
 import * as swapRecoveryService from '../services/swapRecoveryService';
@@ -37,6 +39,7 @@ import {
   ZapCounterpartyInfo,
   walletLabel,
 } from '../types/wallet';
+import { deferPostPaymentRefresh } from '../utils/deferPostPaymentRefresh';
 
 // Captured at module-evaluation time, which is the closest proxy we have to "JS bundle started executing after app launch". Used by the [Perf] wallet-connect marker so perf scripts can report time-from-launch-to-first-NWC-connect without needing a separate launch timestamp source.
 const WALLET_MODULE_LOAD_T0 = Date.now();
@@ -1872,9 +1875,11 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     // refresh here would be a redundant list_transactions round-trip. Only the
     // expectPayment path needs it (the list may not yet include the settle).
     if (lastIncomingPayment.fromTxList) return;
-    fetchTransactionsForWallet(lastIncomingPayment.walletId).catch(() => {
-      // Non-fatal: next organic refresh will pick the tx up.
-    });
+    const walletId = lastIncomingPayment.walletId;
+    // Defer past the interaction frame so the overlay's dismiss tap is serviced
+    // before this heavy refresh runs on the JS thread (#859, #828).
+    const handle = deferPostPaymentRefresh(() => fetchTransactionsForWallet(walletId));
+    return () => handle.cancel();
     // Intentionally only fire on `lastIncomingPayment` changes; the
     // callback identity is stable enough across renders that adding it
     // would double-fetch on unrelated renders.
@@ -1896,15 +1901,20 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         AsyncStorage.removeItem(`seenReceipts_${id}`).catch(() => {});
       }
 
+    const handles: { cancel: () => void }[] = [];
     for (const wallet of wallets) {
       const bal = wallet.balance;
       if (bal === null || bal === undefined) continue;
       const prev = baselines.get(wallet.id);
       baselines.set(wallet.id, bal);
       if (prev !== undefined && bal > prev) {
-        void fetchTransactionsForWallet(wallet.id).catch(() => {});
+        // A balance bump is when the receive overlay pops — defer the refresh
+        // off the interaction path so the dismiss tap stays responsive (#859).
+        const walletId = wallet.id;
+        handles.push(deferPostPaymentRefresh(() => fetchTransactionsForWallet(walletId)));
       }
     }
+    return () => handles.forEach((h) => h.cancel());
     // fetchTransactionsForWallet is a stable useCallback; omitting it from deps
     // avoids re-running on unrelated renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1939,13 +1949,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     // setLastIncomingPayment is one state value — calling it in a loop would
     // batch and keep only the last, dropping the rest (#655 review). Pick the
     // newest by settled_at, deterministically, across all wallets.
-    let newest: {
-      walletId: string;
-      amountSats: number;
-      paymentHash: string;
-      settledAt: number;
-    } | null = null;
-    let newestLabel = '';
+    let newest: AnnouncedReceipt | null = null;
     for (const wallet of wallets) {
       const txns = wallet.transactions ?? [];
       const seen = seenReceiptsRef.current.get(wallet.id);
@@ -1958,10 +1962,11 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       for (const receipt of pickNewReceipts(txns, seen)) {
         seen.add(receipt.paymentHash);
         changed = true;
-        if (!newest || receipt.settledAt > newest.settledAt) {
-          newest = { walletId: wallet.id, ...receipt };
-          newestLabel = walletLabel(wallet);
-        }
+        newest = pickNewerReceipt(newest, {
+          ...receipt,
+          walletId: wallet.id,
+          walletLabel: walletLabel(wallet),
+        });
       }
       // Persist the moment a new receipt is seen so a reload before the next
       // write can't re-announce it.
@@ -1970,7 +1975,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     if (newest) {
       if (__DEV__)
         console.log(
-          `[Wallet] incoming payment detected: +${newest.amountSats} sats on ${newestLabel} (${newest.paymentHash.slice(0, 12)}…)`,
+          `[Wallet] incoming payment detected: +${newest.amountSats} sats on ${newest.walletLabel} (${newest.paymentHash.slice(0, 12)}…)`,
         );
       setLastIncomingPayment({
         walletId: newest.walletId,

--- a/src/utils/deferPostPaymentRefresh.test.ts
+++ b/src/utils/deferPostPaymentRefresh.test.ts
@@ -1,0 +1,92 @@
+import { deferPostPaymentRefresh, type InteractionScheduler } from './deferPostPaymentRefresh';
+
+// A controllable fake of InteractionManager: it captures the queued task
+// instead of running it, so a test can assert the refresh is scheduled
+// off the interaction path (deferred) rather than run synchronously —
+// the core guarantee of #859 / #828 (the overlay dismiss is never gated
+// behind the refresh).
+function makeFakeScheduler() {
+  const tasks: (() => void)[] = [];
+  let cancelled = 0;
+  const scheduler: InteractionScheduler = {
+    runAfterInteractions(task: () => void) {
+      tasks.push(task);
+      return {
+        cancel() {
+          cancelled += 1;
+        },
+      };
+    },
+  };
+  return {
+    scheduler,
+    runQueued: () => tasks.forEach((t) => t()),
+    pendingCount: () => tasks.length,
+    cancelledCount: () => cancelled,
+  };
+}
+
+describe('deferPostPaymentRefresh', () => {
+  it('does NOT run the refresh synchronously — it schedules it after interactions', () => {
+    const refresh = jest.fn();
+    const fake = makeFakeScheduler();
+
+    deferPostPaymentRefresh(refresh, fake.scheduler);
+
+    // The dismiss tap path is never blocked: nothing ran inline.
+    expect(refresh).not.toHaveBeenCalled();
+    expect(fake.pendingCount()).toBe(1);
+  });
+
+  it('runs the refresh once the interaction frame settles', () => {
+    const refresh = jest.fn();
+    const fake = makeFakeScheduler();
+
+    deferPostPaymentRefresh(refresh, fake.scheduler);
+    fake.runQueued();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel() drops a not-yet-run refresh (effect cleanup / unmount)', () => {
+    const refresh = jest.fn();
+    const fake = makeFakeScheduler();
+
+    const handle = deferPostPaymentRefresh(refresh, fake.scheduler);
+    handle.cancel();
+
+    expect(fake.cancelledCount()).toBe(1);
+  });
+
+  it('swallows a synchronous throw from the refresh so the UI cannot crash', () => {
+    const refresh = jest.fn(() => {
+      throw new Error('refresh boom');
+    });
+    const fake = makeFakeScheduler();
+
+    deferPostPaymentRefresh(refresh, fake.scheduler);
+
+    expect(() => fake.runQueued()).not.toThrow();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a rejected promise from an async refresh', async () => {
+    const refresh = jest.fn(() => Promise.reject(new Error('async boom')));
+    const fake = makeFakeScheduler();
+
+    deferPostPaymentRefresh(refresh, fake.scheduler);
+    fake.runQueued();
+
+    // Give the rejected promise a tick to settle; no unhandled rejection.
+    await Promise.resolve();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to the real InteractionManager when no scheduler is passed', () => {
+    const refresh = jest.fn();
+    // Should not throw and should return a handle with cancel().
+    const handle = deferPostPaymentRefresh(refresh);
+    expect(typeof handle.cancel).toBe('function');
+    handle.cancel();
+  });
+});

--- a/src/utils/deferPostPaymentRefresh.test.ts
+++ b/src/utils/deferPostPaymentRefresh.test.ts
@@ -6,22 +6,27 @@ import { deferPostPaymentRefresh, type InteractionScheduler } from './deferPostP
 // the core guarantee of #859 / #828 (the overlay dismiss is never gated
 // behind the refresh).
 function makeFakeScheduler() {
-  const tasks: (() => void)[] = [];
+  // Model real InteractionManager semantics: cancel() removes the task from
+  // the queue so a later "interactions settled" tick (runQueued) does NOT run
+  // it. This lets the cancel test verify the contract behaviourally, not just
+  // that cancel was forwarded (Copilot review on #875).
+  const tasks = new Set<() => void>();
   let cancelled = 0;
   const scheduler: InteractionScheduler = {
     runAfterInteractions(task: () => void) {
-      tasks.push(task);
+      tasks.add(task);
       return {
         cancel() {
           cancelled += 1;
+          tasks.delete(task);
         },
       };
     },
   };
   return {
     scheduler,
-    runQueued: () => tasks.forEach((t) => t()),
-    pendingCount: () => tasks.length,
+    runQueued: () => [...tasks].forEach((t) => t()),
+    pendingCount: () => tasks.size,
     cancelledCount: () => cancelled,
   };
 }
@@ -55,7 +60,14 @@ describe('deferPostPaymentRefresh', () => {
     const handle = deferPostPaymentRefresh(refresh, fake.scheduler);
     handle.cancel();
 
+    // cancel was forwarded to the scheduler handle...
     expect(fake.cancelledCount()).toBe(1);
+    expect(fake.pendingCount()).toBe(0);
+
+    // ...and crucially, a later "interactions settled" tick does NOT run the
+    // cancelled refresh — the contract effect cleanup relies on.
+    fake.runQueued();
+    expect(refresh).not.toHaveBeenCalled();
   });
 
   it('swallows a synchronous throw from the refresh so the UI cannot crash', () => {

--- a/src/utils/deferPostPaymentRefresh.ts
+++ b/src/utils/deferPostPaymentRefresh.ts
@@ -1,0 +1,51 @@
+import { InteractionManager } from 'react-native';
+
+// Why this exists (#859, #828): when a payment lands (send-success or
+// receive), the success/receive overlay paints, but the post-payment
+// refresh (tx fetch, the tx-blob JSON.stringify, zap-sender resolution)
+// runs synchronously on the same single JS thread that has to service the
+// OK / tap-to-close press. The thread is busy, so the dismiss tap is
+// dropped until the heavy work finishes — the overlay looks frozen, then
+// snaps closed (same class as the cold-start DM freeze, #846).
+//
+// The dismiss must NEVER be gated behind the refresh. We push the refresh
+// past the interaction frame with InteractionManager.runAfterInteractions:
+// React paints the overlay and any queued touch (the OK tap) is serviced
+// first, THEN the refresh runs and the balance / tx list / zaps catch up
+// underneath. The user-facing guarantee: the moment the card is up, OK
+// works instantly.
+
+// The slice of InteractionManager we depend on — narrowed so tests can
+// pass a fake scheduler without dragging in the whole RN module.
+export interface InteractionScheduler {
+  runAfterInteractions(task: () => void): { cancel: () => void };
+}
+
+export interface DeferredRefreshHandle {
+  // Cancel a not-yet-run deferred refresh (effect cleanup / unmount).
+  cancel(): void;
+}
+
+// Schedule `refresh` to run AFTER the current interaction/animation frame
+// settles, so it never blocks the overlay's dismiss tap. Returns a handle
+// whose cancel() drops the task if it hasn't run yet.
+//
+// `refresh` is invoked fire-and-forget; if it returns a promise its
+// rejection is swallowed (a failed background refresh must not crash the
+// app — the next organic refresh picks the data up).
+export function deferPostPaymentRefresh(
+  refresh: () => void | Promise<void>,
+  scheduler: InteractionScheduler = InteractionManager,
+): DeferredRefreshHandle {
+  const handle = scheduler.runAfterInteractions(() => {
+    try {
+      const maybePromise = refresh();
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.catch(() => {});
+      }
+    } catch {
+      // Non-fatal: swallow so a throwing refresh can't take down the UI.
+    }
+  });
+  return { cancel: () => handle.cancel() };
+}

--- a/src/utils/incomingReceipts.test.ts
+++ b/src/utils/incomingReceipts.test.ts
@@ -1,8 +1,10 @@
 import {
   pickNewReceipts,
+  pickNewerReceipt,
   settledIncomingHashes,
   isValidPaymentHash,
   shouldSeedBaseline,
+  type AnnouncedReceipt,
 } from './incomingReceipts';
 import type { WalletTransaction } from '../types/wallet';
 
@@ -73,6 +75,36 @@ describe('pickNewReceipts (#653 — dedup receives by payment_hash)', () => {
     expect(pickNewReceipts(txns, new Set([H1]))).toEqual([
       { paymentHash: H2, amountSats: 222, settledAt: 200 },
     ]);
+  });
+});
+
+describe('pickNewerReceipt (#859 — announce one, the most recent)', () => {
+  const r = (settledAt: number, walletId = 'w', paymentHash = H1): AnnouncedReceipt => ({
+    paymentHash,
+    amountSats: 1,
+    settledAt,
+    walletId,
+    walletLabel: walletId,
+  });
+
+  it('takes the candidate when there is no current winner yet', () => {
+    const cand = r(100);
+    expect(pickNewerReceipt(null, cand)).toBe(cand);
+  });
+
+  it('keeps the later-settled receipt when the candidate is older', () => {
+    const current = r(200, 'a');
+    expect(pickNewerReceipt(current, r(100, 'b'))).toBe(current);
+  });
+
+  it('switches to the candidate when it settled later', () => {
+    const candidate = r(300, 'b');
+    expect(pickNewerReceipt(r(200, 'a'), candidate)).toBe(candidate);
+  });
+
+  it('keeps the existing winner on an exact tie (stable, deterministic)', () => {
+    const current = r(150, 'a');
+    expect(pickNewerReceipt(current, r(150, 'b'))).toBe(current);
   });
 });
 

--- a/src/utils/incomingReceipts.ts
+++ b/src/utils/incomingReceipts.ts
@@ -59,6 +59,25 @@ export function shouldSeedBaseline(
   return existingBaseline === undefined;
 }
 
+// A new receipt tagged with which wallet (and label) it belongs to — the unit
+// the receive detector picks a single winner from across all wallets.
+export interface AnnouncedReceipt extends NewReceipt {
+  walletId: string;
+  walletLabel: string;
+}
+
+// Pick the newer of two candidate receipts deterministically (latest
+// settledAt wins). The overlay shows ONE payment per render, so when several
+// wallets each surface a fresh receive in the same tick we announce only the
+// most recent — extracted so the tie-break is unit-testable (#859, #828).
+export function pickNewerReceipt(
+  current: AnnouncedReceipt | null,
+  candidate: AnnouncedReceipt,
+): AnnouncedReceipt {
+  if (!current || candidate.settledAt > current.settledAt) return candidate;
+  return current;
+}
+
 // All payment_hashes of settled incoming txns (well-formed only) — used to seed
 // the seen-set on first sight of a wallet (silent baseline: no launch re-announce).
 export function settledIncomingHashes(transactions: readonly WalletTransaction[]): Set<string> {


### PR DESCRIPTION
## What & why

When a payment is **received** (with a notification) or **successfully sent**, the success/receive overlay appears but **can't be dismissed** — tapping OK does nothing for several seconds, then it snaps closed on its own. The thread is "locked".

### Root cause (confirmed from the issue diagnosis)

The dismiss is wired correctly — send-success and incoming-payment use the same `PaymentProgressOverlay` (`App.tsx` `GlobalIncomingPaymentOverlay`), whose OK button calls `onDismiss` → `clearLastIncomingPayment`. The OK button is never `disabled` in the `success` state.

The lock is a **blocked JS thread** at the moment the overlay paints. A payment event kicks off heavy synchronous work on the same single JS thread that processes taps:

- `fetchTransactionsForWallet` does `mapNwcTransactions` + a `JSON.stringify` of the tx blob, then
- kicks off `resolveZapSendersForWallet` (the ~300-line zap-attribution state machine).

These fire from the receive-detector effect (`WalletContext` — runs when `lastIncomingPayment` is set), the balance-bump effect (runs on the same balance increase), and the send-success path (`SendSheet`). React has painted the overlay, but the OK `onPress` can't run until the thread frees → frozen, then snaps closed. Same class as the cold-start DM freeze (#846).

### The fix

Push the post-payment refresh **past the interaction frame** so the dismiss tap is serviced first:

- New `src/utils/deferPostPaymentRefresh.ts` — a small, testable wrapper over `InteractionManager.runAfterInteractions` (the pattern already used across `NostrContext` / `HomeScreen` / `MapScreen`). Returns a cancel handle for effect cleanup; swallows refresh errors so a background failure can't crash the UI.
- `WalletContext.tsx` — the receive-detector refresh and the balance-bump refresh now schedule via `deferPostPaymentRefresh` (with effect-cleanup cancellation).
- `SendSheet.tsx` — the send-success tx-list refresh is deferred the same way.
- The dismiss is **never** gated on the refresh completing — it can fire while a background refresh is in flight.

The refresh itself is unchanged (balance / tx list / zaps still update) — it just no longer blocks the UI thread at the dismiss moment.

To keep `WalletContext` (an over-cap file) at its baseline line count, the "announce the newest of several simultaneous receipts" tie-break was extracted to a pure `pickNewerReceipt()` in `incomingReceipts.ts`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` (changed files) — 0 errors (1 pre-existing `import/first` warning on the existing `perfLog` import)
- [x] `npx prettier --check` (changed files) — clean
- [x] `bash scripts/check-file-size.sh` — passes (`WalletContext.tsx` held at baseline 2173)
- [x] `npx jest` — full suite green (103 suites, 1203 tests)
- New unit tests:
  - `deferPostPaymentRefresh.test.ts` — refresh is **not** run synchronously (scheduled after interactions); runs once the frame settles; `cancel()` drops a pending refresh; sync throw and async rejection are swallowed.
  - `incomingReceipts.test.ts` — `pickNewerReceipt` picks the latest-settled, keeps the existing winner on a tie (deterministic).

### On-device verification (deferred to maintainer)

Per the task, on-device verification is deferred — I did not run adb / Metro / the emulator (an emulator perf run was in progress on the main checkout). To verify: receive a 1–2 sat payment from a Piggy and confirm the overlay's OK dismisses **instantly**; with perf logs on, the multi-second `[Perf] heartbeat gap` should move off the interaction window (or shrink).

Closes #859
Closes #828
