### PR TITLE
fix(send): open Send sheet regardless of camera-permission hook state (#878)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -195,6 +195,28 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // it twice makes the second config win silently, so keep the single
     // entry above. No FCM / no remote push — all fired on-device.
     'expo-task-manager',
+    // expo-build-properties — inject R8/proguard keep rules into the CNG
+    // prebuild output. Production builds run R8 minification, which strips
+    // expo-camera's MLKit barcode classes (loaded dynamically), so the QR
+    // scanner previews but never decodes in release. Editing
+    // android/proguard-rules.pro directly would be wiped by prebuild, so the
+    // keeps live here. See the linked bug for the full root cause.
+    [
+      'expo-build-properties',
+      {
+        android: {
+          extraProguardRules: [
+            '# Keep MLKit barcode scanning (expo-camera QR scanner) from R8 stripping',
+            '-keep class com.google.mlkit.** { *; }',
+            '-keep class com.google.android.gms.internal.mlkit_vision_** { *; }',
+            '-dontwarn com.google.mlkit.**',
+            '-keep class com.google.android.gms.vision.** { *; }',
+            '# Keep expo-camera native module',
+            '-keep class expo.modules.camera.** { *; }',
+          ].join('\n'),
+        },
+      },
+    ],
   ],
   android: {
     adaptiveIcon: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "expo-asset": "~55.0.17",
         "expo-audio": "~55.0.14",
         "expo-background-task": "~55.0.18",
+        "expo-build-properties": "~55.0.14",
         "expo-calendar": "~55.0.14",
         "expo-camera": "~55.0.11",
         "expo-clipboard": "~55.0.9",
@@ -2102,9 +2103,9 @@
       }
     },
     "node_modules/@expo/schema-utils": {
-      "version": "55.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.3.tgz",
-      "integrity": "sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==",
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.4.tgz",
+      "integrity": "sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==",
       "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -7515,6 +7516,20 @@
       "license": "MIT",
       "dependencies": {
         "expo-task-manager": "~55.0.16"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.14.tgz",
+      "integrity": "sha512-5wopuLXlzFpDnCfsIjgAcj4yKnVTYg3XYGnYV5Hqi7u6jJipLG4fwtUqxVIFqBj7vEHXjd4zYCyXjp39AtAD7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.4",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
       },
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "expo-asset": "~55.0.17",
     "expo-audio": "~55.0.14",
     "expo-background-task": "~55.0.18",
+    "expo-build-properties": "~55.0.14",
     "expo-calendar": "~55.0.14",
     "expo-camera": "~55.0.11",
     "expo-clipboard": "~55.0.9",

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -177,7 +177,10 @@ const SendSheet: React.FC<Props> = ({
       setDecoded(null);
       setScanned(false);
       setSending(false);
-      setInputMode(initialAddress ? 'paste' : 'scan');
+      // Default to the paste tab unless the camera is actually usable — opening
+      // on a scanner that can't start (permission unresolved/denied) is a
+      // dead-end; the user can still switch to Scan, which prompts for access.
+      setInputMode(initialAddress || !permission?.granted ? 'paste' : 'scan');
       setPasteText(initialAddress || '');
       setSatsValue('');
       setStep('main');
@@ -817,7 +820,13 @@ const SendSheet: React.FC<Props> = ({
     [],
   );
 
-  if (!visible || !permission) return null;
+  // Open the sheet whenever it's asked to be visible. Do NOT gate on the
+  // camera-permission hook: `useCameraPermissions()` can stay `null` (e.g. the
+  // hook hasn't resolved, or returns null on some devices even when the OS
+  // permission is granted), and gating here made the whole sheet render null so
+  // `.present()` no-op'd and Send silently never opened. Only the scanner tab
+  // needs the permission, and it handles a missing one with its own prompt.
+  if (!visible) return null;
 
   // On-chain sends from a hot on-chain wallet go direct; otherwise they
   // hop through a Boltz reverse swap whose server-reported min/max must
@@ -945,7 +954,7 @@ const SendSheet: React.FC<Props> = ({
                   />
                 ) : inputMode === 'scan' ? (
                   <SendScanPane
-                    permissionGranted={permission.granted}
+                    permissionGranted={!!permission?.granted}
                     onRequestPermission={requestPermission}
                     onBarcodeScanned={handleBarCodeScanned}
                   />


### PR DESCRIPTION
## Problem
Tapping **Send** does nothing on some devices — button reacts, but no bottom sheet and **no backdrop dim**. Confirmed on a physical Pixel 8 (release) on v1.3.3 + v1.3.4. Receive/Transfer fine.

`SendSheet` gated the **whole component** on the camera-permission hook:
```ts
if (!visible || !permission) return null;   // permission = useCameraPermissions()
```
When `permission` is `null` at tap time, the component renders null → `<BottomSheetModal>` never mounts → the `present()` in the `[visible]` effect no-ops → never retried. "No backdrop" confirmed the component returned null.

On the affected Pixel the hook appears to stay `null` **even though the OS permission is granted** (revoking + re-granting didn't change the behaviour), so the sheet is permanently gated off. A related open-race also shows on iOS as "tap Send twice".

## Fix
Only the scanner tab needs the camera:
- render gate → `if (!visible) return null;` (don't gate on `permission`)
- `permissionGranted={!!permission?.granted}` (null-safe)
- default to the **Paste** tab when the camera isn't usable, so the sheet opens on a working tab

## Test plan
- tsc / eslint / prettier / file-size — green (SendSheet 1171 ≤ baseline).
- Components are excluded from unit scope; **on-device verification REQUIRED** on the affected Pixel via a production APK of this branch (not yet done — the failure only reproduces on that device's release build, not the dev emulator where the hook resolves).

Closes #878