### PR TITLE
chore(nostr): add NIP-89 client tag to public Lightning Piggy events

### DIFF
--- a/src/services/nip89ClientTag.test.ts
+++ b/src/services/nip89ClientTag.test.ts
@@ -17,6 +17,9 @@ import type { HiddenPiggy } from './piggyStorageService';
 const CLIENT_TAG = ['client', 'Lightning Piggy'];
 const PK = 'a'.repeat(64);
 const PK2 = 'b'.repeat(64);
+const RELAY = 'wss://relay.example.com';
+// Realistic NIP-01 coordinate: <kind>:<64-hex-pubkey>:<d>.
+const CACHE_COORD = `37516:${PK}:d1`;
 
 describe('NIP-89 client tag', () => {
   it('is the bare two-element form', () => {
@@ -34,7 +37,7 @@ describe('NIP-89 client tag', () => {
     });
 
     it('kind 9734 — zap request', () => {
-      expect(createZapRequestEvent(PK, PK2, 1000, [], '').tags).toContainEqual(CLIENT_TAG);
+      expect(createZapRequestEvent(PK, PK2, 1000, [RELAY], '').tags).toContainEqual(CLIENT_TAG);
     });
 
     it('kind 30200 — group state', () => {
@@ -48,11 +51,11 @@ describe('NIP-89 client tag', () => {
     });
 
     it('kind 7516 — found log', () => {
-      expect(buildFoundLog('37516:abc:d1', 'found it').tags).toContainEqual(CLIENT_TAG);
+      expect(buildFoundLog(CACHE_COORD, 'found it').tags).toContainEqual(CLIENT_TAG);
     });
 
     it('kind 1111 — NIP-22 comment', () => {
-      expect(buildComment('37516:abc:d1', PK, 'note', 'note').tags).toContainEqual(CLIENT_TAG);
+      expect(buildComment(CACHE_COORD, PK, 'note', 'note').tags).toContainEqual(CLIENT_TAG);
     });
   });
 

--- a/src/services/nip89ClientTag.test.ts
+++ b/src/services/nip89ClientTag.test.ts
@@ -1,5 +1,5 @@
+import { LP_CLIENT_TAG } from './nip89ClientTag';
 import {
-  LP_CLIENT_TAG,
   createContactListEvent,
   createProfileEvent,
   createZapRequestEvent,

--- a/src/services/nip89ClientTag.test.ts
+++ b/src/services/nip89ClientTag.test.ts
@@ -1,0 +1,79 @@
+import {
+  LP_CLIENT_TAG,
+  createContactListEvent,
+  createProfileEvent,
+  createZapRequestEvent,
+  createGroupStateEvent,
+  createDirectMessageRumor,
+  createGroupChatRumor,
+} from './nostrService';
+import { buildCacheListing, buildFoundLog, buildComment } from './nostrPlacesService';
+import type { HiddenPiggy } from './piggyStorageService';
+
+// NIP-89 client tag (https://github.com/nostr-protocol/nips/blob/master/89.md).
+// The tag must ride on every PUBLIC event LP publishes (attribution +
+// client filtering) and must NOT appear on the kind-14 rumors that get
+// sealed into NIP-17 gift wraps, where it would leak client metadata.
+const CLIENT_TAG = ['client', 'Lightning Piggy'];
+const PK = 'a'.repeat(64);
+const PK2 = 'b'.repeat(64);
+
+describe('NIP-89 client tag', () => {
+  it('is the bare two-element form', () => {
+    expect([...LP_CLIENT_TAG]).toEqual(CLIENT_TAG);
+  });
+
+  describe('present on public events', () => {
+    it('kind 0 — profile metadata', () => {
+      expect(createProfileEvent({ name: 'piggy' }).tags).toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 3 — contact list', () => {
+      const ev = createContactListEvent([{ pubkey: PK, relay: null, petname: null }]);
+      expect(ev.tags).toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 9734 — zap request', () => {
+      expect(createZapRequestEvent(PK, PK2, 1000, [], '').tags).toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 30200 — group state', () => {
+      const ev = createGroupStateEvent({ groupId: 'g1', name: 'fam', memberPubkeys: [PK2] });
+      expect(ev.tags).toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 37516 — NIP-GC cache listing', () => {
+      const piggy = { id: 'p1', lat: 1, lon: 2 } as HiddenPiggy;
+      expect(buildCacheListing(piggy).tags).toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 7516 — found log', () => {
+      expect(buildFoundLog('37516:abc:d1', 'found it').tags).toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 1111 — NIP-22 comment', () => {
+      expect(buildComment('37516:abc:d1', PK, 'note', 'note').tags).toContainEqual(CLIENT_TAG);
+    });
+  });
+
+  describe('absent from NIP-17 gift-wrapped rumors', () => {
+    it('kind 14 — direct message rumor', () => {
+      const ev = createDirectMessageRumor({
+        senderPubkey: PK,
+        recipientPubkey: PK2,
+        content: 'hi',
+      });
+      expect(ev.tags).not.toContainEqual(CLIENT_TAG);
+    });
+
+    it('kind 14 — group chat rumor', () => {
+      const ev = createGroupChatRumor({
+        senderPubkey: PK,
+        subject: 'fam',
+        memberPubkeys: [PK2],
+        content: 'hi',
+      });
+      expect(ev.tags).not.toContainEqual(CLIENT_TAG);
+    });
+  });
+});

--- a/src/services/nip89ClientTag.ts
+++ b/src/services/nip89ClientTag.ts
@@ -1,0 +1,21 @@
+// NIP-89 client tag stamped onto the PUBLIC events Lightning Piggy publishes,
+// so that anything LP signs is attributable to the app and filterable by
+// client. See https://github.com/nostr-protocol/nips/blob/master/89.md
+//
+// NIP-89's first `client` argument is a human-readable application name (the
+// same string a 31990 application-handler advertises as its display name),
+// which is why this is "Lightning Piggy" and not a reverse-DNS app id. Real
+// clients follow the same convention (e.g. Damus tags "Damus", Primal tags
+// "Primal"). Reverse-DNS ids are an Android `applicationId` convention, not a
+// Nostr client-tag one.
+//
+// Bare two-element form for now. Once an LP application-handler event
+// (kind 31990) is published, this can be upgraded to the full
+// ['client', name, '31990:<pubkey>:<d>', '<relay-hint>'] coordinate so a
+// reader can resolve the handler (name, icon, supported kinds) from the tag.
+//
+// Deliberately NOT added to the kind-14 DM / group-chat rumors: those are
+// sealed into NIP-17 gift wraps, and a client tag inside the seal would leak
+// client metadata. Public events only — spread a fresh copy at each use site
+// (`[...LP_CLIENT_TAG]`) so no event aliases the shared array.
+export const LP_CLIENT_TAG = ['client', 'Lightning Piggy'] as const;

--- a/src/services/nip89ClientTag.ts
+++ b/src/services/nip89ClientTag.ts
@@ -17,5 +17,9 @@
 // Deliberately NOT added to the kind-14 DM / group-chat rumors: those are
 // sealed into NIP-17 gift wraps, and a client tag inside the seal would leak
 // client metadata. Public events only — spread a fresh copy at each use site
-// (`[...LP_CLIENT_TAG]`) so no event aliases the shared array.
-export const LP_CLIENT_TAG = ['client', 'Lightning Piggy'] as const;
+// (`[...LP_CLIENT_TAG]`) so no event aliases the shared array. Frozen so the
+// shared template can't be mutated in place.
+export const LP_CLIENT_TAG = Object.freeze(['client', 'Lightning Piggy']) as readonly [
+  'client',
+  'Lightning Piggy',
+];

--- a/src/services/nostrPlacesService.ts
+++ b/src/services/nostrPlacesService.ts
@@ -2,6 +2,7 @@ import type { VerifiedEvent } from 'nostr-tools';
 import { rot13 } from '../utils/rot13';
 import { encodeGeohash } from '../utils/geohash';
 import type { HiddenPiggy } from './piggyStorageService';
+import { LP_CLIENT_TAG } from './nostrService';
 
 /**
  * NIP-GC publish + subscribe layer. Wraps the existing SimplePool from
@@ -51,6 +52,7 @@ export const buildCacheListing = (
   }
   const g9 = piggy.geohash ?? encodeGeohash(piggy.lat, piggy.lon, 9);
   const tags: string[][] = [
+    [...LP_CLIENT_TAG],
     ['d', piggy.id],
     ['name', piggy.name ?? piggy.lnurlDescription?.slice(0, 60) ?? 'Hunt Piggy'],
   ];
@@ -134,7 +136,7 @@ export const buildFoundLog = (
   content: string,
   opts: { imageUrl?: string; sats?: number } = {},
 ): { kind: number; created_at: number; tags: string[][]; content: string } => {
-  const tags: string[][] = [['a', cacheCoord]];
+  const tags: string[][] = [[...LP_CLIENT_TAG], ['a', cacheCoord]];
   if (opts.imageUrl) tags.push(['image', opts.imageUrl]);
   if (typeof opts.sats === 'number' && opts.sats > 0) {
     tags.push(['amount', String(opts.sats)]);
@@ -154,6 +156,7 @@ export const buildComment = (
   type: 'dnf' | 'maintenance' | 'archived' | 'note' = 'note',
 ): { kind: number; created_at: number; tags: string[][]; content: string } => {
   const tags: string[][] = [
+    [...LP_CLIENT_TAG],
     // Root pointers (uppercase per NIP-22).
     ['A', cacheCoord],
     ['K', String(GC_LISTING_KIND)],

--- a/src/services/nostrPlacesService.ts
+++ b/src/services/nostrPlacesService.ts
@@ -2,7 +2,7 @@ import type { VerifiedEvent } from 'nostr-tools';
 import { rot13 } from '../utils/rot13';
 import { encodeGeohash } from '../utils/geohash';
 import type { HiddenPiggy } from './piggyStorageService';
-import { LP_CLIENT_TAG } from './nostrService';
+import { LP_CLIENT_TAG } from './nip89ClientTag';
 
 /**
  * NIP-GC publish + subscribe layer. Wraps the existing SimplePool from

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1134,6 +1134,9 @@ export interface GroupStateEventInput {
 /**
  * Build (unsigned) the kind-30200 group-state event. Caller is responsible
  * for signing + publishing — same pattern as createDirectMessageRumor.
+ *
+ * Tags: the NIP-89 `client` tag (LP_CLIENT_TAG, this is a public event),
+ * then `d` (groupId), `name`, and one `p` per member.
  */
 export function createGroupStateEvent(input: GroupStateEventInput): {
   kind: number;

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -20,8 +20,11 @@ import { slimDisplayProfile } from '../utils/profileSanitize';
 import { tagsToContacts } from '../utils/contacts';
 import { publishWrapsTrackingRelays } from './nostrDmPublish';
 import type { DmSendResult, OnDeliveryFinalized } from './nostrDmPublish';
+import { LP_CLIENT_TAG } from './nip89ClientTag';
 
 export type { DmSendResult };
+// Re-exported for back-compat: the canonical home is ./nip89ClientTag.
+export { LP_CLIENT_TAG };
 
 // Exported so feature-specific modules (e.g. nostrPlacesPublisher.ts for
 // the Hunt feature's NIP-GC subs) can share the single connection pool
@@ -179,21 +182,6 @@ const PROFILE_RELAYS = [
   'wss://relay.damus.io',
   'wss://nos.lol',
 ];
-
-// NIP-89 client tag stamped onto the PUBLIC events Lightning Piggy publishes,
-// so that anything LP signs is attributable to the app and filterable by
-// client. See https://github.com/nostr-protocol/nips/blob/master/89.md
-//
-// Bare two-element form for now. Once an LP application-handler event
-// (kind 31990) is published, this can be upgraded to the full
-// ['client', name, '31990:<pubkey>:<d>', '<relay-hint>'] coordinate so a
-// reader can resolve the handler (name, icon, supported kinds) from the tag.
-//
-// Deliberately NOT added to the kind-14 DM / group-chat rumors: those are
-// sealed into NIP-17 gift wraps, and a client tag inside the seal would leak
-// client metadata. Public events only — spread a fresh copy at each use site
-// (`[...LP_CLIENT_TAG]`) so no event aliases the shared array.
-export const LP_CLIENT_TAG = ['client', 'Lightning Piggy'] as const;
 
 export function decodeNsec(nsec: string): { pubkey: string; secretKey: Uint8Array } {
   const decoded = nip19.decode(nsec);
@@ -1153,11 +1141,7 @@ export function createGroupStateEvent(input: GroupStateEventInput): {
   tags: string[][];
   content: string;
 } {
-  const tags: string[][] = [
-    [...LP_CLIENT_TAG],
-    ['d', input.groupId],
-    ['name', input.name],
-  ];
+  const tags: string[][] = [[...LP_CLIENT_TAG], ['d', input.groupId], ['name', input.name]];
   for (const pk of input.memberPubkeys) {
     tags.push(['p', pk]);
   }

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -180,6 +180,21 @@ const PROFILE_RELAYS = [
   'wss://nos.lol',
 ];
 
+// NIP-89 client tag stamped onto the PUBLIC events Lightning Piggy publishes,
+// so that anything LP signs is attributable to the app and filterable by
+// client. See https://github.com/nostr-protocol/nips/blob/master/89.md
+//
+// Bare two-element form for now. Once an LP application-handler event
+// (kind 31990) is published, this can be upgraded to the full
+// ['client', name, '31990:<pubkey>:<d>', '<relay-hint>'] coordinate so a
+// reader can resolve the handler (name, icon, supported kinds) from the tag.
+//
+// Deliberately NOT added to the kind-14 DM / group-chat rumors: those are
+// sealed into NIP-17 gift wraps, and a client tag inside the seal would leak
+// client metadata. Public events only — spread a fresh copy at each use site
+// (`[...LP_CLIENT_TAG]`) so no event aliases the shared array.
+export const LP_CLIENT_TAG = ['client', 'Lightning Piggy'] as const;
+
 export function decodeNsec(nsec: string): { pubkey: string; secretKey: Uint8Array } {
   const decoded = nip19.decode(nsec);
   if (decoded.type !== 'nsec') {
@@ -795,6 +810,7 @@ export function createZapRequestEvent(
   zapEventId?: string,
 ): { kind: number; created_at: number; tags: string[][]; content: string; pubkey: string } {
   const tags: string[][] = [
+    [...LP_CLIENT_TAG],
     ['p', recipientPubkey],
     ['amount', amountMsats.toString()],
     ['relays', ...relays],
@@ -828,7 +844,7 @@ export function createContactListEvent(
   return {
     kind: 3,
     created_at: Math.floor(Date.now() / 1000),
-    tags,
+    tags: [[...LP_CLIENT_TAG], ...tags],
     content: '',
   };
 }
@@ -850,7 +866,7 @@ export function createProfileEvent(profileData: {
   return {
     kind: 0,
     created_at: Math.floor(Date.now() / 1000),
-    tags: [],
+    tags: [[...LP_CLIENT_TAG]],
     content: JSON.stringify(cleaned),
   };
 }
@@ -1138,6 +1154,7 @@ export function createGroupStateEvent(input: GroupStateEventInput): {
   content: string;
 } {
   const tags: string[][] = [
+    [...LP_CLIENT_TAG],
     ['d', input.groupId],
     ['name', input.name],
   ];


### PR DESCRIPTION
## What

Stamps a [NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md) `client` tag on the public events Lightning Piggy publishes, so anything LP signs is attributable to the app and filterable by client.

Adds a single constant `LP_CLIENT_TAG = ['client', 'Lightning Piggy']` (in its own module `src/services/nip89ClientTag.ts`) and applies it to the seven public builders:

- kind 0 — profile metadata
- kind 3 — contact list
- kind 9734 — zap request
- kind 30200 — group state
- kind 37516 — NIP-GC cache listing
- kind 7516 — found log
- kind 1111 — NIP-22 comment

Left **off** the two kind-14 NIP-17 rumors (`createDirectMessageRumor`, `createGroupChatRumor`) on purpose — those get sealed into gift wraps, and a client tag inside the seal would leak client metadata.

## Why

Treasures (treasures.to), which renders LP's Hunt caches, asked whether LP events could carry a client tag so LP-originated events can be attributed and filtered. This is the bare two-element form, which already covers attribution + filtering.

## Client-tag value: "Lightning Piggy" (not a reverse-DNS id)

NIP-89's `client` tag first argument is a **human-readable application name** — the same display name a kind-31990 application-handler advertises (`["client", <name>, "31990:<pubkey>:<d>", <relay-hint>]`). It is **not** a reverse-DNS `applicationId` like `com.lightningpiggy.app` (that's an Android packaging convention, not a Nostr one). Real-world clients confirm this: **Damus** tags `Damus`, **Primal** tags `Primal`, **Amethyst** tags `Amethyst`. So `Lightning Piggy` is the correct value, and the tag now uses it.

## Follow-up (not in this PR)

Once LP publishes a kind-31990 application-handler event (name / icon / supported kinds), the constant can be upgraded to the full coordinate form `['client', 'Lightning Piggy', '31990:<pubkey>:<d>', '<relay-hint>']` so a reader can resolve the handler from the tag. It's a single constant, so that's a one-line change when the handler exists.

## Test plan

- `npx jest src/services/nip89ClientTag.test.ts` — asserts the tag is present on all seven public builders (kinds 0, 3, 9734, 30200, 37516, 7516, 1111) and absent from both kind-14 rumors.
- `npx tsc --noEmit` — clean.
- `npx prettier --check` + `npx eslint` on the touched files — clean.
- `bash scripts/check-file-size.sh` — passes (the constant moved into its own module, so `nostrService.ts` shrank below its baseline rather than growing).
