### PR TITLE
perf(nostr): kill tab-focus re-render storm in core contexts (#899)

### DIFF
--- a/src/contexts/DmInboxContext.tsx
+++ b/src/contexts/DmInboxContext.tsx
@@ -43,6 +43,20 @@ export interface DmInboxContextType {
    * Cold-boot does NOT arm the sub by itself, so Home stays responsive.
    */
   armLiveDmSub: () => void;
+  /**
+   * Tri-state for the NIP-17 silent-decrypt fast path.
+   *  - 'unknown': haven't tried yet in this session
+   *  - 'granted': a decrypt succeeded silently → cache the plaintext, no dialogs
+   *  - 'denied':  a decrypt rejected with PERMISSION_NOT_GRANTED → Account
+   *              should surface a one-tap grant button rather than flood the
+   *              signer with dialogs on subsequent refreshes
+   *
+   * Lives on this hot slice (not the stable `useNostr()` value) because the
+   * Amber DM loop flips it on every inbox drain — in the main context value
+   * that re-rendered all ~40 `useNostr()` consumers per refresh for a field
+   * only the account screen reads.
+   */
+  amberNip44Permission: 'unknown' | 'granted' | 'denied';
 }
 
 export const DmInboxContext = createContext<DmInboxContextType | undefined>(undefined);

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -220,15 +220,6 @@ interface NostrContextType {
    * refresh ingested (it writes the store, not the per-conv blob).
    */
   loadInitialConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
-  /**
-   * Tri-state for the NIP-17 silent-decrypt fast path.
-   *  - 'unknown': haven't tried yet in this session
-   *  - 'granted': a decrypt succeeded silently → cache the plaintext, no dialogs
-   *  - 'denied':  a decrypt rejected with PERMISSION_NOT_GRANTED → Account
-   *              should surface a one-tap grant button rather than flood the
-   *              signer with dialogs on subsequent refreshes
-   */
-  amberNip44Permission: 'unknown' | 'granted' | 'denied';
   signEvent: (event: {
     kind: number;
     created_at: number;
@@ -270,6 +261,23 @@ const NostrContactsContext = createContext<NostrContactsContextType | undefined>
 // JS engine started executing our code" — the upstream of every other
 // [Perf] line in this file.
 perfLog('NostrContext module-eval');
+
+/**
+ * Shallow field-equality for own-profile updates. Every `loadProfile` /
+ * `loadProfileFromCache` call builds a *fresh* object (JSON.parse / relay
+ * fetch), and Home/Friends call `refreshProfile()` on every tab focus — so
+ * without this guard each focus minted a new `profile` identity, rebuilt the
+ * main context value, and re-rendered every `useNostr()` consumer even when
+ * nothing changed. Profile fields are all primitives, so shallow compare is
+ * exact.
+ */
+const sameProfile = (a: NostrProfile | null, b: NostrProfile): boolean => {
+  if (!a) return false;
+  const ka = Object.keys(a) as (keyof NostrProfile)[];
+  const kb = Object.keys(b) as (keyof NostrProfile)[];
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => Object.is(a[k], b[k]));
+};
 
 let __nostrProviderFirstRenderLogged = false;
 let __nostrProviderLoggedInLogged = false;
@@ -430,14 +438,14 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         perAccountKey(OWN_PROFILE_TIMESTAMP_KEY_BASE, pk),
       );
       if (!opts?.force && cached && ageMs < CACHE_MAX_AGE_MS) {
-        setProfile(cached);
+        setProfile((prev) => (sameProfile(prev, cached) ? prev : cached));
         if (__DEV__) console.log(`[Nostr] fetchProfile: skipped (cache fresh)`);
         return;
       }
       const fetchedProfile = await nostrService.fetchProfile(pk, relayUrls);
       if (__DEV__) console.log(`[Nostr] fetchProfile: ${Date.now() - t0}ms`);
       if (fetchedProfile) {
-        setProfile(fetchedProfile);
+        setProfile((prev) => (sameProfile(prev, fetchedProfile) ? prev : fetchedProfile));
         InteractionManager.runAfterInteractions(() => {
           AsyncStorage.setItem(
             perAccountKey(OWN_PROFILE_CACHE_KEY_BASE, pk),
@@ -477,7 +485,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       const raw = await AsyncStorage.getItem(perAccountKey(OWN_PROFILE_CACHE_KEY_BASE, pk));
       if (!raw) return false;
       const cached = JSON.parse(raw) as NostrProfile;
-      setProfile(cached);
+      setProfile((prev) => (sameProfile(prev, cached) ? prev : cached));
       return true;
     } catch (error) {
       console.warn('Failed to load profile cache:', error);
@@ -1746,7 +1754,6 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       loadInitialConversation,
       appendLocalDmMessage,
       persistDeliveryStatuses,
-      amberNip44Permission,
       signEvent,
     }),
     [
@@ -1777,7 +1784,6 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       loadInitialConversation,
       appendLocalDmMessage,
       persistDeliveryStatuses,
-      amberNip44Permission,
       signEvent,
     ],
   );
@@ -1792,9 +1798,13 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   // Sibling value carrying the hot DM-inbox slice (#806). Memoised separately
   // so a decrypted message rebuilds only this — not `contextValue` above — and
   // only `useNostrDmInbox()` consumers re-render on inbox churn.
+  // `amberNip44Permission` lives here (not in the main value) because it is
+  // DM-subsystem state flipped by every Amber inbox drain — in the main value
+  // each flip re-rendered all ~40 `useNostr()` consumers for a field only the
+  // account screen reads.
   const dmInboxValue = useMemo(
-    () => ({ dmInbox, dmInboxLoading, refreshDmInbox, armLiveDmSub }),
-    [dmInbox, dmInboxLoading, refreshDmInbox, armLiveDmSub],
+    () => ({ dmInbox, dmInboxLoading, refreshDmInbox, armLiveDmSub, amberNip44Permission }),
+    [dmInbox, dmInboxLoading, refreshDmInbox, armLiveDmSub, amberNip44Permission],
   );
 
   return (

--- a/src/contexts/TrustGraphContext.tsx
+++ b/src/contexts/TrustGraphContext.tsx
@@ -183,23 +183,30 @@ export const TrustGraphProvider: React.FC<ProviderProps> = ({ children }) => {
   // For 'all' tier we still compute a trust set (so the UI can show
   // "n hidden" counts symmetrically) but `isTrusted` short-circuits to
   // true below.
-  const trustSet = useMemo(() => {
-    const effectiveL2 = wotTier === 'fof' || wotTier === 'all' ? l2Follows : new Set<string>();
-    return computeTrustSet(pubkey, l1Follows, effectiveL2, true);
-  }, [pubkey, l1Follows, l2Follows, wotTier]);
+  //
+  // ALL tiers are memoised up front (not just the persisted one). The
+  // previous `trustSetForTier` only fast-pathed `tier === wotTier` and ran
+  // `computeTrustSet` per call otherwise — minting a fresh Set identity on
+  // every render of every caller. MessagesScreen evaluates the UI-effective
+  // tier (persisted 'all' clamps to 'friends' when secretMode is off — the
+  // DEFAULT configuration) and keys two O(inbox) memos on the returned set,
+  // so its whole memo chain re-ran every render. Building both sets here is
+  // O(follows) — cheap — and only on contacts/identity change.
+  const tierSets = useMemo(() => {
+    const friends = computeTrustSet(pubkey, l1Follows, new Set<string>(), true);
+    const widened = computeTrustSet(pubkey, l1Follows, l2Follows, true);
+    return { friends, fof: widened, all: widened } satisfies Record<WotTier, ReadonlySet<string>>;
+  }, [pubkey, l1Follows, l2Follows]);
+
+  const trustSet = tierSets[wotTier];
 
   // Tier-parameterised version of `trustSet`. Returns the set that
   // *would* apply if the requested tier were active, regardless of
-  // what's persisted. Hot path: when the requested tier equals the
-  // persisted one we hand back the memoised `trustSet` directly so
-  // we don't rebuild on every consumer call.
+  // what's persisted. Referentially stable per (pubkey, contacts) — see
+  // `tierSets` above.
   const trustSetForTier = useCallback(
-    (tier: WotTier): ReadonlySet<string> => {
-      if (tier === wotTier) return trustSet;
-      const effectiveL2 = tier === 'fof' || tier === 'all' ? l2Follows : new Set<string>();
-      return computeTrustSet(pubkey, l1Follows, effectiveL2, true);
-    },
-    [trustSet, wotTier, pubkey, l1Follows, l2Follows],
+    (tier: WotTier): ReadonlySet<string> => tierSets[tier],
+    [tierSets],
   );
 
   const isTrusted = useCallback(

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1143,7 +1143,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         setTimeout(() => {
           resolveZapSendersRef
             .current?.(walletId, { force: opts?.force })
-            .catch((e) => console.warn(`resolveZapSenders failed for ${walletId}:`, e));
+            ?.catch((e) => console.warn(`resolveZapSenders failed for ${walletId}:`, e));
         }, 0);
       } catch (error) {
         console.warn(`fetchTransactions failed for ${walletId}:`, error);

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -331,7 +331,27 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   const updateWalletInState = useCallback((walletId: string, updates: Partial<WalletState>) => {
-    setWallets((prev) => prev.map((w) => (w.id === walletId ? { ...w, ...updates } : w)));
+    setWallets((prev) => {
+      // No-op bail-out: a poll that reports an unchanged balance /
+      // connection state must NOT mint a new `wallets` identity — the
+      // main context value depends on `wallets`, so every identity
+      // change re-renders all `useWallet()` consumers. Balance checks
+      // run every few seconds during a receive window; before this
+      // guard each one produced a full-consumer re-render wave even
+      // when nothing changed. (Object identity per field: `transactions`
+      // arrays are always freshly built by callers, so list updates
+      // still commit — only true field-level no-ops bail.)
+      const current = prev.find((w) => w.id === walletId);
+      if (
+        !current ||
+        (Object.keys(updates) as (keyof WalletState)[]).every((k) =>
+          Object.is(current[k], updates[k]),
+        )
+      ) {
+        return prev;
+      }
+      return prev.map((w) => (w.id === walletId ? { ...w, ...updates } : w));
+    });
     // Persist fresh balance to disk so the next cold start can hydrate
     // it instantly (vs paying ~9 s BDK.Wallet.create + Electrum.sync to
     // re-derive it). Fire-and-forget; failure mode is "next boot shows
@@ -1133,9 +1153,16 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         // transactions that haven't been resolved yet. `force` (set by
         // an explicit pull-to-refresh) bypasses the fingerprint skip so
         // the resolver always does a full pass — see resolveZapSenders.
-        resolveZapSendersRef
-          .current?.(walletId, { force: opts?.force })
-          .catch((e) => console.warn(`resolveZapSenders failed for ${walletId}:`, e));
+        // Deferred one macrotask so the resolver's setup + its
+        // `mergeResolverResults` re-render burst can't land in the same
+        // event-loop tick as the `updateWalletInState` commit above —
+        // that tick is exactly where the incoming-payment overlay's
+        // dismiss tap was getting queued (#828).
+        setTimeout(() => {
+          resolveZapSendersRef
+            .current?.(walletId, { force: opts?.force })
+            .catch((e) => console.warn(`resolveZapSenders failed for ${walletId}:`, e));
+        }, 0);
       } catch (error) {
         console.warn(`fetchTransactions failed for ${walletId}:`, error);
       }
@@ -1197,29 +1224,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         }
       };
 
-      const userPubkey = nostrService.getCurrentUserPubkey();
-      // Collect recipient pubkeys for the `#p` filter: the user's own Nostr
-      // pubkey plus every lightning-address LNURL server's `nostrPubkey`.
-      // Self-hosted LNbits typically tags receipts with the server's pubkey,
-      // not the user's.
-      const recipients: string[] = [];
-      if (userPubkey) recipients.push(userPubkey);
-      const lud16s = new Set<string>();
-      const currentWallet = walletsRef.current.find((w) => w.id === walletId);
-      if (currentWallet?.lightningAddress) lud16s.add(currentWallet.lightningAddress);
-      for (const lud16 of lud16s) {
-        const pk = await resolveLud16ToNostrPubkey(lud16);
-        if (pk) recipients.push(pk);
-      }
-      if (recipients.length === 0) {
-        releaseController();
-        return;
-      }
-      if (signal.aborted) {
-        releaseController();
-        return;
-      }
-
       // Snapshot the pending list via a setter so we always read the latest
       // transactions without having to thread a ref through this callback.
       // We deliberately don't require `bolt11` — cached transactions from
@@ -1279,6 +1283,32 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         void zapResolverFingerprintStorage.set(walletId, currentFingerprint);
         releaseController();
       };
+
+      // Collect recipient pubkeys for the `#p` filter: the user's own Nostr
+      // pubkey plus every lightning-address LNURL server's `nostrPubkey`.
+      // Self-hosted LNbits typically tags receipts with the server's pubkey,
+      // not the user's. Runs AFTER the pending/fingerprint short-circuits so
+      // the common skip path (nothing new to attribute — every balance tick)
+      // never pays the `resolveLud16ToNostrPubkey` network round-trip (#828
+      // tap-window contention).
+      const userPubkey = nostrService.getCurrentUserPubkey();
+      const recipients: string[] = [];
+      if (userPubkey) recipients.push(userPubkey);
+      const lud16s = new Set<string>();
+      const currentWallet = walletsRef.current.find((w) => w.id === walletId);
+      if (currentWallet?.lightningAddress) lud16s.add(currentWallet.lightningAddress);
+      for (const lud16 of lud16s) {
+        const pk = await resolveLud16ToNostrPubkey(lud16);
+        if (pk) recipients.push(pk);
+      }
+      if (recipients.length === 0) {
+        releaseController();
+        return;
+      }
+      if (signal.aborted) {
+        releaseController();
+        return;
+      }
 
       const incomingPending = pending.filter(({ tx }) => tx.type === 'incoming');
       const outgoingPending = pending.filter(({ tx }) => tx.type === 'outgoing');

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -41,6 +41,8 @@ import {
   walletLabel,
 } from '../types/wallet';
 import { deferPostPaymentRefresh } from '../utils/deferPostPaymentRefresh';
+import { mergeWalletUpdate } from '../utils/walletStateMerge';
+import { collectZapRecipientPubkeys } from '../utils/zapRecipients';
 
 // Captured at module-evaluation time, which is the closest proxy we have to "JS bundle started executing after app launch". Used by the [Perf] wallet-connect marker so perf scripts can report time-from-launch-to-first-NWC-connect without needing a separate launch timestamp source.
 const WALLET_MODULE_LOAD_T0 = Date.now();
@@ -331,27 +333,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   const updateWalletInState = useCallback((walletId: string, updates: Partial<WalletState>) => {
-    setWallets((prev) => {
-      // No-op bail-out: a poll that reports an unchanged balance /
-      // connection state must NOT mint a new `wallets` identity — the
-      // main context value depends on `wallets`, so every identity
-      // change re-renders all `useWallet()` consumers. Balance checks
-      // run every few seconds during a receive window; before this
-      // guard each one produced a full-consumer re-render wave even
-      // when nothing changed. (Object identity per field: `transactions`
-      // arrays are always freshly built by callers, so list updates
-      // still commit — only true field-level no-ops bail.)
-      const current = prev.find((w) => w.id === walletId);
-      if (
-        !current ||
-        (Object.keys(updates) as (keyof WalletState)[]).every((k) =>
-          Object.is(current[k], updates[k]),
-        )
-      ) {
-        return prev;
-      }
-      return prev.map((w) => (w.id === walletId ? { ...w, ...updates } : w));
-    });
+    // No-op bail-out (unchanged poll → same `wallets` identity) lives in mergeWalletUpdate.
+    setWallets((prev) => mergeWalletUpdate(prev, walletId, updates));
     // Persist fresh balance to disk so the next cold start can hydrate
     // it instantly (vs paying ~9 s BDK.Wallet.create + Electrum.sync to
     // re-derive it). Fire-and-forget; failure mode is "next boot shows
@@ -1153,11 +1136,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         // transactions that haven't been resolved yet. `force` (set by
         // an explicit pull-to-refresh) bypasses the fingerprint skip so
         // the resolver always does a full pass — see resolveZapSenders.
-        // Deferred one macrotask so the resolver's setup + its
-        // `mergeResolverResults` re-render burst can't land in the same
-        // event-loop tick as the `updateWalletInState` commit above —
-        // that tick is exactly where the incoming-payment overlay's
-        // dismiss tap was getting queued (#828).
+        // Deferred one macrotask so the resolver's `mergeResolverResults`
+        // re-render burst can't land in the same event-loop tick as the
+        // `updateWalletInState` commit above — that tick is where the
+        // incoming-payment overlay's dismiss tap was getting queued (#828).
         setTimeout(() => {
           resolveZapSendersRef
             .current?.(walletId, { force: opts?.force })
@@ -1284,28 +1266,16 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         releaseController();
       };
 
-      // Collect recipient pubkeys for the `#p` filter: the user's own Nostr
-      // pubkey plus every lightning-address LNURL server's `nostrPubkey`.
-      // Self-hosted LNbits typically tags receipts with the server's pubkey,
-      // not the user's. Runs AFTER the pending/fingerprint short-circuits so
-      // the common skip path (nothing new to attribute — every balance tick)
-      // never pays the `resolveLud16ToNostrPubkey` network round-trip (#828
-      // tap-window contention).
+      // Recipient pubkeys for the `#p` filter — resolved AFTER the pending/
+      // fingerprint short-circuits so the common no-op balance tick never pays
+      // the resolveLud16ToNostrPubkey round-trip. userPubkey reused below.
       const userPubkey = nostrService.getCurrentUserPubkey();
-      const recipients: string[] = [];
-      if (userPubkey) recipients.push(userPubkey);
-      const lud16s = new Set<string>();
-      const currentWallet = walletsRef.current.find((w) => w.id === walletId);
-      if (currentWallet?.lightningAddress) lud16s.add(currentWallet.lightningAddress);
-      for (const lud16 of lud16s) {
-        const pk = await resolveLud16ToNostrPubkey(lud16);
-        if (pk) recipients.push(pk);
-      }
-      if (recipients.length === 0) {
-        releaseController();
-        return;
-      }
-      if (signal.aborted) {
+      const recipients = await collectZapRecipientPubkeys(
+        userPubkey,
+        walletsRef.current.find((w) => w.id === walletId)?.lightningAddress,
+        resolveLud16ToNostrPubkey,
+      );
+      if (recipients.length === 0 || signal.aborted) {
         releaseController();
         return;
       }

--- a/src/screens/account/NostrScreen.tsx
+++ b/src/screens/account/NostrScreen.tsx
@@ -14,6 +14,7 @@ import * as amberService from '../../services/amberService';
 import { DEFAULT_RELAYS, getRelayConnectionStatus } from '../../services/nostrService';
 import { validateRelayUrl } from '../../services/nostrRelayStorage';
 import { useNostr } from '../../contexts/NostrContext';
+import { useNostrDmInbox } from '../../contexts/DmInboxContext';
 import { useThemeColors } from '../../contexts/ThemeContext';
 import type { Palette } from '../../styles/palettes';
 
@@ -41,15 +42,9 @@ const NostrScreen: React.FC = () => {
   const colors = useThemeColors();
   const sharedAccountStyles = useMemo(() => createSharedAccountStyles(colors), [colors]);
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const {
-    profile,
-    signerType,
-    amberNip44Permission,
-    relays,
-    userRelays,
-    addUserRelay,
-    removeUserRelay,
-  } = useNostr();
+  const { profile, signerType, relays, userRelays, addUserRelay, removeUserRelay } = useNostr();
+  // From the hot DM slice, not `useNostr()` — see DmInboxContext for why.
+  const { amberNip44Permission } = useNostrDmInbox();
   const [connStatus, setConnStatus] = useState<Map<string, boolean>>(new Map());
   const [newRelayInput, setNewRelayInput] = useState('');
   const [addRelayError, setAddRelayError] = useState<string | null>(null);

--- a/src/utils/walletStateMerge.test.ts
+++ b/src/utils/walletStateMerge.test.ts
@@ -1,0 +1,41 @@
+import { mergeWalletUpdate } from './walletStateMerge';
+import type { WalletState } from '../types/wallet';
+
+const w = (over: Partial<WalletState> = {}): WalletState =>
+  ({ id: 'a', balance: 100, ...over }) as WalletState;
+
+describe('mergeWalletUpdate', () => {
+  it('returns the SAME array identity when the update is a field-level no-op', () => {
+    const prev = [w({ id: 'a', balance: 100 }), w({ id: 'b', balance: 5 })];
+    const next = mergeWalletUpdate(prev, 'a', { balance: 100 });
+    expect(next).toBe(prev); // referential equality → no re-render
+  });
+
+  it('returns a new array when a field actually changes', () => {
+    const prev = [w({ id: 'a', balance: 100 })];
+    const next = mergeWalletUpdate(prev, 'a', { balance: 250 });
+    expect(next).not.toBe(prev);
+    expect(next[0].balance).toBe(250);
+  });
+
+  it('only updates the targeted wallet', () => {
+    const prev = [w({ id: 'a', balance: 100 }), w({ id: 'b', balance: 5 })];
+    const next = mergeWalletUpdate(prev, 'b', { balance: 9 });
+    expect(next[0]).toBe(prev[0]); // untouched wallet keeps identity
+    expect(next[1].balance).toBe(9);
+  });
+
+  it('returns prev unchanged when the wallet id is not found', () => {
+    const prev = [w({ id: 'a' })];
+    expect(mergeWalletUpdate(prev, 'missing', { balance: 1 })).toBe(prev);
+  });
+
+  it('commits when one of several fields differs', () => {
+    const prev = [w({ id: 'a', balance: 100, name: 'Old' } as Partial<WalletState>)];
+    const next = mergeWalletUpdate(prev, 'a', {
+      balance: 100,
+      name: 'New',
+    } as Partial<WalletState>);
+    expect(next).not.toBe(prev);
+  });
+});

--- a/src/utils/walletStateMerge.ts
+++ b/src/utils/walletStateMerge.ts
@@ -1,0 +1,31 @@
+import type { WalletState } from '../types/wallet';
+
+/**
+ * Apply a partial field update to one wallet in the `wallets` array, with a
+ * **no-op bail-out**: when every updated field is `Object.is`-equal to what's
+ * already stored, return the SAME array identity so React doesn't re-render.
+ *
+ * The `WalletContext` value depends on `wallets`, so any new array identity
+ * re-renders every `useWallet()` consumer (HomeScreen, WalletCarousel,
+ * TransactionList…). Balance checks run every few seconds during a receive
+ * window; before this guard each one produced a full-consumer re-render wave
+ * even when the polled balance was unchanged.
+ *
+ * Object identity is per field: `transactions` arrays are always freshly built
+ * by callers, so genuine list updates still commit — only true field-level
+ * no-ops bail. Returns `prev` unchanged when the wallet isn't found.
+ */
+export function mergeWalletUpdate(
+  prev: WalletState[],
+  walletId: string,
+  updates: Partial<WalletState>,
+): WalletState[] {
+  const current = prev.find((w) => w.id === walletId);
+  if (
+    !current ||
+    (Object.keys(updates) as (keyof WalletState)[]).every((k) => Object.is(current[k], updates[k]))
+  ) {
+    return prev;
+  }
+  return prev.map((w) => (w.id === walletId ? { ...w, ...updates } : w));
+}

--- a/src/utils/zapRecipients.test.ts
+++ b/src/utils/zapRecipients.test.ts
@@ -1,0 +1,33 @@
+import { collectZapRecipientPubkeys } from './zapRecipients';
+
+describe('collectZapRecipientPubkeys', () => {
+  const resolveOk = jest.fn(async (_lud16: string) => 'serverpk');
+  const resolveNull = jest.fn(async (_lud16: string) => null);
+
+  beforeEach(() => {
+    resolveOk.mockClear();
+    resolveNull.mockClear();
+  });
+
+  it('includes the user pubkey and the resolved LNURL-server pubkey', async () => {
+    const out = await collectZapRecipientPubkeys('userpk', 'me@host', resolveOk);
+    expect(out).toEqual(['userpk', 'serverpk']);
+    expect(resolveOk).toHaveBeenCalledWith('me@host');
+  });
+
+  it('omits the server pubkey when the address does not resolve', async () => {
+    const out = await collectZapRecipientPubkeys('userpk', 'me@host', resolveNull);
+    expect(out).toEqual(['userpk']);
+  });
+
+  it('skips the lud16 round-trip entirely when there is no lightning address', async () => {
+    const out = await collectZapRecipientPubkeys('userpk', undefined, resolveOk);
+    expect(out).toEqual(['userpk']);
+    expect(resolveOk).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when there is neither a user pubkey nor a resolvable address', async () => {
+    const out = await collectZapRecipientPubkeys(null, 'me@host', resolveNull);
+    expect(out).toEqual([]);
+  });
+});

--- a/src/utils/zapRecipients.ts
+++ b/src/utils/zapRecipients.ts
@@ -1,0 +1,24 @@
+/**
+ * Recipient pubkeys for the incoming-zap `#p` filter: the user's own Nostr
+ * pubkey plus the LNURL server's `nostrPubkey` for the wallet's lightning
+ * address (self-hosted LNbits tags zap receipts with the server's pubkey, not
+ * the user's).
+ *
+ * The caller awaits this only AFTER the zap resolver's pending/fingerprint
+ * short-circuits, so the common no-op balance tick (nothing new to attribute)
+ * never pays the `resolveLud16ToNostrPubkey` network round-trip — that
+ * round-trip on every balance poll was part of the #828 tap-window contention.
+ */
+export async function collectZapRecipientPubkeys(
+  userPubkey: string | null,
+  lightningAddress: string | null | undefined,
+  resolveLud16ToNostrPubkey: (lud16: string) => Promise<string | null>,
+): Promise<string[]> {
+  const recipients: string[] = [];
+  if (userPubkey) recipients.push(userPubkey);
+  if (lightningAddress) {
+    const pk = await resolveLud16ToNostrPubkey(lightningAddress);
+    if (pk) recipients.push(pk);
+  }
+  return recipients;
+}


### PR DESCRIPTION
Cuts the tab-focus re-render storm in the core contexts — switching tabs (Home ↔ Messages ↔ Friends) was re-minting the Nostr / Wallet / TrustGraph context values even when nothing changed, re-rendering every consumer. Pure render-count reduction, **no behaviour change**.

## Changes
- **TrustGraphContext** — memoise all WoT tier sets (friends/fof/all) up front so `trustSetForTier` is referentially stable; previously minted a fresh `Set` per call, re-running MessagesScreen's whole memo chain every render.
- **NostrContext** — `sameProfile` shallow-equality guard on `setProfile` so a `refreshProfile()` on every tab focus doesn't mint a new `profile` identity when fields are unchanged; move `amberNip44Permission` off the stable `useNostr()` value onto the hot DM slice (the Amber DM loop flipping it was re-rendering all ~40 `useNostr()` consumers).
- **WalletContext** — no-op bail-out when a balance poll reports unchanged state (was re-rendering every `useWallet()` consumer); defer the resolver re-render burst one macrotask so it can't collide with the incoming-payment overlay's dismiss tap; skip `resolveLud16ToNostrPubkey` on the no-change path.
- **NostrScreen** — read `amberNip44Permission` from `useNostrDmInbox()`.

## Measured impact (Stev.ie before/after audit, 2 runs each, emulator)

Tab-churn flow Home→Messages→Friends×3→Home (~37s):

| | BEFORE (main) | AFTER (this PR) |
|---|---|---|
| HomeScreen `React.Profiler` commits / sequence | 3 (138–159ms each) | **0** |
| Spurious JS-thread render work / sequence | ~894ms | **0ms** |
| Friends hidden-tab leave latency | 244–256ms | **72–76ms** |
| Wallet re-renders on unchanged balance poll | 3 commits | **0** |
| gfxinfo janky% (tab-churn window) | 3.9–6.4% | 1.7–2.5% |

Reproducible 2/2 each side. No regressions. `tap→focus` wall-clock unchanged (the `sameProfile` win is background render pressure, not perceived latency). Verdict: safe to ship in v1.3.8.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` — 0 errors (only pre-existing warnings)
- [x] `npx prettier --check` clean
- [x] `npx jest` — 1276/1276 pass
- [x] Emulator before/after perf audit (Stev.ie) — 3×138–159ms HomeScreen commits → 0 per tab-churn sequence, reproducible 2/2; wallet no-op poll no longer re-renders consumers; no regressions
- [x] Manual smoke: tab navigation, Messages/Friends, profile, wallet balance display — no behaviour change

Closes #899
Refs #602, #566
