### PR TITLE
fix(swap): finish swaps from more triggers + clear stale clock + rename Claim→Finish (#902)

### DIFF
--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -49,6 +49,7 @@ import { executeReverseSwap, isSwapSettlingError } from '../utils/reverseSwapSen
 import { npubEncode } from '../services/nostrService';
 import { recordOutgoing as recordOutgoingCounterparty } from '../services/zapCounterpartyStorage';
 import { isReplyTimeoutError, isConnectionError } from '../services/nwcService';
+import * as swapRecoveryService from '../services/swapRecoveryService';
 import PaymentProgressOverlay, { PaymentProgressState } from './PaymentProgressOverlay';
 import { deferPostPaymentRefresh } from '../utils/deferPostPaymentRefresh';
 import AmountEntryScreen from './AmountEntryScreen';
@@ -745,6 +746,11 @@ const SendSheet: React.FC<Props> = ({
     const shouldCloseParent = prevState === 'success' || prevState === 'in-flight-extended';
     if (prevState === 'in-flight-extended') {
       dismissedInFlightRef.current = true;
+      // "Continue in background" on an in-flight swap: kick a recovery pass so
+      // the claim is retried now rather than waiting for the next app launch.
+      // Safe no-op (single-flight guarded) if the lockup isn't claimable yet —
+      // pull-to-refresh / next foreground will retry.
+      swapRecoveryService.recoverPendingSwaps().catch(() => {});
     }
     setProgressState('hidden');
     setProgressError(undefined);

--- a/src/components/SendSheet.tsx
+++ b/src/components/SendSheet.tsx
@@ -750,7 +750,9 @@ const SendSheet: React.FC<Props> = ({
       // the claim is retried now rather than waiting for the next app launch.
       // Safe no-op (single-flight guarded) if the lockup isn't claimable yet —
       // pull-to-refresh / next foreground will retry.
-      swapRecoveryService.recoverPendingSwaps().catch(() => {});
+      swapRecoveryService.recoverPendingSwaps().catch((e) => {
+        console.warn('[Send] continue-in-background swap recovery failed:', e);
+      });
     }
     setProgressState('hidden');
     setProgressError(undefined);

--- a/src/components/TransactionDetailSheet.tsx
+++ b/src/components/TransactionDetailSheet.tsx
@@ -229,8 +229,8 @@ const TransactionDetailSheet: React.FC<Props> = ({
       await swapRecoveryService.recoverPendingSwaps();
       Toast.show({
         type: 'info',
-        text1: 'Retry kicked off',
-        text2: 'Any claimable swaps are being re-broadcast.',
+        text1: 'Finishing swap',
+        text2: 'Any unfinished swaps are being re-broadcast.',
         position: 'top',
         visibilityTime: 6000,
       });
@@ -269,7 +269,7 @@ const TransactionDetailSheet: React.FC<Props> = ({
     const pending = !tx.settled_at && !tx.blockHeight;
     if (swap?.terminalFailure) return { style: styles.badgeFailed, text: `Swap: ${swap.status}` };
     if (swap?.terminalSuccess) return { style: styles.badgeConfirmed, text: 'Swap complete' };
-    if (swap?.claimable) return { style: styles.badgeInfo, text: 'Claim available' };
+    if (swap?.claimable) return { style: styles.badgeInfo, text: 'Ready to finish' };
     if (swap) return { style: styles.badgeInfo, text: `Swap: ${swap.status}` };
     if (pending) return { style: styles.badgePending, text: 'Pending' };
     return { style: styles.badgeConfirmed, text: 'Confirmed' };
@@ -302,7 +302,7 @@ const TransactionDetailSheet: React.FC<Props> = ({
         heading: 'Swap complete',
         body: incoming
           ? 'Boltz received your on-chain payment and settled the Lightning side — funds are in your Lightning wallet.'
-          : 'Lightning was paid and Boltz’s on-chain lockup has been claimed to your Bitcoin address.',
+          : 'Lightning was paid and Boltz’s on-chain lockup has been swept to your Bitcoin address.',
       };
     }
     // Live poll says claimable AND the row is flagged for attention: our
@@ -311,7 +311,7 @@ const TransactionDetailSheet: React.FC<Props> = ({
       return {
         tone: 'warning' as const,
         heading: 'Needs attention',
-        body: 'Lightning was paid and the Boltz lockup confirmed, but the on-chain claim hasn’t broadcast yet. Your funds are safe — tap Retry claim below if it hasn’t cleared.',
+        body: 'Lightning was paid and the Boltz lockup confirmed, but the on-chain transaction that finishes the swap hasn’t broadcast yet. Your funds are safe — tap Finish swap below if it hasn’t cleared.',
       };
     }
     // Live poll says claimable, but the row isn't (yet) in the attention
@@ -319,8 +319,8 @@ const TransactionDetailSheet: React.FC<Props> = ({
     if (swap?.claimable) {
       return {
         tone: 'info' as const,
-        heading: 'Claim broadcasting',
-        body: 'Boltz has locked funds on-chain. The claim transaction is broadcasting and usually confirms in a few minutes.',
+        heading: 'Finishing swap',
+        body: 'Boltz has locked funds on-chain. The transaction that finishes the swap is broadcasting and usually confirms in a few minutes.',
       };
     }
     // No live swap data yet — trust the row-tap iconState as a fallback.
@@ -328,7 +328,7 @@ const TransactionDetailSheet: React.FC<Props> = ({
       return {
         tone: 'warning' as const,
         heading: 'Needs attention',
-        body: 'Lightning was paid and the Boltz lockup confirmed, but the on-chain claim hasn’t broadcast yet. Your funds are safe — tap Retry claim below if it hasn’t cleared.',
+        body: 'Lightning was paid and the Boltz lockup confirmed, but the on-chain transaction that finishes the swap hasn’t broadcast yet. Your funds are safe — tap Finish swap below if it hasn’t cleared.',
       };
     }
     if (iconState === 'done') {
@@ -338,7 +338,7 @@ const TransactionDetailSheet: React.FC<Props> = ({
         heading: 'Swap complete',
         body: incoming
           ? 'Boltz received your on-chain payment and settled the Lightning side — funds are in your Lightning wallet.'
-          : 'Lightning was paid and Boltz’s on-chain lockup has been claimed to your Bitcoin address.',
+          : 'Lightning was paid and Boltz’s on-chain lockup has been swept to your Bitcoin address.',
       };
     }
     if (pending) {
@@ -646,7 +646,7 @@ const TransactionDetailSheet: React.FC<Props> = ({
           ) : null}
 
           {tx.txid ? <CopyRow label="On-chain tx" value={tx.txid} onCopy={copyValue} /> : null}
-          {claimTxId ? <CopyRow label="Claim tx" value={claimTxId} onCopy={copyValue} /> : null}
+          {claimTxId ? <CopyRow label="Finish tx" value={claimTxId} onCopy={copyValue} /> : null}
 
           {swap?.lockupTxId ? (
             <CopyRow label="Lockup tx" value={swap.lockupTxId} onCopy={copyValue} />
@@ -666,12 +666,12 @@ const TransactionDetailSheet: React.FC<Props> = ({
                 style={styles.primaryButton}
                 onPress={handleRetryClaim}
                 disabled={retrying}
-                accessibilityLabel="Retry claim"
+                accessibilityLabel="Finish swap"
               >
                 {retrying ? (
                   <ActivityIndicator color="#fff" />
                 ) : (
-                  <Text style={styles.primaryButtonText}>Retry claim</Text>
+                  <Text style={styles.primaryButtonText}>Finish swap</Text>
                 )}
               </TouchableOpacity>
             ) : null}
@@ -699,8 +699,8 @@ const TransactionDetailSheet: React.FC<Props> = ({
             ) : null}
             {swap?.claimable ? (
               <Text style={styles.info}>
-                Retry re-runs the swap recovery service, which will re-broadcast the claim
-                transaction from persisted swap state.
+                Finish swap re-runs the recovery service, which re-broadcasts the on-chain
+                transaction that finishes the swap from persisted swap state.
               </Text>
             ) : null}
           </View>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -184,22 +184,10 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
     };
   }, []);
 
-  /** Resolves the icon-corner badge for a row:
-   *   - 'attention' for any Boltz row whose paymentHash is currently in
-   *     swapRecoveryService's attention set;
-   *   - 'pending' for in-flight Boltz rows (so the lifecycle reads
-   *     clock → tick / warning instead of bare → tick);
-   *   - 'done' for settled INCOMING Boltz rows that aren't in the
-   *     attention set — on incoming swaps LN-settled implies the swap
-   *     is complete (Boltz received on-chain before paying our invoice);
-   *   - 'done' for settled OUTGOING Boltz rows whose claim has been
-   *     recorded in swapRecoveryService's claimed-hash cache (i.e. we've
-   *     observed the on-chain claim broadcast / Boltz reported terminal
-   *     success). Settled outgoing rows without a recorded claim stay
-   *     unbadged — the LN leg can settle before the claim broadcasts,
-   *     and a green tick on a stuck swap would be misleading;
-   *   - undefined (no badge) for vanilla Lightning rows and the
-   *     settled-but-claim-not-recorded outgoing case above. */
+  /** Maps a row's live swap-recovery flags (Boltz row? in the attention set?
+   *  claim recorded?) onto the icon badge. The badge rules — including why a
+   *  recorded claim shows 'done' even when `settled_at` is missing (the #891
+   *  ambiguous-pay case) — live in `swapIconState`. */
   const iconStateFor = (tx: WalletTransaction): TransactionIconState | undefined =>
     swapIconState(tx, {
       isBoltz: swapRecoveryService.isBoltzTransaction(tx),

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -16,6 +16,7 @@ import TransactionDetailSheet, {
 } from './TransactionDetailSheet';
 import SendSheet from './SendSheet';
 import TransactionTypeIcon, { TransactionIconState } from './TransactionTypeIcon';
+import { swapIconState } from '../utils/swapIconState';
 import { getTxCategory } from '../utils/txCategory';
 import * as swapRecoveryService from '../services/swapRecoveryService';
 import { isSupportedImageUrl } from '../utils/imageUrl';
@@ -199,17 +200,14 @@ const TransactionList: React.FC<Props> = ({ transactions }) => {
    *     and a green tick on a stuck swap would be misleading;
    *   - undefined (no badge) for vanilla Lightning rows and the
    *     settled-but-claim-not-recorded outgoing case above. */
-  const iconStateFor = (tx: WalletTransaction): TransactionIconState | undefined => {
-    if (!swapRecoveryService.isBoltzTransaction(tx)) return undefined;
-    if (tx.paymentHash && swapRecoveryService.getAttentionPaymentHashes().has(tx.paymentHash))
-      return 'attention';
-    const settled = Boolean(tx.settled_at || tx.blockHeight);
-    if (!settled) return 'pending';
-    if (tx.type === 'incoming') return 'done';
-    return tx.paymentHash && swapRecoveryService.hasClaimedPaymentHash(tx.paymentHash)
-      ? 'done'
-      : undefined;
-  };
+  const iconStateFor = (tx: WalletTransaction): TransactionIconState | undefined =>
+    swapIconState(tx, {
+      isBoltz: swapRecoveryService.isBoltzTransaction(tx),
+      inAttention: Boolean(
+        tx.paymentHash && swapRecoveryService.getAttentionPaymentHashes().has(tx.paymentHash),
+      ),
+      claimed: Boolean(tx.paymentHash && swapRecoveryService.hasClaimedPaymentHash(tx.paymentHash)),
+    });
 
   // Counterparty preview — opened from TransactionDetailSheet → "view
   // profile". A quick-peek bottom sheet first; "View full profile"

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -29,6 +29,7 @@ import { ArrowDownIcon, ArrowUpIcon, ArrowLeftRightIcon } from '../components/ic
 import { createHomeScreenStyles } from '../styles/HomeScreen.styles';
 import { isSendableWallet } from '../utils/walletCapabilities';
 import { perfLog } from '../utils/perfLog';
+import * as swapRecoveryService from '../services/swapRecoveryService';
 import type { MainTabParamList } from '../navigation/types';
 
 const HomeScreen: React.FC = () => {
@@ -206,6 +207,13 @@ const HomeScreen: React.FC = () => {
   const handleRefresh = async () => {
     setRefreshing(true);
     if (activeWalletId) fetchedWallets.current.delete(activeWalletId);
+    // Also retry any pending Boltz swap claims — recovery otherwise only runs
+    // at app startup, so a swap parked mid-session (e.g. an ambiguous pay that
+    // resolved later) would stay unclaimed until a full restart. Fire-and-
+    // forget; the single-flight guard dedupes against a startup pass.
+    swapRecoveryService.recoverPendingSwaps().catch((e) => {
+      console.warn('[Home] pull-to-refresh swap recovery failed:', e);
+    });
     // Explicit pull-to-refresh — force a full zap-resolver pass.
     await fetchData({ force: true });
     setRefreshing(false);

--- a/src/services/swapRecoveryService.ts
+++ b/src/services/swapRecoveryService.ts
@@ -446,7 +446,22 @@ export async function unregisterPendingSwap(swapId: string): Promise<void> {
  *  - If transaction.mempool/confirmed, build and broadcast claim tx
  *  - If already claimed or expired, clean up
  */
-export async function recoverPendingSwaps(): Promise<void> {
+// Single-flight guard: recovery now fires from several triggers (startup,
+// app-foreground, pull-to-refresh, "Continue in background", the detail
+// sheet). Without this, two overlapping passes could both try to claim the
+// same swap and double-broadcast. Concurrent callers share the in-flight
+// promise; a fresh pass only starts once the previous one settles.
+let recoveryInFlight: Promise<void> | null = null;
+
+export function recoverPendingSwaps(): Promise<void> {
+  if (recoveryInFlight) return recoveryInFlight;
+  recoveryInFlight = runRecoveryPass().finally(() => {
+    recoveryInFlight = null;
+  });
+  return recoveryInFlight;
+}
+
+async function runRecoveryPass(): Promise<void> {
   // Wipe the attention set at the start of every pass so it always reflects
   // the current persisted swap state and not stale entries from prior runs.
   // Without this, payment hashes for swaps that have since been removed

--- a/src/services/swapRecoveryService.ts
+++ b/src/services/swapRecoveryService.ts
@@ -440,10 +440,13 @@ export async function unregisterPendingSwap(swapId: string): Promise<void> {
 }
 
 /**
- * Attempt to recover all pending reverse swaps on app startup.
+ * Attempt to finish all pending reverse swaps. Fires from several triggers —
+ * app startup, pull-to-refresh, and the in-flight overlay's "Continue in
+ * background" dismiss — so a swap parked mid-session doesn't wait for a
+ * restart (see the single-flight guard below for why overlap is safe).
  * For each persisted swap:
  *  - Query Boltz API for current status
- *  - If transaction.mempool/confirmed, build and broadcast claim tx
+ *  - If transaction.mempool/confirmed, build and broadcast the claim tx
  *  - If already claimed or expired, clean up
  */
 // Single-flight guard: recovery now fires from several triggers (startup,

--- a/src/utils/swapIconState.test.ts
+++ b/src/utils/swapIconState.test.ts
@@ -1,0 +1,42 @@
+import { swapIconState } from './swapIconState';
+import type { WalletTransaction } from '../types/wallet';
+
+const tx = (over: Partial<WalletTransaction> = {}): WalletTransaction =>
+  ({ type: 'outgoing', amount: 1000, paymentHash: 'ph', ...over }) as WalletTransaction;
+
+const F = { isBoltz: true, inAttention: false, claimed: false };
+
+describe('swapIconState', () => {
+  it('returns undefined for non-Boltz rows', () => {
+    expect(swapIconState(tx(), { ...F, isBoltz: false })).toBeUndefined();
+  });
+
+  it("returns 'attention' when flagged, regardless of settled/claimed", () => {
+    expect(swapIconState(tx({ settled_at: 123 }), { ...F, inAttention: true })).toBe('attention');
+  });
+
+  it("returns 'pending' (clock) for an unsettled, unclaimed outgoing swap", () => {
+    expect(swapIconState(tx({ settled_at: null }), F)).toBe('pending');
+  });
+
+  it("returns 'done' for an outgoing swap with a recorded claim even when settled_at is unset (#891 ambiguous-pay)", () => {
+    // The core fix: pay_invoice was UNKNOWN so the LN leg never settled
+    // locally, but the swap completed and the claim was recorded.
+    expect(swapIconState(tx({ settled_at: null }), { ...F, claimed: true })).toBe('done');
+  });
+
+  it("returns 'done' for a settled incoming swap", () => {
+    expect(swapIconState(tx({ type: 'incoming', settled_at: 123 }), F)).toBe('done');
+  });
+
+  it('leaves a settled outgoing swap without a recorded claim unbadged', () => {
+    // LN leg can settle before the on-chain claim broadcasts — don't tick early.
+    expect(swapIconState(tx({ settled_at: 123 }), F)).toBeUndefined();
+  });
+
+  it('treats a blockHeight-confirmed row as settled', () => {
+    expect(swapIconState(tx({ type: 'incoming', settled_at: null, blockHeight: 800000 }), F)).toBe(
+      'done',
+    );
+  });
+});

--- a/src/utils/swapIconState.ts
+++ b/src/utils/swapIconState.ts
@@ -1,0 +1,37 @@
+import type { WalletTransaction } from '../types/wallet';
+import type { TransactionIconState } from '../components/TransactionTypeIcon';
+
+/**
+ * Resolve the corner badge for a transaction row's Boltz-swap icon, given the
+ * swap-recovery flags for that row. Pure so it can be unit-tested without the
+ * component/service.
+ *
+ * Order matters:
+ *  - non-Boltz rows get no badge;
+ *  - a row currently flagged for attention (Boltz locked on-chain, claim not
+ *    yet broadcast) shows 'attention';
+ *  - **a recorded claim marks an OUTGOING swap 'done' even when the row's
+ *    `settled_at` was never set** — that happens on the #891 ambiguous-pay
+ *    path, where `pay_invoice` returned UNKNOWN so the LN leg never settled
+ *    locally even though the swap completed (Boltz `invoice.settled`). Without
+ *    this the row is stuck on the 'pending' clock forever despite the detail
+ *    sheet's live poll showing "Finish swap → complete";
+ *  - otherwise unsettled rows are 'pending' (clock); settled incoming rows are
+ *    'done'; settled outgoing rows without a recorded claim stay unbadged (the
+ *    LN leg can settle before the claim broadcasts, and a premature tick would
+ *    mislead).
+ */
+export function swapIconState(
+  tx: WalletTransaction,
+  flags: { isBoltz: boolean; inAttention: boolean; claimed: boolean },
+): TransactionIconState | undefined {
+  if (!flags.isBoltz) return undefined;
+  if (flags.inAttention) return 'attention';
+  // Recorded claim ⇒ the swap terminally finished; trust it over a missing
+  // local settled flag for outgoing (Send-to-BTC reverse) rows.
+  if (tx.type === 'outgoing' && flags.claimed) return 'done';
+  const settled = Boolean(tx.settled_at || tx.blockHeight);
+  if (!settled) return 'pending';
+  if (tx.type === 'incoming') return 'done';
+  return undefined;
+}


### PR DESCRIPTION
Three fixes to the reverse-swap **finish** experience, all surfaced by a swap that hit the #891 ambiguous-pay path on a real device (Pixel, v1.3.8).

## Changes
1. **Recovery now retries from more than just app startup.** `recoverPendingSwaps()` was wired only into launch hydration, so a swap parked mid-session (or left via "Continue in background") stayed unclaimed until a full restart. It now also fires on **pull-to-refresh** and on the in-flight overlay's **"Continue in background"** dismiss, behind a new **single-flight guard** so overlapping triggers can't double-broadcast a claim.
2. **Stale "pending" clock fixed.** The list icon logic returned `pending` on `!settled_at` *before* checking whether the swap finished. On the #891 path `pay_invoice` returns UNKNOWN, so the LN leg's `settled_at` is never set even though the swap completed (Boltz `invoice.settled`, claim recorded) — leaving the row stuck on the clock while the detail sheet's live poll correctly showed complete. Extracted the icon logic to a pure, unit-tested `swapIconState()` that treats a recorded claim as `done` for outgoing rows regardless of `settled_at`.
3. **Renamed "Claim" → "Finish swap"** in the swap detail sheet (button, badge, headings, body, "Claim tx" → "Finish tx"). The prize-claim NFC/LNURL "claim" copy is intentionally left untouched.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` — 0 errors
- [x] `npx prettier --check` clean
- [x] `npx jest` — 1292/1292 pass (incl. new `swapIconState` suite: clock-when-unsettled, **done-when-claimed-despite-unset-settled_at (the #891 case)**, no premature tick, etc.)
- [x] Emulator smoke: app bundles + renders with the change; swap detail shows the renamed wording ("Swap complete", "…lockup has been **swept**…", "**Finish tx**") with no crash
- [ ] Live stale-clock repro is on the reporter's Pixel (two stuck "Send to BTC" clocks); verifies once this ships in a build and pull-to-refresh records the claim → row flips to done

Closes #902
