### PR TITLE
chore(release): v1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Version bump to **v1.3.5** (marketing version source of truth; the EAS build version is also written from the `v1.3.5` release tag by `release.yml`).

Bundles what merged since v1.3.4:
- #879 — open the Send sheet regardless of the camera-permission hook state
- #881 — keep MLKit/expo-camera classes from R8 so the QR scanner works in production
- #882 — add BitPopArt wallet card design
- #883 — slim the EAS upload (`.easignore`, drop bugreport zip, compress card images)

## Test plan

N/A — release version bump only (package.json + lock). The bundled changes were each verified in their own PRs; the camera/Send-sheet fix was additionally verified on a physical Pixel 8 release build (see #879).

🤖 Generated with [Claude Code](https://claude.com/claude-code)