### PR TITLE
chore(release): v1.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Version bump to **v1.3.6** (the EAS build version is also written from the `v1.3.6` release tag by `release.yml`).

Patch release for the cold-start replay fix:
- **#886 / #887** — `sanitizeNavigationState` strips one-shot action params and pops transient deep-link routes from the persisted nav state, so the app no longer re-opens the Send sheet pre-filled to pay a stale invoice (or reopens the last geo-cache page) on launch. Applied on load too, so already-stuck devices self-heal on first launch.

## Test plan

N/A — release version bump only (package.json + lock). The bundled fix was verified in #887 (24 nav-persistence tests; full suite 1250 pass) and the symptom reproduced/explained on a physical Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)