### PR TITLE
chore(release): v1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Bumps the marketing version to **1.3.4** (`package.json` → flows into `app.config.ts` `version: pkg.version`).

This is the source-of-truth bump for the v1.3.4 release; the actual cloud builds are driven by the `v1.3.4` tag via `.github/workflows/release.yml` (which writes the version from the tag). Bumping main keeps the next `npm version` correct.

## Test plan
- `npm version patch --no-git-tag-version` only touched `package.json` (+ lockfile if present).
- CI gates (tsc/eslint/prettier/jest/file-size) confirm no functional change.

Release notes for v1.3.4 are attached to the GitHub Release.