### PR TITLE
fix(location): work without Google Play Services on GrapheneOS / AOSP (#918)

### DIFF
--- a/src/components/LocationPickerSheet.tsx
+++ b/src/components/LocationPickerSheet.tsx
@@ -9,6 +9,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,
@@ -174,7 +175,8 @@ const LocationPickerSheet: React.FC<Props> = ({
       .then((perm) => {
         if (cancelled) return;
         if (perm.status !== 'granted') return; // last-known/UK paths take over
-        return Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+        // No-Play-Services-safe one-shot fix (see aospLocation.ts).
+        return getOneShotPosition();
       })
       .then((pos) => {
         if (!pos || cancelled) return;

--- a/src/hooks/useLiveUserLocation.ts
+++ b/src/hooks/useLiveUserLocation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import * as Location from 'expo-location';
+import { oneShotPositionOptions } from '../services/aospLocation';
 
 /**
  * Live user-location subscription for map views.
@@ -155,7 +156,11 @@ export function useLiveUserLocation(
       // already bit us in `locationService.ts`) silently block the
       // live subscription forever — so the dot would freeze on the
       // last-known fix and never update.
-      Location.getCurrentPositionAsync({ accuracy })
+      // `oneShotPositionOptions` adds `mayShowUserSettingsDialog: false` so
+      // the one-shot fix never hits the Play `SettingsClient` path that
+      // rejects with "unsatisfied device settings" on de-Googled devices.
+      // See src/services/aospLocation.ts.
+      Location.getCurrentPositionAsync(oneShotPositionOptions(accuracy))
         .then((fresh) => {
           if (cancelled) return;
           applyIfNewer(fresh);

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -13,6 +13,7 @@ import {
   RefreshControl,
 } from 'react-native';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 import {
   CalendarDays,
   ChevronLeft,
@@ -179,9 +180,8 @@ const EventsScreen: React.FC<Props> = ({ navigation }) => {
           setLoading(false);
           return;
         }
-        const liveFix = await Location.getCurrentPositionAsync({
-          accuracy: Location.Accuracy.High,
-        });
+        // No-Play-Services-safe one-shot fix (see aospLocation.ts).
+        const liveFix = await getOneShotPosition();
         // Focus was lost while we awaited location — bail before opening a
         // sub the cleanup already ran past.
         if (cancelled()) return;

--- a/src/screens/ExploreHomeScreen.tsx
+++ b/src/screens/ExploreHomeScreen.tsx
@@ -9,6 +9,7 @@ import {
   RefreshControl,
 } from 'react-native';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   CalendarDays,
@@ -172,9 +173,8 @@ const ExploreHomeScreen: React.FC<Props> = ({ navigation }) => {
         // Non-fatal — fall through to getCurrentPositionAsync.
       }
       try {
-        const current = await Location.getCurrentPositionAsync({
-          accuracy: Location.Accuracy.High,
-        });
+        // No-Play-Services-safe one-shot fix (see aospLocation.ts).
+        const current = await getOneShotPosition();
         if (!cancelled) {
           setPos({
             lat: current.coords.latitude,

--- a/src/screens/HuntCreateScreen.tsx
+++ b/src/screens/HuntCreateScreen.tsx
@@ -16,6 +16,7 @@ import { CameraView, useCameraPermissions } from 'expo-camera';
 import * as Clipboard from 'expo-clipboard';
 import * as ImagePicker from 'expo-image-picker';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 // SAF + base64 helpers live on the legacy expo-file-system module. The
 // new class API (File/Paths) doesn't expose StorageAccessFramework yet,
 // so we mix the two: class API for the cache copy, legacy for the SAF
@@ -822,9 +823,7 @@ const HuntCreateScreen: React.FC<Props> = ({ navigation, route }) => {
         ]);
         return;
       }
-      const pos = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      const lat = pos.coords.latitude;
-      const lon = pos.coords.longitude;
+      const { latitude: lat, longitude: lon } = (await getOneShotPosition()).coords;
       setPin({ lat, lon, geohash: encodeGeohash(lat, lon, 9) });
     } catch (e) {
       Alert.alert('Could not get location', (e as Error).message, [{ text: 'OK' }]);

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -12,6 +12,7 @@ import {
   InteractionManager,
 } from 'react-native';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 import {
   ChevronLeft,
   Clock,
@@ -206,9 +207,8 @@ const MapScreen: React.FC<Props> = ({ navigation, route }) => {
         accuracy = livePos.accuracy;
       } else {
         try {
-          const pos = await Location.getCurrentPositionAsync({
-            accuracy: Location.Accuracy.High,
-          });
+          // No-Play-Services-safe one-shot fix (see aospLocation.ts).
+          const pos = await getOneShotPosition();
           if (cancelled) return;
           lat = pos.coords.latitude;
           lon = pos.coords.longitude;

--- a/src/screens/PlaceDetailScreen.tsx
+++ b/src/screens/PlaceDetailScreen.tsx
@@ -10,6 +10,7 @@ import {
   Share,
 } from 'react-native';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 import {
   Accessibility,
   ChevronLeft,
@@ -145,9 +146,8 @@ const PlaceDetailScreen: React.FC<Props> = ({ navigation, route }) => {
         try {
           const perm = await Location.requestForegroundPermissionsAsync();
           if (perm.status === 'granted') {
-            const fix = await Location.getCurrentPositionAsync({
-              accuracy: Location.Accuracy.High,
-            });
+            // No-Play-Services-safe one-shot fix (see aospLocation.ts).
+            const fix = await getOneShotPosition();
             if (!cancelled) {
               setPos({ lat: fix.coords.latitude, lon: fix.coords.longitude });
             }

--- a/src/screens/PlacesScreen.tsx
+++ b/src/screens/PlacesScreen.tsx
@@ -12,6 +12,7 @@ import {
   Image,
 } from 'react-native';
 import * as Location from 'expo-location';
+import { getOneShotPosition } from '../services/aospLocation';
 import {
   ChevronLeft,
   ChevronRight,
@@ -102,9 +103,8 @@ const PlacesScreen: React.FC<Props> = ({ navigation }) => {
         setLoading(false);
         return;
       }
-      const fix = await Location.getCurrentPositionAsync({
-        accuracy: Location.Accuracy.High,
-      });
+      // No-Play-Services-safe one-shot fix (see aospLocation.ts).
+      const fix = await getOneShotPosition();
       const lat = fix.coords.latitude;
       const lon = fix.coords.longitude;
       setPos({ lat, lon });

--- a/src/services/aospLocation.test.ts
+++ b/src/services/aospLocation.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the GrapheneOS / no-Play-Services location helpers.
+ *
+ * The contract that matters for de-Googled devices and the bare AOSP
+ * emulator is a single flag: every one-shot fix MUST pass
+ * `mayShowUserSettingsDialog: false`. With the default (`true`) the
+ * expo-location native module routes through the Google Play
+ * `SettingsClient.checkLocationSettings()` path and rejects with
+ * "unsatisfied device settings" on devices with no Play Services. These
+ * tests pin that flag down so a future refactor can't silently drop it.
+ */
+import * as Location from 'expo-location';
+import {
+  DEFAULT_LOCATION_ACCURACY,
+  getOneShotPosition,
+  oneShotPositionOptions,
+} from './aospLocation';
+
+jest.mock('expo-location', () => ({
+  __esModule: true,
+  getCurrentPositionAsync: jest.fn(),
+  Accuracy: { Lowest: 1, Low: 2, Balanced: 3, High: 4, Highest: 5, BestForNavigation: 6 },
+}));
+
+const mockedLocation = Location as jest.Mocked<typeof Location>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('oneShotPositionOptions', () => {
+  it('always disables the Play-Services settings dialog', () => {
+    expect(oneShotPositionOptions().mayShowUserSettingsDialog).toBe(false);
+  });
+
+  it('defaults to High accuracy (PRIORITY_HIGH_ACCURACY → GPS provider)', () => {
+    expect(DEFAULT_LOCATION_ACCURACY).toBe(Location.Accuracy.High);
+    expect(oneShotPositionOptions().accuracy).toBe(Location.Accuracy.High);
+  });
+
+  it('honours an explicit accuracy override while keeping the dialog off', () => {
+    const opts = oneShotPositionOptions(Location.Accuracy.Balanced);
+    expect(opts.accuracy).toBe(Location.Accuracy.Balanced);
+    expect(opts.mayShowUserSettingsDialog).toBe(false);
+  });
+});
+
+describe('getOneShotPosition', () => {
+  it('calls getCurrentPositionAsync with the no-Play-dialog options', async () => {
+    const fix = {
+      coords: { latitude: 1, longitude: 2, accuracy: 5 },
+      timestamp: 1000,
+    } as Awaited<ReturnType<typeof Location.getCurrentPositionAsync>>;
+    mockedLocation.getCurrentPositionAsync.mockResolvedValue(fix);
+
+    const result = await getOneShotPosition();
+
+    expect(result).toBe(fix);
+    expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledWith({
+      accuracy: Location.Accuracy.High,
+      mayShowUserSettingsDialog: false,
+    });
+  });
+
+  it('forwards a custom accuracy to getCurrentPositionAsync', async () => {
+    mockedLocation.getCurrentPositionAsync.mockResolvedValue(
+      {} as Awaited<ReturnType<typeof Location.getCurrentPositionAsync>>,
+    );
+
+    await getOneShotPosition(Location.Accuracy.Lowest);
+
+    expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledWith({
+      accuracy: Location.Accuracy.Lowest,
+      mayShowUserSettingsDialog: false,
+    });
+  });
+
+  it('propagates rejections (caller decides how to handle a failed fix)', async () => {
+    mockedLocation.getCurrentPositionAsync.mockRejectedValue(new Error('no fix'));
+    await expect(getOneShotPosition()).rejects.toThrow('no fix');
+  });
+});

--- a/src/services/aospLocation.ts
+++ b/src/services/aospLocation.ts
@@ -1,0 +1,83 @@
+import * as Location from 'expo-location';
+
+/**
+ * GrapheneOS / de-Googled / bare-AOSP-safe location helpers.
+ *
+ * ## The bug this fixes
+ *
+ * On a device WITHOUT Google Play Services (GrapheneOS, /e/OS, and the
+ * stock AOSP emulator image), one-shot location requests failed with:
+ *
+ *   "Location request failed due to unsatisfied device settings"
+ *
+ * That string is expo-location's `LocationSettingsUnsatisfiedException`,
+ * raised from a Play-Services-only code path. Walking it through the
+ * native module (`expo-location/android/.../LocationModule.kt`):
+ *
+ *   - `getCurrentPositionAsync` → `getCurrentLocationImplementation`.
+ *   - If the **NETWORK_PROVIDER is disabled** AND `mayShowUserSettingsDialog`
+ *     is true (its default), it does NOT request a fix directly. Instead it
+ *     calls `resolveUserSettingsForRequest`, which uses
+ *     `LocationServices.getSettingsClient(ctx).checkLocationSettings(...)`
+ *     — the Google Play `SettingsClient`. On a device with no Play Services
+ *     that task fails (not `RESOLUTION_REQUIRED`), so the module rejects
+ *     with `LocationSettingsUnsatisfiedException`.
+ *   - On a stock AOSP emulator the NETWORK_PROVIDER is typically off (GPS
+ *     only, fed by `adb emu geo fix`), so this path is hit every time and
+ *     location never resolves.
+ *
+ * ## The fix
+ *
+ * Pass `mayShowUserSettingsDialog: false`. With that flag the native
+ * module skips the `SettingsClient` branch entirely and goes straight to
+ * `requestSingleLocation`, which requests the fix from the provider
+ * directly. `Accuracy.High` maps to `PRIORITY_HIGH_ACCURACY`, which uses
+ * the GPS provider — exactly what `adb emu geo fix` feeds and what a
+ * de-Googled device still has via the AOSP `LocationManager`. We lose the
+ * "turn on high-accuracy mode" system dialog, but that dialog is a Play
+ * Services surface that does not exist on GrapheneOS anyway, so there is
+ * nothing to lose there.
+ *
+ * `watchPositionAsync` never used the `SettingsClient` path (it calls
+ * `requestLocationUpdates` directly), so live watchers were already fine
+ * — only the one-shot `getCurrentPositionAsync` callers were affected.
+ * We still expose the default accuracy here so every call site shares one
+ * accuracy / no-Play-dialog policy.
+ */
+
+/**
+ * Default accuracy for both one-shot fixes and watchers. `High` maps to
+ * Android's `PRIORITY_HIGH_ACCURACY`, which prefers the raw GPS provider
+ * over Google's network-assisted fused location — the right choice on
+ * de-Googled hardware and on emulators fed by `adb emu geo fix`.
+ */
+export const DEFAULT_LOCATION_ACCURACY: Location.LocationAccuracy = Location.Accuracy.High;
+
+/**
+ * Options for a single GPS fix that never touches the Play-Services
+ * `SettingsClient`. Spread this into `getCurrentPositionAsync`.
+ */
+export function oneShotPositionOptions(
+  accuracy: Location.LocationAccuracy = DEFAULT_LOCATION_ACCURACY,
+): Location.LocationOptions {
+  return {
+    accuracy,
+    // The load-bearing flag — see the module doc-comment. Without it,
+    // de-Googled devices hit the Play `SettingsClient.checkLocationSettings`
+    // path and reject with "unsatisfied device settings".
+    mayShowUserSettingsDialog: false,
+  };
+}
+
+/**
+ * Request a single GPS fix in a way that works with OR without Google
+ * Play Services. Thin wrapper over `getCurrentPositionAsync` that always
+ * passes the GrapheneOS-safe options — use this instead of calling
+ * `getCurrentPositionAsync` directly so the no-Play-dialog policy can't
+ * be forgotten at a call site.
+ */
+export function getOneShotPosition(
+  accuracy: Location.LocationAccuracy = DEFAULT_LOCATION_ACCURACY,
+): Promise<Location.LocationObject> {
+  return Location.getCurrentPositionAsync(oneShotPositionOptions(accuracy));
+}

--- a/src/services/geofenceService.ts
+++ b/src/services/geofenceService.ts
@@ -1,6 +1,7 @@
 import * as Location from 'expo-location';
 import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
+import { getOneShotPosition } from './aospLocation';
 import { acceptsLightning, fetchPlacesInBbox, type Bbox, type BtcMapPlace } from './btcMapService';
 import { isWithinQuietHours, loadNearbySettings } from './nearbySettingsService';
 import { haversineMetres } from '../utils/geohash';
@@ -108,9 +109,9 @@ export const isGeofencingActive = async (): Promise<boolean> => {
 export const enableGeofencing = async (): Promise<number | null> => {
   ensureTaskDefined();
 
-  const pos = await Location.getCurrentPositionAsync({
-    accuracy: Location.Accuracy.High,
-  });
+  // getOneShotPosition passes `mayShowUserSettingsDialog: false` so this
+  // works on de-Googled / no-Play-Services devices — see aospLocation.ts.
+  const pos = await getOneShotPosition();
   const bbox: Bbox = {
     minLon: pos.coords.longitude - FETCH_HALF_DEGREES,
     minLat: pos.coords.latitude - FETCH_HALF_DEGREES,

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -1,4 +1,5 @@
 import * as Location from 'expo-location';
+import { getOneShotPosition } from './aospLocation';
 
 export interface SharedLocation {
   lat: number;
@@ -83,7 +84,12 @@ async function tryGetCurrent(): Promise<Location.LocationObject | null> {
     // which actively demands GPS. Balanced prefers the network provider, which
     // is unavailable on emulators configured with GPS only — so Balanced throws
     // ERR_CURRENT_LOCATION_IS_UNAVAILABLE on empty cache even when GPS has a fix.
-    return await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+    //
+    // `getOneShotPosition` also passes `mayShowUserSettingsDialog: false`, so
+    // this never hits the Play `SettingsClient` path that fails with
+    // "unsatisfied device settings" on de-Googled / no-Play-Services devices
+    // (GrapheneOS, bare AOSP emulator). See src/services/aospLocation.ts.
+    return await getOneShotPosition();
   } catch {
     return null;
   }


### PR DESCRIPTION
## What & why

On **GrapheneOS / de-Googled devices** and on the **bare AOSP emulator**, one-shot location requests failed with:

> Location request failed due to unsatisfied device settings

That string is expo-location's `LocationSettingsUnsatisfiedException`. Walking the native module (`expo-location/android/.../LocationModule.kt`): when the `NETWORK_PROVIDER` is disabled **and** `mayShowUserSettingsDialog` is `true` (its default), `getCurrentPositionAsync` does **not** request a fix directly — it calls `resolveUserSettingsForRequest`, which uses the **Google Play `SettingsClient.checkLocationSettings()`**. On a device with no Play Services that task fails, so the module rejects. A stock AOSP emulator is GPS-only (network provider off, fed by `adb emu geo fix`), so this path is hit every time and location never resolves.

`watchPositionAsync` was never affected — it calls `requestLocationUpdates` directly and never touches the `SettingsClient`. Only one-shot `getCurrentPositionAsync` callers broke.

## The fix

Pass `mayShowUserSettingsDialog: false` to every one-shot fix. With that flag the native module skips the `SettingsClient` branch and requests the fix directly via `requestSingleLocation`. `Accuracy.High` maps to `PRIORITY_HIGH_ACCURACY`, which prefers the raw GPS provider — exactly what `adb emu geo fix` feeds and what a de-Googled device exposes via the AOSP `LocationManager`. The lost "turn on high-accuracy" system dialog is a Play surface that doesn't exist on GrapheneOS anyway.

Centralised in a small, unit-tested helper **`src/services/aospLocation.ts`** (`getOneShotPosition` / `oneShotPositionOptions` / `DEFAULT_LOCATION_ACCURACY`) and threaded through every one-shot caller:

- `src/services/locationService.ts`, `src/services/geofenceService.ts`
- `src/hooks/useLiveUserLocation.ts`
- `src/screens/PlaceDetailScreen.tsx`, `EventsScreen.tsx`, `MapScreen.tsx`, `PlacesScreen.tsx`, `ExploreHomeScreen.tsx`, `HuntCreateScreen.tsx`
- `src/components/LocationPickerSheet.tsx`

The over-cap `HuntCreateScreen.tsx` was folded by two lines so the new import leaves it net-smaller (file-size gate green).

This is **item 1** (the only reproduced breakage) of the GrapheneOS audit in #918. Items 2 (FCM — already local-only, no change) and 3 (ML Kit QR — app uses the bundled detector, likely fine; exclude the unused Play `code-scanner` artifact) remain as follow-ups in that issue.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all changed files — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check` on changed files — clean
- [x] `bash scripts/check-file-size.sh` — passed (no baselined file grew)
- [x] `npx jest` — 116 suites / 1298 tests pass, incl. new `src/services/aospLocation.test.ts` (pins `mayShowUserSettingsDialog: false`)
- [ ] **On-device / emulator (no Play Services):** start a bare AOSP emulator, stream `adb emu geo fix <lon> <lat>`, open a map surface (Explore / Places / Map) → the user dot should now resolve and follow the injected fix instead of failing with "unsatisfied device settings". Also verify share-location and "pin here" (Hunt create).

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
