### PR TITLE
fix(nav): sanitize deep-link payloads nested in params (#886)

### DIFF
--- a/src/utils/navigationStatePersistence.test.ts
+++ b/src/utils/navigationStatePersistence.test.ts
@@ -232,6 +232,64 @@ describe('sanitizeNavigationState — replay guard (#886)', () => {
     expect(sanitizeNavigationState({} as unknown as NavigationState)).toEqual({});
   });
 
+  it('strips a deep-link payload nested in params.state / params.params (#886 real shape)', () => {
+    // Mirrors the actual persisted shape from a `navigate('Main', { screen:
+    // 'Explore', params: { state: {…HuntPiggyDetail…} } })` deep link: the
+    // resolved `state` tree looks clean, but the cache lives in the params
+    // navigate-payload, which RN re-applies on restore.
+    const state = {
+      index: 0,
+      routeNames: ['Main'],
+      routes: [
+        {
+          key: 'Main-1',
+          name: 'Main',
+          // resolved tree is already clean (cache not in state.routes)…
+          state: {
+            index: 0,
+            routeNames: ['Explore'],
+            routes: [{ key: 'Explore-1', name: 'Explore' }],
+          },
+          // …but the navigate-payload in params still carries it:
+          params: {
+            screen: 'Explore',
+            params: {
+              state: {
+                index: 2,
+                routes: [
+                  { name: 'ExploreHome' },
+                  { name: 'Hunt' },
+                  { name: 'HuntPiggyDetail', params: { coord: '37516:abc:allotment' } },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    } as unknown as NavigationState;
+    const out = sanitizeNavigationState(state) as any;
+    const payloadRoutes = out.routes[0].params.params.state.routes.map((r: any) => r.name);
+    expect(payloadRoutes).toEqual(['ExploreHome', 'Hunt']); // HuntPiggyDetail popped from the payload
+  });
+
+  it('strips sendToAddress from a nested params.params navigate payload', () => {
+    // navigate('Main', { screen: 'Home', params: { sendToAddress: '…' } })
+    const state = {
+      index: 0,
+      routeNames: ['Main'],
+      routes: [
+        {
+          key: 'Main-1',
+          name: 'Main',
+          params: { screen: 'Home', params: { sendToAddress: 'lnbc5u1pstale', keep: 'me' } },
+        },
+      ],
+    } as unknown as NavigationState;
+    const out = sanitizeNavigationState(state) as any;
+    expect(out.routes[0].params.params).toEqual({ keep: 'me' });
+    expect(out.routes[0].params.params).not.toHaveProperty('sendToAddress');
+  });
+
   it('collapses an empty-routes stack to undefined (no index -1 crash)', () => {
     // A malformed-but-JSON-valid blob with zero routes would otherwise yield
     // index = routes.length - 1 = -1 and crash NavigationContainer on mount.

--- a/src/utils/navigationStatePersistence.ts
+++ b/src/utils/navigationStatePersistence.ts
@@ -47,8 +47,15 @@ interface NavStateLike {
   [key: string]: unknown;
 }
 
-const stripTransientParams = (params: unknown): unknown => {
-  if (!params || typeof params !== 'object') return params;
+// Strip transient bits from a route's `params`. Crucially this must recurse,
+// because React Navigation persists the *navigate-action payload* inside
+// `params` — not just the resolved `state` tree. A deep link / Friends-tab zap
+// dispatched via `navigate('Main', { screen: 'Explore', params: { state: {…} } })`
+// leaves the cache (or the `sendToAddress` invoice) sitting in `params.params`
+// and `params.state`, which RN re-applies on restore. The top-level `state`
+// tree alone looks clean, so a shallow strip (the original bug) misses it.
+const sanitizeParams = (params: unknown): unknown => {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) return params;
   const next = { ...(params as Record<string, unknown>) };
   let changed = false;
   for (const key of TRANSIENT_PARAM_KEYS) {
@@ -56,6 +63,28 @@ const stripTransientParams = (params: unknown): unknown => {
       delete next[key];
       changed = true;
     }
+  }
+  // Nested navigate payload: navigate('A', { screen: 'B', params: {…} }).
+  if (next.params && typeof next.params === 'object' && !Array.isArray(next.params)) {
+    const inner = sanitizeParams(next.params);
+    if (inner !== next.params) {
+      changed = true;
+      if (inner === undefined) delete next.params;
+      else next.params = inner;
+    }
+  }
+  // Embedded navigation state: navigate('A', { state: {…} }) — sanitize it as a
+  // full state so transient routes (HuntPiggyDetail/HuntFound) are popped here
+  // too, not just in the resolved tree.
+  if (
+    next.state &&
+    typeof next.state === 'object' &&
+    Array.isArray((next.state as NavStateLike).routes)
+  ) {
+    const cleaned = sanitizeNavigationState(next.state as unknown as NavigationState);
+    changed = true;
+    if (cleaned === undefined) delete next.state;
+    else next.state = cleaned as unknown;
   }
   if (!changed) return params;
   return Object.keys(next).length > 0 ? next : undefined;
@@ -75,7 +104,7 @@ export const sanitizeNavigationState = (
   const s = state as unknown as NavStateLike;
   const cleanedRoutes = s.routes.map((route) => ({
     ...route,
-    params: stripTransientParams(route.params),
+    params: sanitizeParams(route.params),
     state: route.state
       ? (sanitizeNavigationState(route.state as unknown as NavigationState) as
           | NavStateLike


### PR DESCRIPTION
## Follow-up to #887 — that fix was incomplete

v1.3.6 (#887) still reopened the geo-cache (iOS) and the 500-sat Send sheet (Android production) on every cold start. I read the **actual on-device persisted nav state** and found why:

React Navigation persists the **navigate-action payload inside `params`**, not just the resolved `state` tree. The real blob (from `navigate('Main', { screen: 'Explore', params: { state: {…} } })`) looked like:

```jsonc
Explore route → params: { state: { routes: [ExploreHome, Hunt, HuntPiggyDetail] } }
Main route    → params: { screen: 'Explore', params: { state: {…HuntPiggyDetail…} } }
```

The resolved `state.routes` was already clean (`[ExploreHome, Hunt]`), so #887's sanitizer — which only stripped top-level `route.params` keys and recursed into `route.state` — **missed the payload**, and RN re-applied it on restore. Same story for the Send sheet's `sendToAddress`, nested in `params.params`.

## Fix

Make param sanitization **recursive**:
- strip transient keys (`sendToAddress` & friends) at *every* `params` depth,
- recurse into `params.params` (the `{ screen, params }` navigate form),
- run `params.state` through `sanitizeNavigationState` so transient routes (`HuntPiggyDetail`/`HuntFound`) are popped in the embedded payload too.

Still applied on **both load and save**, still pure/total, never empties a stack.

## Test plan

- `npx tsc --noEmit` — passes.
- `npx jest src/utils/navigationStatePersistence.test.ts` — **26 pass**, incl. 2 new cases mirroring the exact on-device shape (`params.params.state` cache payload; `params.params.sendToAddress`).
- `npx jest src/utils` — 491 pass. ESLint/Prettier clean.

### Verification note
The dev-build Android **emulator does not re-apply `params.state` on restore**, so it can't reproduce the symptom (it landed on ExploreHome regardless) — but it *did* let me read the real persisted structure that proves the mechanism. Production Android (the Pixel) and iOS (Nini's iPhone) do re-apply it. So this needs an on-device build to confirm the symptom is gone; the fix is unit-tested against the exact captured shape.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)