### PR TITLE
chore(release): v1.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Version bump to **v1.3.7** (build version also written from the `v1.3.7` tag by `release.yml`).

Completes the cold-start replay fix:
- **#889** — sanitize deep-link payloads nested in `params.state` / `params.params` (the part v1.3.6/#887 missed). The cache / 500-sat Send sheet no longer reopen on cold start; self-heals already-stuck devices on load.

## Verification
- **Emulator**: primed the params-path stale state, then cold-started both versions — **#887 reopens the cache page, #889 lands on Explore** (healed). 26 unit tests incl. the exact captured shape.
- **Physical Pixel 8**: installed the #889 build over the real stale state → two consecutive cold starts land on **Home**, no 500-sat Send sheet.

## Test plan
N/A — release version bump only (package.json + lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)