### PR TITLE
fix(explore): future-only events + hide test-account content in prod (#916)

### DIFF
--- a/src/hooks/useExplorePlacesPersist.ts
+++ b/src/hooks/useExplorePlacesPersist.ts
@@ -1,0 +1,37 @@
+// Debounced write-through of the Explore in-memory state to AsyncStorage so
+// the next cold start has fresh content to hydrate from. Extracted from
+// ExploreHomeScreen (the screen just owns the state Maps; persistence is its
+// own concern).
+//
+// `stripHiddenForPersist` drops prod test-account ("Piggy") items before
+// saving so prod caches self-heal: stale entries left over from earlier
+// versions age out of storage instead of being re-saved forever and crowding
+// out real content (MAX_ENTRIES). In dev/preview the full set is persisted.
+
+import { useEffect } from 'react';
+import { type ParsedCache, type ParsedEvent } from '../services/nostrPlacesService';
+import { saveCaches, saveEvents } from '../services/nostrPlacesStorage';
+import { stripHiddenForPersist } from '../utils/exploreContentFilter';
+
+// We don't need to persist on every relay event — a slow debounce is plenty.
+const PERSIST_DEBOUNCE_MS = 1500;
+
+/** Write-through `caches` to AsyncStorage, debounced + prod-self-healing. */
+export const usePersistCaches = (caches: Map<string, ParsedCache>): void => {
+  useEffect(() => {
+    if (caches.size === 0) return;
+    const items = stripHiddenForPersist([...caches.values()], (c) => c.hiderPubkey);
+    const t = setTimeout(() => saveCaches(items), PERSIST_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [caches]);
+};
+
+/** Write-through `events` to AsyncStorage, debounced + prod-self-healing. */
+export const usePersistEvents = (events: Map<string, ParsedEvent>): void => {
+  useEffect(() => {
+    if (events.size === 0) return;
+    const items = stripHiddenForPersist([...events.values()], (e) => e.organiserPubkey);
+    const t = setTimeout(() => saveEvents(items), PERSIST_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [events]);
+};

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -43,7 +43,7 @@ import { subscribeNearbyEvents } from '../services/nostrPlacesPublisher';
 import { loadCachedEvents, peekCachedEventsSync, saveEvents } from '../services/nostrPlacesStorage';
 import { useCoalescedMap } from '../utils/useCoalescedMap';
 import { isFutureEvent } from '../utils/futureEvent';
-import { isHiddenInProd } from '../utils/exploreContentFilter';
+import { isHiddenInProd, stripHiddenForPersist } from '../utils/exploreContentFilter';
 
 interface Props {
   navigation: ExploreNavigation;
@@ -98,7 +98,20 @@ const EventsScreen: React.FC<Props> = ({ navigation }) => {
   }, [setEvents]);
   useEffect(() => {
     if (events.size === 0) return;
-    const t = setTimeout(() => saveEvents([...events.values()]), 1500);
+    const t = setTimeout(() => {
+      // Shed prod-hidden (test-account) AND past events before persisting so
+      // prod caches self-heal — stale Piggy/past entries seeded from earlier
+      // versions age out of storage instead of being re-saved forever and
+      // consuming MAX_ENTRIES slots. `stripHiddenForPersist` is a no-op in
+      // dev/preview; the future-only pass always applies (a past event is
+      // useless to re-show on any build). Mirrors ExploreHomeScreen (#917).
+      const nowSec = Math.floor(Date.now() / 1000);
+      const persistable = stripHiddenForPersist(
+        [...events.values()],
+        (e) => e.organiserPubkey,
+      ).filter((e) => isFutureEvent(e, nowSec));
+      saveEvents(persistable);
+    }, 1500);
     return () => clearTimeout(t);
   }, [events]);
   const [loading, setLoading] = useState(true);

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -42,6 +42,8 @@ import { type ParsedEvent } from '../services/nostrPlacesService';
 import { subscribeNearbyEvents } from '../services/nostrPlacesPublisher';
 import { loadCachedEvents, peekCachedEventsSync, saveEvents } from '../services/nostrPlacesStorage';
 import { useCoalescedMap } from '../utils/useCoalescedMap';
+import { isFutureEvent } from '../utils/futureEvent';
+import { isHiddenInProd } from '../utils/exploreContentFilter';
 
 interface Props {
   navigation: ExploreNavigation;
@@ -195,11 +197,13 @@ const EventsScreen: React.FC<Props> = ({ navigation }) => {
         // precision 3..9, so 3-char prefix is enough to catch them.
         const prefixes = geohashPrefixes(myGh, 3).filter((p) => p.length === 3);
         const closer = subscribeNearbyEvents(prefixes, (e) => {
-          // De-dupe by coord — replaceable events; only keep the
-          // newest revision and skip past events.
-          if (e.startsAt && e.startsAt < Math.floor(Date.now() / 1000) - 60 * 60) {
-            return;
-          }
+          // Hide the project's own test-account ("Piggy") events in the
+          // production app; dev/preview keep them for Maestro.
+          if (isHiddenInProd(e.organiserPubkey)) return;
+          // Skip events that have already finished (end, or start when no
+          // end / all-day). De-dupe by coord — replaceable events; only
+          // keep the newest revision.
+          if (!isFutureEvent(e, Math.floor(Date.now() / 1000))) return;
           // WoT filter — see `trustGraphService` for the threat model.
           // `isTrusted` is tier-aware post-#535 (returns true for 'all').
           if (!isTrustedRef.current(e.organiserPubkey)) {
@@ -269,14 +273,22 @@ const EventsScreen: React.FC<Props> = ({ navigation }) => {
     // by the user (sortBy = 'date' | 'distance'); the other key is the
     // tiebreaker so a 0-distance pair never randomly flips order between
     // renders.
-    const items = [...events.values()].map((event) => {
-      const center = event.geohash ? decodeGeohash(event.geohash) : null;
-      const distance =
-        pos && center
-          ? haversineMetres({ lat: pos.lat, lon: pos.lon }, { lat: center.lat, lon: center.lng })
-          : Number.POSITIVE_INFINITY;
-      return { event, distance };
-    });
+    // Re-apply the future-only filter at render time, not just at
+    // ingestion: events hydrated from the AsyncStorage mirror on cold
+    // start bypass the subscription callback, so a cached past event
+    // (e.g. last month's meetup) would otherwise paint until the live
+    // sub refreshes. `nowSec` is captured once per memo pass.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const items = [...events.values()]
+      .filter((event) => isFutureEvent(event, nowSec) && !isHiddenInProd(event.organiserPubkey))
+      .map((event) => {
+        const center = event.geohash ? decodeGeohash(event.geohash) : null;
+        const distance =
+          pos && center
+            ? haversineMetres({ lat: pos.lat, lon: pos.lon }, { lat: center.lat, lon: center.lng })
+            : Number.POSITIVE_INFINITY;
+        return { event, distance };
+      });
     items.sort((a, b) => {
       const startA = a.event.startsAt ?? Number.MAX_SAFE_INTEGER;
       const startB = b.event.startsAt ?? Number.MAX_SAFE_INTEGER;

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -70,7 +70,7 @@ import {
   haversineMetres,
 } from '../utils/geohash';
 import { isFutureEvent } from '../utils/futureEvent';
-import { isHiddenInProd } from '../utils/exploreContentFilter';
+import { isHiddenInProd, visibleCaches, visibleEvents } from '../utils/exploreContentFilter';
 import { usePersistCaches, usePersistEvents } from '../hooks/useExplorePlacesPersist';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { useTrustGraph } from '../contexts/TrustGraphContext';
@@ -472,12 +472,22 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     });
   }, []);
 
-  // Stable array projections of the caches/events Maps so React.memo on
-  // the consuming LibreMiniMap can short-circuit re-renders. Without
-  // these the parent's `[...caches.values()]` literal returns a fresh
-  // array reference every render and defeats the memo entirely.
-  const cachesArr = useMemo(() => [...caches.values()], [caches]);
-  const eventsArr = useMemo(() => [...events.values()], [events]);
+  // Stable array projections of the caches/events Maps so React.memo on the
+  // consuming LibreMiniMap can short-circuit re-renders (a fresh
+  // `[...caches.values()]` literal each render would defeat the memo). These
+  // feed the Explore hub mini-map, so they apply the SAME prod test-account
+  // hide (+ future-only for events) as the rails — cold-start items hydrated
+  // from AsyncStorage bypass the ingestion callback, so a hidden Piggy cache
+  // or past event would otherwise paint as a map marker (#917).
+  const cachesArr = useMemo(
+    () => visibleCaches([...caches.values()], (c) => c.hiderPubkey),
+    [caches],
+  );
+  const eventsArr = useMemo(
+    () =>
+      visibleEvents([...events.values()], (e) => e.organiserPubkey, Math.floor(Date.now() / 1000)),
+    [events],
+  );
 
   // Hydrate last-known caches + events from AsyncStorage so the rails
   // render instantly on cold start while the live relay subs backfill.

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -61,8 +61,6 @@ import {
   loadCachedEvents,
   peekCachedCachesSync,
   peekCachedEventsSync,
-  saveCaches,
-  saveEvents,
 } from '../services/nostrPlacesStorage';
 import {
   decodeGeohash,
@@ -73,6 +71,7 @@ import {
 } from '../utils/geohash';
 import { isFutureEvent } from '../utils/futureEvent';
 import { isHiddenInProd } from '../utils/exploreContentFilter';
+import { usePersistCaches, usePersistEvents } from '../hooks/useExplorePlacesPersist';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { useTrustGraph } from '../contexts/TrustGraphContext';
 import { createExploreHomeScreenStyles } from '../styles/ExploreHomeScreen.styles';
@@ -576,19 +575,10 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signedInPubkey, refreshKey, readRelayKey]);
 
-  // Write-through to AsyncStorage whenever the in-memory state grows
-  // so the next cold start has fresh content to hydrate from. Debounced
-  // via a slow useEffect — we don't need to persist on every event.
-  useEffect(() => {
-    if (caches.size === 0) return;
-    const t = setTimeout(() => saveCaches([...caches.values()]), 1500);
-    return () => clearTimeout(t);
-  }, [caches]);
-  useEffect(() => {
-    if (events.size === 0) return;
-    const t = setTimeout(() => saveEvents([...events.values()]), 1500);
-    return () => clearTimeout(t);
-  }, [events]);
+  // Write-through to AsyncStorage (debounced) so the next cold start hydrates
+  // fresh content; both hooks self-heal prod caches (drop stale test items).
+  usePersistCaches(caches);
+  usePersistEvents(events);
   // Counts of events arriving from pubkeys outside the trust set.
   // Surfaced as "N hidden — from outside your trust graph" so users
   // know the filter is doing something.

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -71,6 +71,8 @@ import {
   geohashNeighbours,
   haversineMetres,
 } from '../utils/geohash';
+import { isFutureEvent } from '../utils/futureEvent';
+import { isHiddenInProd } from '../utils/exploreContentFilter';
 import { useThemeColors } from '../contexts/ThemeContext';
 import { useTrustGraph } from '../contexts/TrustGraphContext';
 import { createExploreHomeScreenStyles } from '../styles/ExploreHomeScreen.styles';
@@ -666,6 +668,8 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     subsCloserRef.current.push(
       subscribeNearbyCaches(cachePrefixes, (c) => {
         if (cancelled) return;
+        // Hide test-account ("Piggy") Piglets in prod (kept in dev/preview).
+        if (isHiddenInProd(c.hiderPubkey)) return;
         // WoT filter: silently drop caches from pubkeys outside the
         // trust graph (an unverified cache could be a phishing LNURL
         // or, worse, a physical lure). Surfaced as a count instead so
@@ -692,8 +696,9 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
     subsCloserRef.current.push(
       subscribeNearbyEvents(eventPrefixes, (e) => {
         if (cancelled) return;
-        // Skip events that already started > 1h ago.
-        if (e.startsAt && e.startsAt < Math.floor(Date.now() / 1000) - 60 * 60) return;
+        // Hide test-account ("Piggy") events in prod; skip finished events.
+        if (isHiddenInProd(e.organiserPubkey)) return;
+        if (!isFutureEvent(e, Math.floor(Date.now() / 1000))) return;
         if (!isTrustedRef.current(e.organiserPubkey)) {
           setUntrustedEventCount((n) => n + 1);
           return;
@@ -794,15 +799,19 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
   const sortedCaches = useMemo(() => {
     const lowerPubkey = signedInPubkey?.toLowerCase() ?? null;
     const haveFix = typeof posLat === 'number' && typeof posLon === 'number';
-    let items = [...caches.values()].map((cache) => {
-      const center = cache.geohash ? decodeGeohash(cache.geohash) : null;
-      const distance =
-        haveFix && center
-          ? haversineMetres({ lat: posLat, lon: posLon }, { lat: center.lat, lon: center.lng })
-          : Number.POSITIVE_INFINITY;
-      const isOwn = lowerPubkey !== null && cache.hiderPubkey.toLowerCase() === lowerPubkey;
-      return { cache, distance, isOwn };
-    });
+    // Re-apply the prod test-account filter at render — cold-start caches
+    // hydrated from AsyncStorage bypass the ingestion callback.
+    let items = [...caches.values()]
+      .filter((cache) => !isHiddenInProd(cache.hiderPubkey))
+      .map((cache) => {
+        const center = cache.geohash ? decodeGeohash(cache.geohash) : null;
+        const distance =
+          haveFix && center
+            ? haversineMetres({ lat: posLat, lon: posLon }, { lat: center.lat, lon: center.lng })
+            : Number.POSITIVE_INFINITY;
+        const isOwn = lowerPubkey !== null && cache.hiderPubkey.toLowerCase() === lowerPubkey;
+        return { cache, distance, isOwn };
+      });
     // Trace own-listing trajectory so a missing-own-cache regression
     // can be diagnosed from logcat alone (#73 follow-up).
     const ownItems = items.filter((c) => c.isOwn);
@@ -840,14 +849,19 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
 
   const sortedEvents = useMemo(() => {
     const haveFix = typeof posLat === 'number' && typeof posLon === 'number';
-    let items = [...events.values()].map((event) => {
-      const center = event.geohash ? decodeGeohash(event.geohash) : null;
-      const distance =
-        haveFix && center
-          ? haversineMetres({ lat: posLat, lon: posLon }, { lat: center.lat, lon: center.lng })
-          : Number.POSITIVE_INFINITY;
-      return { event, distance };
-    });
+    // Re-apply future-only + prod test-account filters at render — a cached
+    // PAST event hydrated from AsyncStorage bypasses the ingestion callback.
+    const nowSec = Math.floor(Date.now() / 1000);
+    let items = [...events.values()]
+      .filter((event) => isFutureEvent(event, nowSec) && !isHiddenInProd(event.organiserPubkey))
+      .map((event) => {
+        const center = event.geohash ? decodeGeohash(event.geohash) : null;
+        const distance =
+          haveFix && center
+            ? haversineMetres({ lat: posLat, lon: posLon }, { lat: center.lat, lon: center.lng })
+            : Number.POSITIVE_INFINITY;
+        return { event, distance };
+      });
     // Keep events with no `g` tag (distance = ∞) — most NIP-52 publishers
     // (OrangePillApp etc.) don't include one, so dropping them would leave
     // the rail mostly empty even when legitimate Bitcoin meetups exist.

--- a/src/screens/HuntScreen.tsx
+++ b/src/screens/HuntScreen.tsx
@@ -41,6 +41,7 @@ import {
   haversineMetres,
 } from '../utils/geohash';
 import { useCoalescedMap } from '../utils/useCoalescedMap';
+import { isHiddenInProd, stripHiddenForPersist } from '../utils/exploreContentFilter';
 
 interface Props {
   navigation: ExploreNavigation;
@@ -148,7 +149,13 @@ const HuntScreen: React.FC<Props> = ({ navigation }) => {
   // Write-through (debounced) so the next cold start has fresh data.
   useEffect(() => {
     if (caches.size === 0) return;
-    const t = setTimeout(() => saveCaches([...caches.values()]), 1500);
+    const t = setTimeout(
+      // Strip prod-hidden (test-account) Piglets before persisting so prod
+      // caches self-heal — stale Piggy entries age out of storage instead
+      // of being re-saved forever (matches ExploreHomeScreen) (#917).
+      () => saveCaches(stripHiddenForPersist([...caches.values()], (c) => c.hiderPubkey)),
+      1500,
+    );
     return () => clearTimeout(t);
   }, [caches]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -241,7 +248,13 @@ const HuntScreen: React.FC<Props> = ({ navigation }) => {
       // re-filters instantly with no re-subscribe or relay round-trip.
       // Per-event work is just the coalescing enqueue (staleness drop +
       // newest-wins live in the hook's `shouldReplace`).
-      const closer = subscribeNearbyCaches(prefixes, (c) => enqueueCache(c.coord, c));
+      const closer = subscribeNearbyCaches(prefixes, (c) => {
+        // Drop test-account Piglets in production at ingestion so they never
+        // enter the Map (and so can't reach the rail, mini-map, or persist).
+        // No-op in dev/preview. Mirrors ExploreHomeScreen's discover guard (#917).
+        if (isHiddenInProd(c.hiderPubkey)) return;
+        enqueueCache(c.coord, c);
+      });
       // Drop the spinner after a beat — relays stream continuously, no EOSE wait.
       const settleTimer = setTimeout(() => setLoading(false), 1500);
       return () => {
@@ -285,6 +298,11 @@ const HuntScreen: React.FC<Props> = ({ navigation }) => {
     // Web-of-trust filter — drop caches from hiders outside the active
     // tier's trust graph. `isTrusted` short-circuits to true for 'all'.
     items = items.filter(({ cache }) => isTrusted(cache.hiderPubkey));
+    // Re-apply the prod test-account hide at render — cold-start caches
+    // hydrated from AsyncStorage bypass the ingestion guard above, so a
+    // stale Piggy entry could otherwise still paint here. No-op in
+    // dev/preview (mirrors ExploreHomeScreen's sortedCaches) (#917).
+    items = items.filter(({ cache }) => !isHiddenInProd(cache.hiderPubkey));
     return items;
   }, [caches, pos, selectedDifficulties, selectedTerrains, selectedTypes, isTrusted]);
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -51,6 +51,7 @@ import {
 import type { ParsedCache } from '../services/nostrPlacesService';
 import { useCoalescedMap } from '../utils/useCoalescedMap';
 import { fetchCachesByAuthor, subscribeNearbyCaches } from '../services/nostrPlacesPublisher';
+import { isHiddenInProd } from '../utils/exploreContentFilter';
 import { useNostr } from '../contexts/NostrContext';
 import { decodeGeohash, encodeGeohash, geohashNeighbours } from '../utils/geohash';
 import { btcMapIconComponent } from '../utils/btcMapIcon';
@@ -263,6 +264,9 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
         const prefixes = geohashNeighbours(myTile);
         cachesCloserRef.current?.();
         cachesCloserRef.current = subscribeNearbyCaches(prefixes, (cache) => {
+          // Hide the project's own test-account ("Piggy") Piglets on the
+          // map in the production app; dev/preview keep them for Maestro.
+          if (isHiddenInProd(cache.hiderPubkey)) return;
           caches.enqueue(cache.coord, cache);
         });
       } catch (e) {
@@ -365,6 +369,7 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
     // lingers on the map after it's gone from the list (#762).
     return [...caches.map.values()].filter(
       (c) =>
+        !isHiddenInProd(c.hiderPubkey) &&
         (c.isLpPiggy ? filters.piglet : filters.nipgcCache) &&
         isTrusted(c.hiderPubkey) &&
         (c.expiresAt === null || c.expiresAt > nowSec),

--- a/src/utils/appEnvironment.test.ts
+++ b/src/utils/appEnvironment.test.ts
@@ -1,0 +1,48 @@
+// Verify the prod-detection helper keys off the applicationId / bundle
+// identifier (com.lightningpiggy.app) and treats dev / preview / unknown
+// as NON-production (so test content keeps showing there).
+
+// Mutable mock for expo-application: the helper reads
+// `Application.applicationId` at call time, so we flip this between cases.
+// The getter closes over `mockApplicationId` (declared below the import per
+// `import/first`); it's only invoked at test time, after the module loads.
+jest.mock('expo-application', () => ({
+  get applicationId() {
+    return mockApplicationId;
+  },
+}));
+
+import { isProductionBuild, PRODUCTION_APPLICATION_ID } from './appEnvironment';
+
+let mockApplicationId: string | null = null;
+
+describe('isProductionBuild', () => {
+  afterEach(() => {
+    mockApplicationId = null;
+  });
+
+  it('is true for the bare production applicationId', () => {
+    mockApplicationId = PRODUCTION_APPLICATION_ID; // com.lightningpiggy.app
+    expect(isProductionBuild()).toBe(true);
+  });
+
+  it('is false for the .dev (development) variant', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    expect(isProductionBuild()).toBe(false);
+  });
+
+  it('is false for the .preview variant', () => {
+    mockApplicationId = 'com.lightningpiggy.app.preview';
+    expect(isProductionBuild()).toBe(false);
+  });
+
+  it('is false when the native module yields null (jest / web)', () => {
+    mockApplicationId = null;
+    expect(isProductionBuild()).toBe(false);
+  });
+
+  it('is false for an unrelated applicationId', () => {
+    mockApplicationId = 'com.someoneelse.app';
+    expect(isProductionBuild()).toBe(false);
+  });
+});

--- a/src/utils/appEnvironment.ts
+++ b/src/utils/appEnvironment.ts
@@ -1,0 +1,45 @@
+// Robust runtime "is this a production build?" check.
+//
+// Why not `__DEV__`? `__DEV__` is true only for Metro/dev-client bundles.
+// It is FALSE for *every* release-mode binary — including the EAS `preview`
+// and `development`-profile APKs that testers run. Those builds still want
+// to see the Piggy test accounts (Maestro flows depend on them), so keying
+// the prod content-hiding filter on `__DEV__` alone would wrongly hide test
+// content in preview and can't distinguish preview from production at all.
+//
+// The reliable signal we already mint per-variant is the applicationId /
+// bundle identifier (see app.config.ts):
+//   development → com.lightningpiggy.app.dev
+//   preview     → com.lightningpiggy.app.preview
+//   production  → com.lightningpiggy.app   (no suffix)
+// EAS sets `APP_VARIANT` per build profile (eas.json) which drives that
+// suffix, so the installed binary's applicationId is the single source of
+// truth for "which variant am I?" at runtime — it can't drift the way an
+// env var read at JS-bundle time can.
+//
+// `expo-application` exposes it as `Application.applicationId` on both
+// Android (the package name) and iOS (the bundle identifier).
+
+import * as Application from 'expo-application';
+
+// The canonical production applicationId / bundle identifier. Dev and
+// preview builds carry a `.dev` / `.preview` suffix; only production is
+// the bare id.
+export const PRODUCTION_APPLICATION_ID = 'com.lightningpiggy.app';
+
+/**
+ * True iff this binary is the public production build.
+ *
+ * - Returns `true` only when the installed applicationId is exactly
+ *   `com.lightningpiggy.app` (no `.dev` / `.preview` suffix).
+ * - Returns `false` for dev-client, the `development` EAS profile, and the
+ *   `preview` EAS profile — so Maestro / internal testers keep seeing the
+ *   Piggy test accounts.
+ * - Returns `false` when the native module is unavailable (e.g. jest /
+ *   web), which is the safe default: never hide content unless we're
+ *   *certain* this is production.
+ *
+ * `now`-free and side-effect-free so callers can treat it as a constant.
+ */
+export const isProductionBuild = (): boolean =>
+  Application.applicationId === PRODUCTION_APPLICATION_ID;

--- a/src/utils/exploreContentFilter.test.ts
+++ b/src/utils/exploreContentFilter.test.ts
@@ -7,7 +7,12 @@ jest.mock('expo-application', () => ({
   },
 }));
 
-import { isHiddenInProd, stripHiddenForPersist } from './exploreContentFilter';
+import {
+  isHiddenInProd,
+  stripHiddenForPersist,
+  visibleCaches,
+  visibleEvents,
+} from './exploreContentFilter';
 
 let mockApplicationId: string | null = null;
 
@@ -69,5 +74,85 @@ describe('stripHiddenForPersist', () => {
     mockApplicationId = 'com.lightningpiggy.app.dev';
     const out = stripHiddenForPersist(items, getPubkey);
     expect(out).not.toBe(items);
+  });
+});
+
+describe('visibleCaches (rail + mini-map)', () => {
+  interface Cache {
+    id: string;
+    pubkey: string;
+  }
+  const caches: Cache[] = [
+    { id: 'piggy', pubkey: BIG_PIGGY },
+    { id: 'real', pubkey: REAL_USER },
+  ];
+  const getPubkey = (c: Cache) => c.pubkey;
+
+  afterEach(() => {
+    mockApplicationId = null;
+  });
+
+  it('hides prod test-account Piglets so the mini-map matches the rail', () => {
+    mockApplicationId = 'com.lightningpiggy.app';
+    expect(visibleCaches(caches, getPubkey).map((c) => c.id)).toEqual(['real']);
+  });
+
+  it('shows everything in dev / preview', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    expect(visibleCaches(caches, getPubkey).map((c) => c.id)).toEqual(['piggy', 'real']);
+  });
+});
+
+describe('visibleEvents (rail + mini-map)', () => {
+  const NOW = 1_000_000_000;
+  interface Event {
+    id: string;
+    pubkey: string;
+    startsAt: number | null;
+    endsAt: number | null;
+  }
+  const futureReal: Event = {
+    id: 'future-real',
+    pubkey: REAL_USER,
+    startsAt: NOW + 3600,
+    endsAt: null,
+  };
+  const pastReal: Event = {
+    id: 'past-real',
+    pubkey: REAL_USER,
+    startsAt: NOW - 3600,
+    endsAt: null,
+  };
+  const futurePiggy: Event = {
+    id: 'future-piggy',
+    pubkey: BIG_PIGGY,
+    startsAt: NOW + 3600,
+    endsAt: null,
+  };
+  const getPubkey = (e: Event) => e.pubkey;
+
+  afterEach(() => {
+    mockApplicationId = null;
+  });
+
+  it('drops PAST events on every build', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    expect(visibleEvents([futureReal, pastReal], getPubkey, NOW).map((e) => e.id)).toEqual([
+      'future-real',
+    ]);
+  });
+
+  it('drops future PIGGY events in production but keeps real future events', () => {
+    mockApplicationId = 'com.lightningpiggy.app';
+    expect(
+      visibleEvents([futureReal, futurePiggy, pastReal], getPubkey, NOW).map((e) => e.id),
+    ).toEqual(['future-real']);
+  });
+
+  it('keeps future Piggy events in dev / preview (only past dropped)', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    expect(
+      visibleEvents([futureReal, futurePiggy, pastReal], getPubkey, NOW).map((e) => e.id),
+    ).toEqual(['future-real', 'future-piggy']);
   });
 });

--- a/src/utils/exploreContentFilter.test.ts
+++ b/src/utils/exploreContentFilter.test.ts
@@ -1,0 +1,41 @@
+// Verify the build-aware composition: a Piggy pubkey is hidden ONLY when
+// the build is production. Dev / preview must let it through (Maestro).
+
+jest.mock('expo-application', () => ({
+  get applicationId() {
+    return mockApplicationId;
+  },
+}));
+
+import { isHiddenInProd } from './exploreContentFilter';
+
+let mockApplicationId: string | null = null;
+
+const BIG_PIGGY = 'ccedbff9a6f261b388078b70225dfa4147efaab5f062a7722a0d253f0360c7e7';
+const REAL_USER = '1111111111111111111111111111111111111111111111111111111111111111';
+
+describe('isHiddenInProd', () => {
+  afterEach(() => {
+    mockApplicationId = null;
+  });
+
+  it('hides a Piggy test account in the production build', () => {
+    mockApplicationId = 'com.lightningpiggy.app';
+    expect(isHiddenInProd(BIG_PIGGY)).toBe(true);
+  });
+
+  it('does NOT hide a Piggy in the dev build', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    expect(isHiddenInProd(BIG_PIGGY)).toBe(false);
+  });
+
+  it('does NOT hide a Piggy in the preview build', () => {
+    mockApplicationId = 'com.lightningpiggy.app.preview';
+    expect(isHiddenInProd(BIG_PIGGY)).toBe(false);
+  });
+
+  it('never hides a real user, even in production', () => {
+    mockApplicationId = 'com.lightningpiggy.app';
+    expect(isHiddenInProd(REAL_USER)).toBe(false);
+  });
+});

--- a/src/utils/exploreContentFilter.test.ts
+++ b/src/utils/exploreContentFilter.test.ts
@@ -7,7 +7,7 @@ jest.mock('expo-application', () => ({
   },
 }));
 
-import { isHiddenInProd } from './exploreContentFilter';
+import { isHiddenInProd, stripHiddenForPersist } from './exploreContentFilter';
 
 let mockApplicationId: string | null = null;
 
@@ -37,5 +37,37 @@ describe('isHiddenInProd', () => {
   it('never hides a real user, even in production', () => {
     mockApplicationId = 'com.lightningpiggy.app';
     expect(isHiddenInProd(REAL_USER)).toBe(false);
+  });
+});
+
+describe('stripHiddenForPersist', () => {
+  interface Item {
+    id: string;
+    pubkey: string;
+  }
+  const items: Item[] = [
+    { id: 'piggy', pubkey: BIG_PIGGY },
+    { id: 'real', pubkey: REAL_USER },
+  ];
+  const getPubkey = (i: Item) => i.pubkey;
+
+  afterEach(() => {
+    mockApplicationId = null;
+  });
+
+  it('drops prod test-account items so the cache self-heals in production', () => {
+    mockApplicationId = 'com.lightningpiggy.app';
+    expect(stripHiddenForPersist(items, getPubkey).map((i) => i.id)).toEqual(['real']);
+  });
+
+  it('persists everything (incl. Piggies) in dev / preview', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    expect(stripHiddenForPersist(items, getPubkey).map((i) => i.id)).toEqual(['piggy', 'real']);
+  });
+
+  it('returns a fresh array (never mutates the input)', () => {
+    mockApplicationId = 'com.lightningpiggy.app.dev';
+    const out = stripHiddenForPersist(items, getPubkey);
+    expect(out).not.toBe(items);
   });
 });

--- a/src/utils/exploreContentFilter.ts
+++ b/src/utils/exploreContentFilter.ts
@@ -20,3 +20,18 @@ import { isHiddenInProdPubkey } from './testAccounts';
  */
 export const isHiddenInProd = (pubkey: string): boolean =>
   isProductionBuild() && isHiddenInProdPubkey(pubkey);
+
+/**
+ * Strip prod-hidden (test-account) items from a list before it's persisted
+ * to the Explore cache, so prod caches self-heal: stale Piggy entries left
+ * over from earlier versions age out of storage instead of being re-saved
+ * forever and crowding out real content. In dev/preview `isHiddenInProd` is
+ * always false, so the list passes through untouched.
+ *
+ * @param items     the list about to be persisted
+ * @param getPubkey projects an item → its author hex pubkey
+ */
+export const stripHiddenForPersist = <T>(
+  items: readonly T[],
+  getPubkey: (item: T) => string,
+): T[] => items.filter((item) => !isHiddenInProd(getPubkey(item)));

--- a/src/utils/exploreContentFilter.ts
+++ b/src/utils/exploreContentFilter.ts
@@ -1,0 +1,22 @@
+// Thin, build-aware composition layer over the pure Explore filters.
+//
+// Screens (ExploreHomeScreen, EventsScreen, MapScreen, …) import from
+// here so they get a single, ready-to-call API and don't each re-wire the
+// `isProductionBuild()` gate. The actual logic stays in the pure,
+// unit-tested helpers:
+//   - isFutureEvent          (futureEvent.ts)
+//   - isHiddenInProdPubkey   (testAccounts.ts)
+//   - isProductionBuild      (appEnvironment.ts)
+
+import { isProductionBuild } from './appEnvironment';
+import { isHiddenInProdPubkey } from './testAccounts';
+
+/**
+ * Per-event / per-cache predicate: should this author's content be hidden
+ * RIGHT NOW (i.e. is it a test account AND are we in production)?
+ *
+ * Drop-in for the relay-ingestion hot path — the build check short-circuits
+ * to `false` in dev/preview so it's a single boolean read there.
+ */
+export const isHiddenInProd = (pubkey: string): boolean =>
+  isProductionBuild() && isHiddenInProdPubkey(pubkey);

--- a/src/utils/exploreContentFilter.ts
+++ b/src/utils/exploreContentFilter.ts
@@ -34,4 +34,11 @@ export const isHiddenInProd = (pubkey: string): boolean =>
 export const stripHiddenForPersist = <T>(
   items: readonly T[],
   getPubkey: (item: T) => string,
-): T[] => items.filter((item) => !isHiddenInProd(getPubkey(item)));
+): T[] => {
+  // The build variant is constant for the process, so resolve the prod gate
+  // ONCE here rather than calling `isProductionBuild()` (a native-module
+  // read) per item inside the loop — relevant when persisting large cache /
+  // event lists. In dev/preview this short-circuits to a pass-through.
+  if (!isProductionBuild()) return [...items];
+  return items.filter((item) => !isHiddenInProdPubkey(getPubkey(item)));
+};

--- a/src/utils/exploreContentFilter.ts
+++ b/src/utils/exploreContentFilter.ts
@@ -10,6 +10,7 @@
 
 import { isProductionBuild } from './appEnvironment';
 import { isHiddenInProdPubkey } from './testAccounts';
+import { isFutureEvent, type EventTiming } from './futureEvent';
 
 /**
  * Per-event / per-cache predicate: should this author's content be hidden
@@ -41,4 +42,34 @@ export const stripHiddenForPersist = <T>(
   // event lists. In dev/preview this short-circuits to a pass-through.
   if (!isProductionBuild()) return [...items];
   return items.filter((item) => !isHiddenInProdPubkey(getPubkey(item)));
+};
+
+/**
+ * The caches to PAINT on an Explore surface (rail + mini-map): everything
+ * except prod-hidden test-account Piglets. Cold-start items hydrated from
+ * AsyncStorage bypass the ingestion guard, so this is re-applied at render so
+ * a stale hidden Piglet can't paint as a map marker (#917). No-op in
+ * dev/preview.
+ */
+export const visibleCaches = <T>(items: readonly T[], getPubkey: (item: T) => string): T[] => {
+  if (!isProductionBuild()) return [...items];
+  return items.filter((item) => !isHiddenInProdPubkey(getPubkey(item)));
+};
+
+/**
+ * The events to PAINT on an Explore surface: future-only AND (in prod) not
+ * authored by a test account. Same cold-start rationale as {@link visibleCaches}
+ * — a cached PAST or hidden event must not survive into the rail or mini-map.
+ *
+ * @param nowSeconds inject `Date.now()/1000`
+ */
+export const visibleEvents = <T extends EventTiming>(
+  items: readonly T[],
+  getPubkey: (item: T) => string,
+  nowSeconds: number,
+): T[] => {
+  const prod = isProductionBuild();
+  return items.filter(
+    (item) => isFutureEvent(item, nowSeconds) && !(prod && isHiddenInProdPubkey(getPubkey(item))),
+  );
 };

--- a/src/utils/futureEvent.test.ts
+++ b/src/utils/futureEvent.test.ts
@@ -1,0 +1,91 @@
+import { isFutureEvent, hideTestContentInProd } from './futureEvent';
+
+// Fixed reference "now": 2026-06-20T12:00:00Z = 1781006400 unix seconds.
+const NOW = Math.floor(Date.UTC(2026, 5, 20, 12, 0, 0) / 1000);
+const HOUR = 60 * 60;
+const DAY = 24 * HOUR;
+
+describe('isFutureEvent', () => {
+  it('keeps an event with no timing at all (Time TBA)', () => {
+    expect(isFutureEvent({ startsAt: null, endsAt: null }, NOW)).toBe(true);
+  });
+
+  it('keeps an event that is still in progress (started in the past, ends in the future)', () => {
+    expect(isFutureEvent({ startsAt: NOW - 2 * HOUR, endsAt: NOW + 2 * HOUR }, NOW)).toBe(true);
+  });
+
+  it('drops an event that has already ended', () => {
+    expect(isFutureEvent({ startsAt: NOW - 4 * HOUR, endsAt: NOW - 2 * HOUR }, NOW)).toBe(false);
+  });
+
+  it('keeps an event ending exactly now (inclusive boundary)', () => {
+    expect(isFutureEvent({ startsAt: NOW - HOUR, endsAt: NOW }, NOW)).toBe(true);
+  });
+
+  it('keeps a timed start-only event in the future', () => {
+    expect(isFutureEvent({ startsAt: NOW + HOUR, endsAt: null }, NOW)).toBe(true);
+  });
+
+  it('drops a timed start-only event in the past (no 1h grace — past is past)', () => {
+    // The OLD behaviour allowed a 1h grace window; the "17 May" style
+    // stale events are exactly what that let linger. Assert it's gone.
+    expect(isFutureEvent({ startsAt: NOW - 30 * 60, endsAt: null }, NOW)).toBe(false);
+  });
+
+  describe('all-day (date-based) events', () => {
+    // An all-day event has its start pinned to a midnight (day) boundary.
+    const todayMidnight = Math.floor(NOW / DAY) * DAY; // 2026-06-20T00:00:00Z
+
+    it('keeps an all-day event happening TODAY (not past until the day ends)', () => {
+      // NOW is midday; the all-day event started at 00:00 today.
+      expect(isFutureEvent({ startsAt: todayMidnight, endsAt: null }, NOW)).toBe(true);
+    });
+
+    it('keeps an all-day event in the future', () => {
+      expect(isFutureEvent({ startsAt: todayMidnight + DAY, endsAt: null }, NOW)).toBe(true);
+    });
+
+    it('drops an all-day event from a previous day', () => {
+      expect(isFutureEvent({ startsAt: todayMidnight - DAY, endsAt: null }, NOW)).toBe(false);
+    });
+
+    it('keeps a yesterday all-day event right up to the end of its day', () => {
+      const yesterdayMidnight = todayMidnight - DAY;
+      // One second before yesterday's day-end boundary, with now set there.
+      const justBeforeDayEnd = yesterdayMidnight + DAY - 1;
+      expect(isFutureEvent({ startsAt: yesterdayMidnight, endsAt: null }, justBeforeDayEnd)).toBe(
+        true,
+      );
+    });
+  });
+});
+
+describe('hideTestContentInProd', () => {
+  interface Item {
+    id: string;
+    pubkey: string;
+  }
+  const items: Item[] = [
+    { id: 'a', pubkey: 'test-pig' },
+    { id: 'b', pubkey: 'real-user' },
+    { id: 'c', pubkey: 'test-pig' },
+  ];
+  const getPubkey = (i: Item) => i.pubkey;
+  const isHidden = (pk: string) => pk === 'test-pig';
+
+  it('strips test-account items in production', () => {
+    const out = hideTestContentInProd(items, getPubkey, isHidden, true);
+    expect(out.map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('passes everything through in non-production (dev / preview)', () => {
+    const out = hideTestContentInProd(items, getPubkey, isHidden, false);
+    expect(out.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns a fresh array (does not mutate the input) even in dev', () => {
+    const out = hideTestContentInProd(items, getPubkey, isHidden, false);
+    expect(out).not.toBe(items);
+    expect(out).toEqual(items);
+  });
+});

--- a/src/utils/futureEvent.test.ts
+++ b/src/utils/futureEvent.test.ts
@@ -57,6 +57,14 @@ describe('isFutureEvent', () => {
         true,
       );
     });
+
+    it('drops an all-day event at the exact midnight rollover (now === start + DAY)', () => {
+      // Visible through 23:59:59 of its day, but NOT at the next day's
+      // 00:00:00 — the boundary uses a strict `>` comparison.
+      const start = todayMidnight;
+      expect(isFutureEvent({ startsAt: start, endsAt: null }, start + DAY - 1)).toBe(true);
+      expect(isFutureEvent({ startsAt: start, endsAt: null }, start + DAY)).toBe(false);
+    });
   });
 });
 

--- a/src/utils/futureEvent.ts
+++ b/src/utils/futureEvent.ts
@@ -19,7 +19,9 @@ export interface EventTiming {
 // `start` pinned to midnight. A start that lands exactly on a day boundary
 // is treated as all-day: it stays "not past" until the END of that day, so
 // an all-day event happening *today* still shows up all day rather than
-// disappearing at 00:00. 24h in seconds.
+// disappearing at 00:00. It vanishes exactly at the NEXT day's midnight
+// (visible through 23:59:59 of its day, but not at `start + 1 day`). 24h in
+// seconds.
 const ONE_DAY_SECONDS = 24 * 60 * 60;
 
 /**
@@ -33,8 +35,9 @@ const ONE_DAY_SECONDS = 24 * 60 * 60;
  *     yesterday but ends tomorrow is still happening, so it's shown).
  *   - Has only a `start`:
  *       · all-day (start on a midnight boundary) → future until the end of
- *         the start day (`start + 1 day >= now`), so a today all-day event
- *         survives the whole day.
+ *         the start day (`start + 1 day > now`), so a today all-day event
+ *         survives the whole day but disappears exactly at the next day's
+ *         midnight (`now === start + 1 day` is past).
  *       · timed → future iff `start >= now`. (No grace window — past is
  *         past. The old code's 1h grace let "17 May" style events linger.)
  *
@@ -54,7 +57,7 @@ export const isFutureEvent = (event: EventTiming, nowSeconds: number): boolean =
   const start = startsAt as number;
   const isAllDay = start % ONE_DAY_SECONDS === 0;
   if (isAllDay) {
-    return start + ONE_DAY_SECONDS >= nowSeconds;
+    return start + ONE_DAY_SECONDS > nowSeconds;
   }
   return start >= nowSeconds;
 };

--- a/src/utils/futureEvent.ts
+++ b/src/utils/futureEvent.ts
@@ -1,0 +1,84 @@
+// Pure helpers for the Explore "Events near you" surfaces:
+//   1. isFutureEvent  — should a calendar event still be shown, or is it
+//                       in the past?
+//   2. hideTestContentInProd — strip the project's own test-account
+//                       content from a list, but only in production.
+//
+// Both are pure (no Date.now(), no native modules) so they unit-test
+// trivially: the caller injects `now` / `isProd`.
+
+/** Minimal shape `isFutureEvent` needs — a subset of `ParsedEvent`. */
+export interface EventTiming {
+  /** Unix-seconds start, or null when the publisher omitted `start`. */
+  startsAt: number | null;
+  /** Unix-seconds end, or null when the publisher omitted `end`. */
+  endsAt: number | null;
+}
+
+// All-day / date-based events (NIP-52 kind 31922) are published with a
+// `start` pinned to midnight. A start that lands exactly on a day boundary
+// is treated as all-day: it stays "not past" until the END of that day, so
+// an all-day event happening *today* still shows up all day rather than
+// disappearing at 00:00. 24h in seconds.
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+/**
+ * Is this event upcoming (or in progress) rather than finished?
+ *
+ * Rules, in order:
+ *   - No timing at all (start AND end null) → KEEP. We can't prove it's
+ *     past, and "Time TBA" events are legitimately future-leaning; better
+ *     to show than to silently drop.
+ *   - Has an `end` → future iff `end >= now` (an event that started
+ *     yesterday but ends tomorrow is still happening, so it's shown).
+ *   - Has only a `start`:
+ *       · all-day (start on a midnight boundary) → future until the end of
+ *         the start day (`start + 1 day >= now`), so a today all-day event
+ *         survives the whole day.
+ *       · timed → future iff `start >= now`. (No grace window — past is
+ *         past. The old code's 1h grace let "17 May" style events linger.)
+ *
+ * @param event the event's start/end timestamps (unix seconds)
+ * @param nowSeconds current time in unix SECONDS (inject `Date.now()/1000`)
+ */
+export const isFutureEvent = (event: EventTiming, nowSeconds: number): boolean => {
+  const { startsAt, endsAt } = event;
+
+  if (startsAt === null && endsAt === null) return true;
+
+  if (endsAt !== null) {
+    return endsAt >= nowSeconds;
+  }
+
+  // start-only from here.
+  const start = startsAt as number;
+  const isAllDay = start % ONE_DAY_SECONDS === 0;
+  if (isAllDay) {
+    return start + ONE_DAY_SECONDS >= nowSeconds;
+  }
+  return start >= nowSeconds;
+};
+
+/**
+ * In PRODUCTION builds, remove items authored by the project's test
+ * accounts (the "Piggies"). In any other build the list passes through
+ * untouched so Maestro / internal testers still see the fixtures.
+ *
+ * Generic over the item shape: the caller supplies a `getPubkey`
+ * projection so the same helper covers both NIP-52 events
+ * (`e.organiserPubkey`) and NIP-GC caches / Piglets (`c.hiderPubkey`).
+ *
+ * @param items     the list to filter
+ * @param getPubkey projects an item → its author hex pubkey
+ * @param isHidden  membership test (e.g. `isHiddenInProdPubkey`)
+ * @param isProd    true only in the production build (`isProductionBuild()`)
+ */
+export const hideTestContentInProd = <T>(
+  items: readonly T[],
+  getPubkey: (item: T) => string,
+  isHidden: (pubkey: string) => boolean,
+  isProd: boolean,
+): T[] => {
+  if (!isProd) return [...items];
+  return items.filter((item) => !isHidden(getPubkey(item)));
+};

--- a/src/utils/testAccounts.test.ts
+++ b/src/utils/testAccounts.test.ts
@@ -42,7 +42,14 @@ describe('testAccounts (HIDDEN_IN_PROD_PUBKEYS)', () => {
     ).toBe(false);
   });
 
-  it('is case-sensitive (defensive — wire pubkeys are always lowercase)', () => {
-    expect(isHiddenInProdPubkey(PIGGIES.BIG.toUpperCase())).toBe(false);
+  it('matches case-insensitively (consistent with how pubkeys are normalized elsewhere)', () => {
+    // Wire pubkeys are normally lowercase, but an upstream decode or relay
+    // could hand us upper / mixed case — it must still be recognized as
+    // hidden so test-account content can't bypass the prod-hide.
+    expect(isHiddenInProdPubkey(PIGGIES.BIG.toUpperCase())).toBe(true);
+
+    const mixedCase =
+      PIGGIES.LITTLE.slice(0, 32).toUpperCase() + PIGGIES.LITTLE.slice(32).toLowerCase();
+    expect(isHiddenInProdPubkey(mixedCase)).toBe(true);
   });
 });

--- a/src/utils/testAccounts.test.ts
+++ b/src/utils/testAccounts.test.ts
@@ -1,0 +1,48 @@
+// Contract guards for the prod-hide test-account list. The data (which
+// pubkeys we hide in production) is the load-bearing thing — these tests
+// lock it in so a careless edit shows up as a failure, and confirm the
+// hex values match the canonical Maestro fixtures.
+
+import { __TEST__, isHiddenInProdPubkey } from './testAccounts';
+const { HIDDEN_IN_PROD_PUBKEYS } = __TEST__;
+
+// Decoded once from the MAESTRO_NPUB_* fixtures in .env (see PR body for
+// the npub → hex assumption). Re-derive with nostr-tools nip19.decode if
+// the fixtures ever rotate.
+const PIGGIES = {
+  BIG: 'ccedbff9a6f261b388078b70225dfa4147efaab5f062a7722a0d253f0360c7e7',
+  MIDDLE: '4b2fcb4e3c30c1363c4af5e3a6adebfe93cd572c3d57c31aaa4479d908612036',
+  LITTLE: 'd9b33280ba733261d8b559fde0d662b6cb0786e30785313a086cdca95639457e',
+  EVIL: '0b7475899c359de3eafeda471ebd7b8dea5e4d07f170570d8bfaece09876d4fc',
+};
+
+describe('testAccounts (HIDDEN_IN_PROD_PUBKEYS)', () => {
+  it('contains exactly the four Piggy test accounts (Big / Middle / Little / Evil)', () => {
+    const expected = Object.values(PIGGIES);
+    for (const pk of expected) {
+      expect(HIDDEN_IN_PROD_PUBKEYS.has(pk)).toBe(true);
+    }
+    expect(HIDDEN_IN_PROD_PUBKEYS.size).toBe(expected.length);
+  });
+
+  it('stores entries as lowercase hex (matches event.pubkey wire format)', () => {
+    for (const pk of HIDDEN_IN_PROD_PUBKEYS) {
+      expect(pk).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('isHiddenInProdPubkey returns true for each Piggy', () => {
+    expect(isHiddenInProdPubkey(PIGGIES.BIG)).toBe(true);
+    expect(isHiddenInProdPubkey(PIGGIES.EVIL)).toBe(true);
+  });
+
+  it('isHiddenInProdPubkey returns false for an arbitrary real user', () => {
+    expect(
+      isHiddenInProdPubkey('1111111111111111111111111111111111111111111111111111111111111111'),
+    ).toBe(false);
+  });
+
+  it('is case-sensitive (defensive — wire pubkeys are always lowercase)', () => {
+    expect(isHiddenInProdPubkey(PIGGIES.BIG.toUpperCase())).toBe(false);
+  });
+});

--- a/src/utils/testAccounts.ts
+++ b/src/utils/testAccounts.ts
@@ -1,0 +1,50 @@
+// The project's own Lightning Piggy TEST / demo Nostr accounts — the
+// "Piggies" (Big / Middle / Little / Evil). Their nsecs live in `.env`
+// (MAESTRO_NSEC_* / MAESTRO_NPUB_*) and Maestro E2E flows publish caches
+// (Piglets) and NIP-52 events as these identities. That test traffic is
+// exactly what we want to SEE in dev / preview builds, but it must NOT
+// leak into the public PRODUCTION app's Explore / near-you / map /
+// discover surfaces — real users shouldn't see "Big Piggy"'s demo
+// meetups and Piglets.
+//
+// This is distinct from `devEventDenylist.ts`:
+//   - devEventDenylist = orphaned, disposable signers we lost the key for.
+//     Filtered ALWAYS (every build) because the events are pure litter.
+//   - testAccounts (this file) = ACTIVE fixtures we still control and want
+//     in dev/preview. Filtered ONLY in production (see appEnvironment.ts).
+//
+// Format: lowercase hex pubkeys (what `event.pubkey` / `parsed.*Pubkey`
+// carry at the ingestion point) — same convention as devEventDenylist so
+// callers do no per-event decode work. The npubs are kept in comments so a
+// maintainer can eyeball them against `.env` (MAESTRO_NPUB_*).
+//
+// To add / remove a test account: edit THIS list only — it's the single
+// source of truth that every prod-hide call routes through.
+
+const HIDDEN_IN_PROD_PUBKEYS: ReadonlySet<string> = new Set([
+  // BIG Piggy — npub1enkml7dx7fsm8zq83dczyh06g9r7l2447p32wu32p5jn7qmqclns65f4st
+  'ccedbff9a6f261b388078b70225dfa4147efaab5f062a7722a0d253f0360c7e7',
+  // MIDDLE Piggy — npub1fvhukn3uxrqnv0z27h36dt0tl6fu64ev84tuxx42g3uajzrpyqmq8vtatq
+  '4b2fcb4e3c30c1363c4af5e3a6adebfe93cd572c3d57c31aaa4479d908612036',
+  // LITTLE Piggy — npub1mxen9q96wvexrk94t877p4nzkm9s0phrq7znzwsgdnw2j43eg4lqtqp265
+  'd9b33280ba733261d8b559fde0d662b6cb0786e30785313a086cdca95639457e',
+  // EVIL Piggy — npub1pd68tzvuxkw786h7mfr3a0tm3h49ung879c9wrvtltkwpxrk6n7qa38l77
+  '0b7475899c359de3eafeda471ebd7b8dea5e4d07f170570d8bfaece09876d4fc',
+]);
+
+/**
+ * Is this pubkey one of the Lightning Piggy test accounts that should be
+ * hidden in production builds? O(1) Set membership — safe to call per
+ * event on the relay-ingestion hot path.
+ *
+ * Pure / build-agnostic: this only answers "is it a test account?" — the
+ * PRODUCTION gate lives in the caller (combine with `isProductionBuild()`
+ * via `hideTestContentInProd`). That separation keeps this list trivially
+ * unit-testable without mocking the native build environment.
+ */
+export const isHiddenInProdPubkey = (pubkey: string): boolean => HIDDEN_IN_PROD_PUBKEYS.has(pubkey);
+
+// Test-only access to the underlying Set so tests can assert membership /
+// count without exposing a mutable surface to production callers. Mirrors
+// the `__TEST__` convention in devEventDenylist.ts.
+export const __TEST__ = { HIDDEN_IN_PROD_PUBKEYS };

--- a/src/utils/testAccounts.ts
+++ b/src/utils/testAccounts.ts
@@ -37,12 +37,18 @@ const HIDDEN_IN_PROD_PUBKEYS: ReadonlySet<string> = new Set([
  * hidden in production builds? O(1) Set membership — safe to call per
  * event on the relay-ingestion hot path.
  *
+ * Case-insensitive: the input is lower-cased before lookup (the Set is
+ * already canonical lowercase hex), matching how pubkeys are treated
+ * elsewhere in the codebase. A mixed/upper-case pubkey — which an upstream
+ * decode or relay could hand us — therefore can't slip past the prod-hide.
+ *
  * Pure / build-agnostic: this only answers "is it a test account?" — the
  * PRODUCTION gate lives in the caller (combine with `isProductionBuild()`
  * via `hideTestContentInProd`). That separation keeps this list trivially
  * unit-testable without mocking the native build environment.
  */
-export const isHiddenInProdPubkey = (pubkey: string): boolean => HIDDEN_IN_PROD_PUBKEYS.has(pubkey);
+export const isHiddenInProdPubkey = (pubkey: string): boolean =>
+  HIDDEN_IN_PROD_PUBKEYS.has(pubkey.toLowerCase());
 
 // Test-only access to the underlying Set so tests can assert membership /
 // count without exposing a mutable surface to production callers. Mirrors


### PR DESCRIPTION
## Summary

Fixes two related defects on the Explore **"Events near you"** rail and the wider Explore / map / discover surfaces.

### Issue 1 — Events are now future-only
Past events ("17 May", "18 May") no longer show. The old guard lived only in the live relay callback and used `startsAt < now - 1h`, which:
- ignored `endsAt` (dropped in-progress events that started yesterday but end tomorrow),
- let recently-started events linger for an hour, and
- **never ran on events hydrated from the AsyncStorage cache on cold start** — the actual "17 May" symptom.

New pure helper `isFutureEvent(event, nowSeconds)`:
- no timing at all → keep ("Time TBA"),
- has `end` → future iff `end >= now` (in-progress events stay),
- start-only **all-day** (start on a midnight boundary) → visible until the **end of that day** (today's all-day event survives the whole day),
- start-only **timed** → future iff `start >= now` (no grace window).

Applied at **both** the ingestion callback **and** the render-time `useMemo` so cached past events can't paint.

### Issue 2 — Test-account ("Piggy") content hidden in production
The Big / Middle / Little / Evil **"Piggy"** test accounts (used by Maestro) published demo events + Piglets that leaked into every build. They're now hidden in **production** only — **dev / preview still show them** so Maestro keeps working.

This is separate from `devEventDenylist.ts` (orphaned disposable signers, hidden in *all* builds). The Piggies are *active* fixtures we control, so they get a prod-only filter.

### Hidden pubkey set + assumption
> **Assumption (please confirm):** the original report said "pigeons" — read as **Piggies** = the test accounts. Hidden pubkeys are the four `MAESTRO_NPUB_*` identities, decoded npub → hex:

| Account | npub | hex pubkey |
| --- | --- | --- |
| BIG | `npub1enkml7dx7fsm8zq83dczyh06g9r7l2447p32wu32p5jn7qmqclns65f4st` | `ccedbff9a6f261b388078b70225dfa4147efaab5f062a7722a0d253f0360c7e7` |
| MIDDLE | `npub1fvhukn3uxrqnv0z27h36dt0tl6fu64ev84tuxx42g3uajzrpyqmq8vtatq` | `4b2fcb4e3c30c1363c4af5e3a6adebfe93cd572c3d57c31aaa4479d908612036` |
| LITTLE | `npub1mxen9q96wvexrk94t877p4nzkm9s0phrq7znzwsgdnw2j43eg4lqtqp265` | `d9b33280ba733261d8b559fde0d662b6cb0786e30785313a086cdca95639457e` |
| EVIL | `npub1pd68tzvuxkw786h7mfr3a0tm3h49ung879c9wrvtltkwpxrk6n7qa38l77` | `0b7475899c359de3eafeda471ebd7b8dea5e4d07f170570d8bfaece09876d4fc` |

All four live in one editable constant — `HIDDEN_IN_PROD_PUBKEYS` in `src/utils/testAccounts.ts` — so the maintainer can correct the set in one place.

### Prod detection
`src/utils/appEnvironment.ts` → `isProductionBuild()` checks `Application.applicationId === 'com.lightningpiggy.app'`. We deliberately **do not** use `__DEV__` alone: it's false for *every* release binary, so it can't tell EAS **production** from **preview**. The per-variant applicationId (`.dev` / `.preview` suffix vs bare id, set per EAS profile in `eas.json` / `app.config.ts`) is the one runtime signal that can. Unknown / null id → treated as non-prod (safe default: never hide unless certain).

## Files changed
- **New** `src/utils/futureEvent.ts` — pure `isFutureEvent` + generic `hideTestContentInProd`.
- **New** `src/utils/appEnvironment.ts` — `isProductionBuild()` + `PRODUCTION_APPLICATION_ID`.
- **New** `src/utils/testAccounts.ts` — `HIDDEN_IN_PROD_PUBKEYS` + `isHiddenInProdPubkey`.
- **New** `src/utils/exploreContentFilter.ts` — build-aware `isHiddenInProd` (composes the three above).
- `src/screens/ExploreHomeScreen.tsx` — future + prod-hide for events; prod-hide for caches (ingestion + render). Kept at the **1377-line baseline** (not grown).
- `src/screens/EventsScreen.tsx` — future + prod-hide (ingestion + render).
- `src/screens/MapScreen.tsx` — prod-hide for Piglets (ingestion + render).
- **New tests** (27): `futureEvent.test.ts`, `appEnvironment.test.ts`, `testAccounts.test.ts`, `exploreContentFilter.test.ts` (co-located per `jest.config.js` `testMatch`).

## Scope / coordination
Events + the shared prod-hiding util only. The Explore **PLACES** sections (featured-places ordering, places caching) are untouched — left for the concurrent PRs.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] ESLint (changed files) — 0 errors (pre-existing warnings only; test `import/first` matches the repo's existing jest-mock pattern)
- [x] Prettier — all changed files conform
- [x] `bash scripts/check-file-size.sh` — passes; `ExploreHomeScreen.tsx` stays at 1377
- [x] `npx jest` new + related suites — 47 passed (27 new)

### How to verify on the emulator (for the reviewer)
**Future-only events** (works in any build):
1. Open Explore → "Events near you" (and the Events sub-screen). Confirm every visible event's date is today-or-later; no past dates.
2. To force the cached-past-event path: with cached events present, change the device clock forward a few weeks, cold-start the app, reopen Explore — previously-future events that are now past must disappear (they no longer paint from cache, then the live sub confirms).

**Test-content hiding** — note this is a **prod-only** path, so a normal dev build will STILL show the Piggies (by design). To verify:
- **Unit test (fastest):** `npx jest src/utils/exploreContentFilter.test.ts src/utils/testAccounts.test.ts` — proves a Piggy pubkey is hidden when applicationId is `com.lightningpiggy.app` and shown for `.dev` / `.preview`.
- **Real prod path:** sideload a cloud-built **production** APK (CLAUDE.md → "Sideloading a release-flavor APK") and confirm Piggy events/Piglets are absent from Explore / map. A locally-signed prod build works too.
- **Temporary dev override (if you want to eyeball it in dev):** make `isProductionBuild()` return `true` for one run — the Piggies should vanish from Explore/Events/Map; revert after.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)
