### PR TITLE
chore(release): v1.3.9 — finish-swap triggers + stale-clock fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Marketing version bump **v1.3.8 → v1.3.9**. (`versionCode`/`buildNumber` stay on EAS's remote auto-increment.)

### Shipping in v1.3.9
- **fix(swap)** — reverse-swap **finish** hardening (#902 / PR #903):
  - Swap claims now retry on **pull-to-refresh** and on **"Continue in background"**, not just at app startup (single-flight guarded) — no more needing a full restart.
  - Fixed the **stale "pending" clock**: a completed swap that hit the #891 ambiguous-pay path no longer stays on the clock in the list (it now reads "Swap complete", matching the detail sheet).
  - Renamed **"Claim" → "Finish swap"** in the swap detail.

On merge I tag `v1.3.9` on the squashed commit and publish the GitHub Release → EAS cloud builds (both platforms) + iOS TestFlight auto-submit.

## Test plan
- [x] PR #903 merged green: tsc / eslint / prettier / file-size / 1292 Jest tests
- [x] Emulator smoke: renamed wording renders, no breakage
- [x] Version bump only — no source change in this PR
