### PR TITLE
fix(nav): stop replaying a stale action on cold start (#886)

### DIFF
--- a/src/utils/navigationStatePersistence.test.ts
+++ b/src/utils/navigationStatePersistence.test.ts
@@ -232,6 +232,13 @@ describe('sanitizeNavigationState — replay guard (#886)', () => {
     expect(sanitizeNavigationState({} as unknown as NavigationState)).toEqual({});
   });
 
+  it('collapses an empty-routes stack to undefined (no index -1 crash)', () => {
+    // A malformed-but-JSON-valid blob with zero routes would otherwise yield
+    // index = routes.length - 1 = -1 and crash NavigationContainer on mount.
+    const empty = { index: 0, routeNames: [], routes: [] } as unknown as NavigationState;
+    expect(sanitizeNavigationState(empty)).toBeUndefined();
+  });
+
   it('load() heals an already-persisted stale invoice (sanitize on read)', async () => {
     await AsyncStorage.setItem(
       NAV_STATE_KEY,

--- a/src/utils/navigationStatePersistence.test.ts
+++ b/src/utils/navigationStatePersistence.test.ts
@@ -5,6 +5,7 @@ import {
   clearPersistedNavigationState,
   loadPersistedNavigationState,
   persistNavigationState,
+  sanitizeNavigationState,
 } from './navigationStatePersistence';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
@@ -114,23 +115,144 @@ describe('navigationStatePersistence — defensive parsing', () => {
     expect(await loadPersistedNavigationState()).toBeUndefined();
   });
 
+  // NB: these use `mockRejectedValueOnce` directly on the mock fn rather than
+  // `jest.spyOn(...).mockRestore()`. `spyOn` + `mockRestore` on the
+  // async-storage jest mock swaps in a bare jest.fn() that drops the in-memory
+  // storage backing, silently breaking setItem/getItem for EVERY later test in
+  // the file. `mockRejectedValueOnce` queues one rejection then reverts to the
+  // mock's default storage-backed impl on its own — no restore, no fallout.
   it('swallows AsyncStorage failures on load', async () => {
-    const spy = jest.spyOn(AsyncStorage, 'getItem').mockRejectedValueOnce(new Error('disk full'));
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
     expect(await loadPersistedNavigationState()).toBeUndefined();
-    spy.mockRestore();
   });
 
   it('swallows AsyncStorage failures on save', async () => {
-    const spy = jest.spyOn(AsyncStorage, 'setItem').mockRejectedValueOnce(new Error('disk full'));
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
     await expect(persistNavigationState(sampleState)).resolves.toBeUndefined();
-    spy.mockRestore();
   });
 
   it('swallows AsyncStorage failures on clear', async () => {
-    const spy = jest
-      .spyOn(AsyncStorage, 'removeItem')
-      .mockRejectedValueOnce(new Error('disk full'));
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
     await expect(clearPersistedNavigationState()).resolves.toBeUndefined();
-    spy.mockRestore();
+  });
+});
+
+describe('sanitizeNavigationState — replay guard (#886)', () => {
+  // Factory (not a shared const) so each test gets a pristine, deeply
+  // independent fixture — a realistic nested shape: root stack → Main → tab
+  // navigator, with the Home tab carrying a stale `sendToAddress` invoice and
+  // an Explore stack sitting on a HuntPiggyDetail cache page.
+  const makeDirtyState = (): NavigationState =>
+    ({
+      index: 0,
+      routeNames: ['Main'],
+      routes: [
+        {
+          key: 'Main-1',
+          name: 'Main',
+          state: {
+            index: 0,
+            routeNames: ['Home', 'Explore'],
+            routes: [
+              {
+                key: 'Home-1',
+                name: 'Home',
+                params: { sendToAddress: 'lnbc5u1pstale', sendToName: 'Bob', keep: 'me' },
+              },
+              {
+                key: 'Explore-1',
+                name: 'Explore',
+                state: {
+                  index: 2,
+                  routeNames: ['ExploreHome', 'Hunt', 'HuntPiggyDetail'],
+                  routes: [
+                    { key: 'EH-1', name: 'ExploreHome' },
+                    { key: 'H-1', name: 'Hunt' },
+                    {
+                      key: 'HPD-1',
+                      name: 'HuntPiggyDetail',
+                      params: { coord: '37516:abc:allotment' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }) as unknown as NavigationState;
+
+  const homeParamsOf = (s: NavigationState | undefined): Record<string, unknown> | undefined =>
+    (s as any)?.routes?.[0]?.state?.routes?.[0]?.params ?? undefined;
+  const exploreStateOf = (s: NavigationState | undefined): any =>
+    (s as any)?.routes?.[0]?.state?.routes?.[1]?.state;
+
+  it('strips one-shot action params from a nested Home route', () => {
+    const params = homeParamsOf(sanitizeNavigationState(makeDirtyState()));
+    expect(params).toEqual({ keep: 'me' }); // transient keys gone, others kept
+    expect(params).not.toHaveProperty('sendToAddress');
+    expect(params).not.toHaveProperty('sendToName');
+  });
+
+  it('pops a transient HuntPiggyDetail leaf and clamps the index to the parent', () => {
+    const explore = exploreStateOf(sanitizeNavigationState(makeDirtyState()));
+    expect(explore.routes.map((r: any) => r.name)).toEqual(['ExploreHome', 'Hunt']);
+    expect(explore.index).toBe(1); // was 2 (HuntPiggyDetail), clamped to Hunt
+  });
+
+  it('does not mutate its input (pure)', () => {
+    const input = makeDirtyState();
+    const snapshot = JSON.stringify(input);
+    sanitizeNavigationState(input);
+    expect(JSON.stringify(input)).toEqual(snapshot);
+  });
+
+  it('leaves a clean state untouched (identity for the common case)', () => {
+    const clean = {
+      index: 0,
+      routeNames: ['Main'],
+      routes: [{ key: 'Main-1', name: 'Main' }],
+    } as unknown as NavigationState;
+    expect(sanitizeNavigationState(clean)).toEqual(clean);
+  });
+
+  it('never empties a stack made entirely of transient routes', () => {
+    const allTransient = {
+      index: 0,
+      routeNames: ['HuntFound'],
+      routes: [{ key: 'HF-1', name: 'HuntFound', params: { lnurl: 'lnurl1stale' } }],
+    } as unknown as NavigationState;
+    const out = sanitizeNavigationState(allTransient) as any;
+    expect(out.routes).toHaveLength(1); // kept rather than crash the navigator
+    expect(out.index).toBe(0);
+  });
+
+  it('returns undefined / passthrough for empty or malformed input', () => {
+    expect(sanitizeNavigationState(undefined)).toBeUndefined();
+    expect(sanitizeNavigationState({} as unknown as NavigationState)).toEqual({});
+  });
+
+  it('load() heals an already-persisted stale invoice (sanitize on read)', async () => {
+    await AsyncStorage.setItem(
+      NAV_STATE_KEY,
+      JSON.stringify({ version: 1, savedAt: 0, state: makeDirtyState() }),
+    );
+    const loaded = await loadPersistedNavigationState();
+    expect(loaded).toBeDefined();
+    expect(homeParamsOf(loaded)).not.toHaveProperty('sendToAddress');
+    expect(exploreStateOf(loaded).routes.map((r: any) => r.name)).toEqual(['ExploreHome', 'Hunt']);
+  });
+
+  it('persist() writes a sanitized blob (sanitize on write)', async () => {
+    await persistNavigationState(makeDirtyState());
+    const raw = await AsyncStorage.getItem(NAV_STATE_KEY);
+    expect(raw).toBeTruthy();
+    const saved = JSON.parse(raw as string);
+    // Assert on the restored stack, not a substring: `routeNames` is the
+    // navigator's registered-screen list and legitimately still lists
+    // HuntPiggyDetail — what matters is that it's gone from `routes`.
+    const explore = saved.state.routes[0].state.routes[1].state;
+    expect(explore.routes.map((r: any) => r.name)).toEqual(['ExploreHome', 'Hunt']);
+    expect(saved.state.routes[0].state.routes[0].params).not.toHaveProperty('sendToAddress');
   });
 });

--- a/src/utils/navigationStatePersistence.ts
+++ b/src/utils/navigationStatePersistence.ts
@@ -62,9 +62,12 @@ const stripTransientParams = (params: unknown): unknown => {
 };
 
 // Recursively remove one-shot params and pop transient deep-link routes so a
-// restored cold-start never replays a stale action. Pure + total: returns the
-// input unchanged when there's nothing to clean, and never produces an empty
-// `routes` array (which would throw at NavigationContainer mount).
+// restored cold-start never replays a stale action. Pure (never mutates its
+// input) and total: a malformed/leaf state with no `routes` array is returned
+// as-is; a valid state yields a NEW, cleaned object. An empty `routes` array
+// (only reachable from a malformed-but-JSON-valid blob) collapses to
+// `undefined` so the navigator falls through to its defaults instead of
+// mounting an index-out-of-range stack.
 export const sanitizeNavigationState = (
   state: NavigationState | undefined,
 ): NavigationState | undefined => {
@@ -83,10 +86,11 @@ export const sanitizeNavigationState = (
   // Never hand back an empty stack — if every route was transient, keep the
   // cleaned (param-stripped) routes rather than crash the navigator.
   const routes = kept.length > 0 ? kept : cleanedRoutes;
-  const index = Math.min(
-    typeof s.index === 'number' ? s.index : routes.length - 1,
-    routes.length - 1,
-  );
+  // A genuinely empty stack (malformed input) can't be restored — drop it so
+  // the navigator renders defaults instead of mounting with index -1.
+  if (routes.length === 0) return undefined;
+  const desired = typeof s.index === 'number' ? s.index : routes.length - 1;
+  const index = Math.max(0, Math.min(desired, routes.length - 1));
   return { ...s, routes, index } as unknown as NavigationState;
 };
 

--- a/src/utils/navigationStatePersistence.ts
+++ b/src/utils/navigationStatePersistence.ts
@@ -19,6 +19,77 @@ interface PersistedNavState {
   savedAt: number;
 }
 
+// One-shot action params that make a screen DO something on mount — e.g.
+// HomeScreen opens the Send sheet whenever `sendToAddress` is present (set
+// by a Friends-tab zap). If these survive a cold start they replay every
+// launch: a stale invoice keeps re-opening the Send sheet pre-filled to pay
+// (#886). Stripped from every route before the state is persisted/restored.
+const TRANSIENT_PARAM_KEYS = [
+  'sendToAddress',
+  'sendToPicture',
+  'sendToPubkey',
+  'sendToName',
+  'openComposer',
+];
+
+// One-shot destination routes reached via a deep link / NFC tap / share — a
+// geo-cache (Piglet) detail page or an LNURL-withdraw claim flow. Restoring
+// straight back into one on launch replays a stale action (the app reopens
+// the last cache every time). Popped on restore so we land on the parent
+// stack (ExploreHome / Hunt) instead of the transient leaf.
+const TRANSIENT_ROUTE_NAMES = ['HuntPiggyDetail', 'HuntFound'];
+
+// Structural view of a NavigationState used by the sanitizer — React
+// Navigation's own type is deeply generic; we only touch these fields.
+interface NavStateLike {
+  index?: number;
+  routes: { name: string; params?: unknown; state?: NavStateLike }[];
+  [key: string]: unknown;
+}
+
+const stripTransientParams = (params: unknown): unknown => {
+  if (!params || typeof params !== 'object') return params;
+  const next = { ...(params as Record<string, unknown>) };
+  let changed = false;
+  for (const key of TRANSIENT_PARAM_KEYS) {
+    if (key in next) {
+      delete next[key];
+      changed = true;
+    }
+  }
+  if (!changed) return params;
+  return Object.keys(next).length > 0 ? next : undefined;
+};
+
+// Recursively remove one-shot params and pop transient deep-link routes so a
+// restored cold-start never replays a stale action. Pure + total: returns the
+// input unchanged when there's nothing to clean, and never produces an empty
+// `routes` array (which would throw at NavigationContainer mount).
+export const sanitizeNavigationState = (
+  state: NavigationState | undefined,
+): NavigationState | undefined => {
+  if (!state || !Array.isArray((state as unknown as NavStateLike).routes)) return state;
+  const s = state as unknown as NavStateLike;
+  const cleanedRoutes = s.routes.map((route) => ({
+    ...route,
+    params: stripTransientParams(route.params),
+    state: route.state
+      ? (sanitizeNavigationState(route.state as unknown as NavigationState) as
+          | NavStateLike
+          | undefined)
+      : route.state,
+  }));
+  const kept = cleanedRoutes.filter((route) => !TRANSIENT_ROUTE_NAMES.includes(route.name));
+  // Never hand back an empty stack — if every route was transient, keep the
+  // cleaned (param-stripped) routes rather than crash the navigator.
+  const routes = kept.length > 0 ? kept : cleanedRoutes;
+  const index = Math.min(
+    typeof s.index === 'number' ? s.index : routes.length - 1,
+    routes.length - 1,
+  );
+  return { ...s, routes, index } as unknown as NavigationState;
+};
+
 // Minimal NavigationState shape check — enough to keep us from handing
 // NavigationContainer a malformed blob that crashes on mount. We don't
 // recurse into nested route state; React Navigation rebuilds nested
@@ -63,7 +134,10 @@ export const loadPersistedNavigationState = async (): Promise<NavigationState | 
     const parsed: unknown = JSON.parse(raw);
     if (!isPersistedNavState(parsed)) return undefined;
     if (parsed.version !== SCHEMA_VERSION) return undefined;
-    return parsed.state;
+    // Sanitize on READ as well as write: devices that persisted a stale
+    // action (a pre-filled Send invoice, a deep-linked cache page) BEFORE
+    // this fix shipped self-heal on the next launch instead of replaying it.
+    return sanitizeNavigationState(parsed.state);
   } catch {
     // Corrupt JSON, AsyncStorage unavailable, schema mismatch — treat
     // as "no saved state" and let the navigator render defaults.
@@ -77,7 +151,13 @@ export const loadPersistedNavigationState = async (): Promise<NavigationState | 
 export const persistNavigationState = async (state: NavigationState | undefined): Promise<void> => {
   if (!state) return;
   try {
-    const payload: PersistedNavState = { version: SCHEMA_VERSION, state, savedAt: Date.now() };
+    const clean = sanitizeNavigationState(state);
+    if (!clean) return;
+    const payload: PersistedNavState = {
+      version: SCHEMA_VERSION,
+      state: clean,
+      savedAt: Date.now(),
+    };
     await AsyncStorage.setItem(NAV_STATE_KEY, JSON.stringify(payload));
   } catch {
     // Swallow.


### PR DESCRIPTION
## What

On cold start the app re-entered a stale, one-shot action instead of starting clean:

- **Pixel (production):** the **Send sheet auto-opened pre-filled to pay a 500-sat invoice** — tapping Send would actually pay it (a real footgun / security concern).
- **iPhone (preview):** the app **reopened the last geo-cache (Piglet) page** every launch.

## Root cause

Navigation-state persistence (#598) saves the **entire** nav state via `onStateChange`, including:
1. `HomeScreen`'s transient `sendToAddress` param (set by a Friends-tab zap — HomeScreen opens the Send sheet whenever it's present), and
2. transient deep-link destinations (`HuntPiggyDetail` / `HuntFound`).

On the next cold start `loadPersistedNavigationState()` restores that blob verbatim, so the one-shot action replays. The runtime param-cleanup in HomeScreen never reaches the already-persisted state.

## Fix

`sanitizeNavigationState()` in `src/utils/navigationStatePersistence.ts`, applied on **both save and load**:
- strips one-shot action params (`sendToAddress`, `sendToPicture`, `sendToPubkey`, `sendToName`, `openComposer`) from every route, and
- pops transient deep-link routes (`HuntPiggyDetail` / `HuntFound`) — restoring the parent stack (ExploreHome / Hunt) instead of the leaf, clamping the index.

**Why sanitize on load too:** devices that already persisted a stale action (before this ships) self-heal on the next launch, instead of needing the fix *plus* a manual navigate-away. The function is pure, total, and never hands back an empty `routes` array (which would crash `NavigationContainer`).

Drive-by: fixed a pre-existing test-isolation bug in the same suite — the "swallows AsyncStorage failures" tests used `jest.spyOn(...).mockRestore()`, which drops the async-storage mock's in-memory backing for every later test. Switched to `mockRejectedValueOnce` on the mock fn (auto-reverts).

## Test plan

- `npx tsc --noEmit` — passes.
- `npx jest src/utils/navigationStatePersistence.test.ts` — 23 pass, incl. new cases: strips nested Home params, pops HuntPiggyDetail + clamps index, purity (no input mutation), never-empties-a-stack, and load()/persist() round-trips proving the heal-on-read and clean-on-write behaviour.
- Full suite: `npx jest` — 109 suites / 1250 tests pass.
- ESLint / Prettier — clean (0 errors).

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)