### PR TITLE
chore(release): v1.3.8 — Boltz swap fixes + render-storm perf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Marketing version bump **v1.3.7 → v1.3.8**. (`versionCode`/`buildNumber` stay owned by EAS's remote auto-increment — see DEPLOYMENT.adoc.)

### Shipping in v1.3.8
- **fix(swap)** — no false "Payment failed" on ambiguous NWC pay; correct Boltz swap-tx display + auto-recovery (#891, #894, #895, #896, #898 — PR #893).
- **perf(nostr)** — tab-focus re-render storm eliminated: 3×138–159ms HomeScreen commits per tab-churn → 0; wallet no-op balance-poll bail-out (#899 — PR #900).

On merge, I tag the squashed commit `v1.3.8` and publish the GitHub Release, which kicks off the EAS cloud builds (both platforms) + iOS TestFlight auto-submit.

## Test plan
- [x] Both feature PRs (#893, #900) merged green: tsc / eslint / prettier / file-size / 1285 Jest tests
- [x] Boltz fixes verified live on emulator (real on-chain↔LN round-trip; screenshots in #893)
- [x] Render-storm reduction verified live on emulator (Stev.ie before/after audit in #900)
- [x] Version bump only — no source change in this PR
