### PR TITLE
fix(android): keep MLKit/expo-camera classes from R8 so the QR scanner works in production (#880)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -195,6 +195,28 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // it twice makes the second config win silently, so keep the single
     // entry above. No FCM / no remote push — all fired on-device.
     'expo-task-manager',
+    // expo-build-properties — inject R8/proguard keep rules into the CNG
+    // prebuild output. Production builds run R8 minification, which strips
+    // expo-camera's MLKit barcode classes (loaded dynamically), so the QR
+    // scanner previews but never decodes in release. Editing
+    // android/proguard-rules.pro directly would be wiped by prebuild, so the
+    // keeps live here. See the linked bug for the full root cause.
+    [
+      'expo-build-properties',
+      {
+        android: {
+          extraProguardRules: [
+            '# Keep MLKit barcode scanning (expo-camera QR scanner) from R8 stripping',
+            '-keep class com.google.mlkit.** { *; }',
+            '-keep class com.google.android.gms.internal.mlkit_vision_** { *; }',
+            '-dontwarn com.google.mlkit.**',
+            '-keep class com.google.android.gms.vision.** { *; }',
+            '# Keep expo-camera native module',
+            '-keep class expo.modules.camera.** { *; }',
+          ].join('\n'),
+        },
+      },
+    ],
   ],
   android: {
     adaptiveIcon: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "expo-asset": "~55.0.17",
         "expo-audio": "~55.0.14",
         "expo-background-task": "~55.0.18",
+        "expo-build-properties": "~55.0.14",
         "expo-calendar": "~55.0.14",
         "expo-camera": "~55.0.11",
         "expo-clipboard": "~55.0.9",
@@ -2102,9 +2103,9 @@
       }
     },
     "node_modules/@expo/schema-utils": {
-      "version": "55.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.3.tgz",
-      "integrity": "sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==",
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.4.tgz",
+      "integrity": "sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==",
       "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -7515,6 +7516,20 @@
       "license": "MIT",
       "dependencies": {
         "expo-task-manager": "~55.0.16"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.14.tgz",
+      "integrity": "sha512-5wopuLXlzFpDnCfsIjgAcj4yKnVTYg3XYGnYV5Hqi7u6jJipLG4fwtUqxVIFqBj7vEHXjd4zYCyXjp39AtAD7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.4",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
       },
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "expo-asset": "~55.0.17",
     "expo-audio": "~55.0.14",
     "expo-background-task": "~55.0.18",
+    "expo-build-properties": "~55.0.14",
     "expo-calendar": "~55.0.14",
     "expo-camera": "~55.0.11",
     "expo-clipboard": "~55.0.9",


### PR DESCRIPTION
## What

Adds the `expo-build-properties` config plugin and injects R8/proguard **keep** rules so the production QR scanner actually decodes.

```
-keep class com.google.mlkit.** { *; }
-keep class com.google.android.gms.internal.mlkit_vision_** { *; }
-dontwarn com.google.mlkit.**
-keep class com.google.android.gms.vision.** { *; }
-keep class expo.modules.camera.** { *; }
```

## Why

In **production (R8-minified) builds** the Send QR scanner previews the camera but never decodes a code. Root cause:

- `android/` is CNG/prebuild output (gitignored); the app had **no** `expo-build-properties` plugin and the only keeps were Reanimated + TurboModule.
- Production runs R8 minification. expo-camera's QR scanner uses MLKit (`com.google.mlkit:barcode-scanning` + `androidx.camera:camera-mlkit-vision`), loaded **dynamically** — so R8 sees no static reference and strips those classes → preview works, decode doesn't.
- Dev/preview builds don't minify the same way, so they scan fine (the v1.2.1 preview works, production v1.3.x doesn't).

Editing `android/proguard-rules.pro` directly is not viable — prebuild wipes it — so the keeps go through `app.config.ts` → `expo-build-properties`, which writes them into the prebuild output.

## Stacking

Stacked on **#879 (#878)** — based on `fix/send-sheet-camera-permission-gate` rather than `main` — so a single build carries **both** fixes: #878's sheet-open / permission-gate workaround **and** the underlying R8 strip that this PR addresses. Merge #879 first, then re-target this to `main` (or merge in order).

## Test plan

- **Needs a production build + on-device scan test — cannot be reproduced in dev/preview** (those builds don't minify the MLKit classes the same way).
- Build a production APK, open Send → scan a Lightning QR, confirm it decodes and populates the address field.
- Gates run locally and pass: `tsc --noEmit`, `eslint`, `prettier --check`, `scripts/check-file-size.sh`, `jest` (109 suites / 1242 tests), and `expo config` resolves with the keep rules present in the merged Android config.

Closes #880