### PR TITLE
chore(release): v1.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Bumps the marketing version to **1.3.11** ahead of cutting the release.

`package.json` is the single source of truth — it flows into the in-app version label (`src/utils/appVersion.ts`) and the native `versionName` / `CFBundleShortVersionString`. Build numbers (`versionCode` / `CFBundleVersion`) come from EAS (`appVersionSource: remote` + `autoIncrement`), so they're not touched here.

Pairs with #929 (the v1.3.11 release notes). Once merged, publishing the `v1.3.11` Release on this commit triggers `release.yml`.

## Test plan
- Confirm `package.json` version is `1.3.11` so the Release tag and the in-app version label agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
