### PR TITLE
chore(release): v1.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## v1.3.10

Marketing version bump 1.3.9 → 1.3.10. Merging this triggers the EAS cloud release builds (`release.yml`).

### What's included (since v1.3.9)
- **Hunt:** local-only **"Private"** Piglets (Public-off) now appear in My Piglets and re-open for editing — previously they were saved but invisible (#909/#912).
- **Explore/Places:** cache-first hydration — the Places page no longer flashes empty or reloads on every visit (#910/#915).
- **Map:** prize-bearing Piglet markers show a lightning-bolt badge across all maps (#920/#921).
- **Explore:** up to 3 featured places pinned to the top of the Places list + capped on the rail (#913/#914).
- **Geo-caches:** dedicated relay set (GC_RELAYS) + an Account → Nostr sub-section (#907/#911).
- **Events:** only future events shown; test-account content hidden in production (#916/#917).
- **Friends:** contacts stay cached when a forced refresh times out (#906).
- **Nostr:** public events now carry a NIP-89 client tag = "Lightning Piggy" (#905).

## Test plan
- All included PRs merged green (CI: tsc, ESLint, Prettier, Jest coverage, file-size, PR-lint) with Copilot reviews resolved.
- Marketing version is bumped in package.json (app.config.ts reads it); versionCode/buildNumber remain EAS-remote auto-incremented.
- After merge: tag v1.3.10 on the merged commit + publish the GitHub Release to kick off EAS builds.
