### PR TITLE
chore(release): prep v1.3.11 release notes

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,5 +14,5 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
-- **Shop orders show as cards in your chats.** An order or receipt from a merchant now shows items, total in sats, and status — not raw text.
+- **Shop orders show as cards in your chats.** An order or receipt from a merchant now shows the item count, total in sats, and status — not raw text.
 - **Pay an order in a tap.** Order cards have a Pay button and a QR code to pay the invoice from the chat, or scan it with another wallet.

--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,5 +14,5 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
-- **See shop orders right in your chats.** When a merchant sends you a Lightning order or receipt over an encrypted message, it now appears as a clear order card — item count, total in sats, and status — instead of raw text.
-- **Pay an order in a tap.** Order cards now have a Pay button and a QR code, so you can pay the Lightning invoice for your order straight from the conversation, or scan it with another wallet.
+- **Shop orders show as cards in your chats.** An order or receipt from a merchant now shows items, total in sats, and status — not raw text.
+- **Pay an order in a tap.** Order cards have a Pay button and a QR code to pay the invoice from the chat, or scan it with another wallet.

--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,4 +14,5 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
-- **Pay by NFC from the Send sheet.** Send now has three modes — QR scan, paste, and NFC — switched with icon toggles. Pick the NFC waves, hold your phone against a Lightning payment tag (invoice, Lightning address or LNURL), and the payment details fill in just like scanning a QR.
+- **See shop orders right in your chats.** When a merchant sends you a Lightning order or receipt over an encrypted message, it now appears as a clear order card — item count, total in sats, and status — instead of raw text.
+- **Pay an order in a tap.** Order cards now have a Pay button and a QR code, so you can pay the Lightning invoice for your order straight from the conversation, or scan it with another wallet.


### PR DESCRIPTION
Prepares the **v1.3.11** release notes.

## What changed
- **Removes the stale NFC "What to test" bullet** — that feature shipped in **v1.3.10**, but its automated reset PR (`chore/reset-release-notes-v1.3.10`) was never merged, so the bullet was left stranded in `RELEASE_NOTES_NEXT.md`.
- **Adds the two marketplace features** that actually land in v1.3.11:
  - #925 — receive + display marketplace order/receipt cards (kinds 16/17) in DMs
  - #928 — Pay / QR affordance on order cards

This file drives TestFlight "What to Test", so it needs to reflect this release before the tag is published.

## Test plan
- Confirm `docs/RELEASE_NOTES_NEXT.md` lists the two marketplace bullets and no longer mentions NFC.
- After merge, publishing the `v1.3.11` GitHub Release runs `release.yml`, which picks up these notes for TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
