### PR TITLE
feat(dm): suppress duplicate order-invoice chat note

### DIFF
--- a/src/utils/conversationItems.test.ts
+++ b/src/utils/conversationItems.test.ts
@@ -14,7 +14,9 @@ import {
   buildConversationItems,
   buildZapItems,
   formatDayHeader,
+  suppressDuplicateOrderInvoiceNotes,
   type ConversationMessageInput,
+  type TimedItem,
 } from './conversationItems';
 import type { WalletState, ZapCounterpartyInfo } from '../types/wallet';
 
@@ -216,6 +218,149 @@ describe('buildConversationItems — unsupported message-kind fallback', () => {
     ).filter((i) => i.kind !== 'dayHeader');
     expect(items[0].kind).toBe('unsupported');
     expect(items[0].kind).not.toBe('message'); // never a raw text bubble
+  });
+});
+
+describe('buildConversationItems — duplicate order-invoice note dedup', () => {
+  // A bech32 data part comfortably over the {50,} floor the bolt11 regex
+  // shares with INVOICE_REGEX. Two distinct invoices for the no-match case.
+  const DATA = '210n1p' + 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'.repeat(2);
+  const INVOICE = `lnbc${DATA}`;
+  const OTHER_INVOICE = `lntb${DATA}`;
+
+  // kind-16 type-2 "Payment" order card JSON carrying `invoice` as its payable
+  // bolt11 — exactly what the order-service sends as the rich card.
+  const paymentOrderJson = (invoice: string, orderId = 'order-abc'): string =>
+    JSON.stringify({
+      kind: 16,
+      type: 'payment',
+      orderId,
+      items: [],
+      message: '',
+      payment: { method: 'lightning', value: invoice },
+    });
+
+  // The kind-14 chat-note fallback: a human-readable line + the SAME raw bolt11.
+  const noteText = (invoice: string): string =>
+    `New order — please pay ${invoice} to confirm. Thanks!`;
+
+  const cardMsg = (invoice: string): ConversationMessageInput => ({
+    id: 'card',
+    fromMe: false,
+    text: paymentOrderJson(invoice),
+    createdAt: DAY2 + 1,
+    wireKind: 16,
+  });
+  const noteMsg = (invoice: string): ConversationMessageInput => ({
+    id: 'note',
+    fromMe: false,
+    text: noteText(invoice),
+    createdAt: DAY2,
+    wireKind: 14,
+  });
+
+  const nonHeader = (msgs: ConversationMessageInput[]) =>
+    buildConversationItems(msgs, []).filter((i) => i.kind !== 'dayHeader');
+
+  it('suppresses the kind-14 note when a matching kind-16 order card exists', () => {
+    const items = nonHeader([cardMsg(INVOICE), noteMsg(INVOICE)]);
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe('order');
+    expect(items.some((i) => i.kind === 'message')).toBe(false);
+  });
+
+  it('suppresses regardless of arrival order (note before OR after the card)', () => {
+    const noteFirst = nonHeader([noteMsg(INVOICE), cardMsg(INVOICE)]);
+    const cardFirst = nonHeader([cardMsg(INVOICE), noteMsg(INVOICE)]);
+    for (const items of [noteFirst, cardFirst]) {
+      expect(items).toHaveLength(1);
+      expect(items[0].kind).toBe('order');
+    }
+  });
+
+  it('shows the kind-14 note when no kind-16 order card is present (fallback)', () => {
+    const items = nonHeader([noteMsg(INVOICE)]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ kind: 'message', id: 'dm-note' });
+  });
+
+  it('shows the note when the order card carries a DIFFERENT invoice', () => {
+    const items = nonHeader([cardMsg(OTHER_INVOICE), noteMsg(INVOICE)]);
+    expect(items.some((i) => i.kind === 'order')).toBe(true);
+    expect(items.some((i) => i.kind === 'message' && i.id === 'dm-note')).toBe(true);
+  });
+
+  it('never suppresses a non-order kind-14 chat message (no invoice)', () => {
+    const items = nonHeader([
+      cardMsg(INVOICE),
+      { id: 'chat', fromMe: false, text: 'gm, when does it ship?', createdAt: DAY2, wireKind: 14 },
+    ]);
+    expect(items.some((i) => i.kind === 'message' && i.id === 'dm-chat')).toBe(true);
+  });
+
+  it('does NOT suppress a non-kind-14 row (e.g. NIP-04 kind-4) sharing the invoice', () => {
+    // Only a kind-14 NIP-17 note is the order-invoice fallback; a kind-4 message
+    // that happens to quote the same invoice must stay.
+    const items = nonHeader([
+      cardMsg(INVOICE),
+      { id: 'nip04', fromMe: false, text: noteText(INVOICE), createdAt: DAY2, wireKind: 4 },
+    ]);
+    expect(items.some((i) => i.kind === 'message' && i.id === 'dm-nip04')).toBe(true);
+  });
+
+  it('does NOT suppress when the only card is a non-payable order (kind-16 type-1 placed)', () => {
+    // An order-placed card has no payable bolt11, so it can never shadow a note.
+    const placedJson = JSON.stringify({
+      kind: 16,
+      type: 'order',
+      orderId: 'order-abc',
+      items: [],
+      message: '',
+    });
+    const items = nonHeader([
+      { id: 'card', fromMe: false, text: placedJson, createdAt: DAY2 + 1, wireKind: 16 },
+      noteMsg(INVOICE),
+    ]);
+    expect(items.some((i) => i.kind === 'message' && i.id === 'dm-note')).toBe(true);
+  });
+
+  describe('suppressDuplicateOrderInvoiceNotes (unit)', () => {
+    const orderItem = (invoice: string): TimedItem => ({
+      kind: 'order',
+      id: 'dm-card',
+      fromMe: false,
+      createdAt: DAY2 + 1,
+      order: {
+        kind: 16,
+        type: 'payment',
+        orderId: 'order-abc',
+        items: [],
+        message: '',
+        payment: { method: 'lightning', value: invoice },
+      },
+    });
+    const messageItem = (text: string, wireKind = 14): TimedItem => ({
+      kind: 'message',
+      id: 'dm-note',
+      fromMe: false,
+      text,
+      createdAt: DAY2,
+      wireKind,
+    });
+
+    it('drops only the matching kind-14 message item', () => {
+      const out = suppressDuplicateOrderInvoiceNotes([
+        orderItem(INVOICE),
+        messageItem(noteText(INVOICE)),
+      ]);
+      expect(out).toHaveLength(1);
+      expect(out[0].kind).toBe('order');
+    });
+
+    it('is a no-op when there are no order cards', () => {
+      const input: TimedItem[] = [messageItem(noteText(INVOICE))];
+      expect(suppressDuplicateOrderInvoiceNotes(input)).toEqual(input);
+    });
   });
 });
 

--- a/src/utils/conversationItems.ts
+++ b/src/utils/conversationItems.ts
@@ -5,7 +5,12 @@ import type { WalletState } from '../types/wallet';
 import { classifyMessageContent } from './messageContent';
 import { sanitizeDisplayText } from './sanitizeDisplayText';
 import type { DeliveryStatus } from './dmDeliveryStatus';
-import { parseStoredOrder, type ParsedOrderEvent } from './orderEvents';
+import {
+  bolt11FromText,
+  parseStoredOrder,
+  payableBolt11,
+  type ParsedOrderEvent,
+} from './orderEvents';
 
 // The row variants ConversationScreen's FlatList renders. Extracted from the
 // screen (with the pure build logic below) to keep the screen file under the
@@ -148,6 +153,49 @@ export function buildZapItems(wallets: WalletState[], pubkey: string): TimedItem
 // (`undefined`), so they never hit the fallback.
 const RENDERABLE_WIRE_KINDS = new Set<number>([4, 14, 15, 16, 17]);
 
+/**
+ * Suppress a kind-14 chat-note that merely re-delivers an order's Lightning
+ * invoice when the SAME conversation already renders the kind-16 order card for
+ * that invoice (#market dedup).
+ *
+ * The order-service delivers an order's invoice two ways for client
+ * compatibility: a kind-16 type-2 payment request (LP's rich "order card") and
+ * a kind-14 NIP-17 chat note carrying the same human-readable line + the SAME
+ * raw bolt11, so generic DM clients that can't render kind-16 still get a
+ * payable invoice. A Gamma-aware client like LP would otherwise show BOTH — the
+ * card and a duplicate invoice bubble — so we drop the note.
+ *
+ * Correlation is by the shared bolt11, not the `["order", …]` tag: LP's
+ * dm_messages store retains only a row's content + wireKind, never the kind-14
+ * rumor's tags, so the order tag isn't available at render time — but the
+ * invoice string IS retained on both sides (the card's `payment.value` and the
+ * note's content) and is an exact, hard key. A note is dropped ONLY when its
+ * bolt11 equals a payable order card's invoice, so a regular chat message —
+ * even one that happens to quote an unrelated invoice — is never suppressed,
+ * and a note with no matching card still shows (it may be the only invoice the
+ * buyer has — the whole point of the fallback). Operating on the assembled item
+ * set means the kind-14 and kind-16 can arrive in either order.
+ */
+export function suppressDuplicateOrderInvoiceNotes(items: TimedItem[]): TimedItem[] {
+  // Every payable bolt11 shown as an order card in this conversation. Only a
+  // kind-16 type-2 payment request yields one (`payableBolt11`), so a receipt
+  // or order-placed card never suppresses anything.
+  const orderInvoices = new Set<string>();
+  for (const it of items) {
+    if (it.kind !== 'order') continue;
+    const invoice = payableBolt11(it.order);
+    if (invoice) orderInvoices.add(invoice);
+  }
+  if (orderInvoices.size === 0) return items;
+  return items.filter((it) => {
+    // Only a kind-14 chat bubble can be an order-invoice fallback note; leave
+    // order cards, zaps, files, NIP-04 (kind-4) rows, etc. untouched.
+    if (it.kind !== 'message' || it.wireKind !== 14) return true;
+    const invoice = bolt11FromText(it.text);
+    return !(invoice && orderInvoices.has(invoice));
+  });
+}
+
 // Merge classified DM messages with wallet zap rows, sort newest-first, and
 // interleave "Today / Yesterday / <date>" dividers between day groups.
 export function buildConversationItems(
@@ -237,11 +285,16 @@ export function buildConversationItems(
       wireKind: m.wireKind,
     };
   });
+  // Drop any kind-14 chat-note that just re-delivers an order's invoice when
+  // its kind-16 order card is also present (#market dedup) — a selector over the
+  // assembled set, so the two events can arrive in either order.
+  const deduped = suppressDuplicateOrderInvoiceNotes(msgItems);
+
   // Descending order — index 0 is newest. The FlatList is `inverted`, so
   // index 0 renders at the visual bottom (chat default) and the
   // RefreshControl attaches to the visual bottom too, which is what
   // drives the pull-up-to-refresh gesture.
-  const sorted = [...msgItems, ...zapItems].sort((a, b) => b.createdAt - a.createdAt);
+  const sorted = [...deduped, ...zapItems].sort((a, b) => b.createdAt - a.createdAt);
 
   // Interleave "Today / Yesterday / <date>" dividers between day groups.
   // With an inverted FlatList the array runs newest → oldest, so each

--- a/src/utils/orderEvents.test.ts
+++ b/src/utils/orderEvents.test.ts
@@ -8,6 +8,7 @@ import {
   orderCardHeader,
   shortOrderId,
   payableBolt11,
+  bolt11FromText,
   type OrderEventInput,
   type ParsedOrderEvent,
 } from './orderEvents';
@@ -391,5 +392,37 @@ describe('payableBolt11', () => {
   it('returns null when there is no payment value', () => {
     expect(payableBolt11({ ...base, payment: undefined })).toBeNull();
     expect(payableBolt11({ ...base, payment: { method: 'lightning', value: '' } })).toBeNull();
+  });
+
+  it('lowercases the returned invoice so it compares equal to a chat-note copy', () => {
+    const upper = BC.toUpperCase();
+    expect(payableBolt11({ ...base, payment: { method: 'lightning', value: upper } })).toBe(BC);
+  });
+});
+
+describe('bolt11FromText', () => {
+  // Same over-the-floor bech32 data part used by the payableBolt11 suite.
+  const DATA = '210n1p' + 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'.repeat(2);
+  const BC = `lnbc${DATA}`;
+
+  it('extracts a bolt11 embedded in a human-readable chat-note line', () => {
+    expect(bolt11FromText(`Please pay your order: ${BC} — thanks!`)).toBe(BC);
+  });
+
+  it('strips a lightning: URI prefix', () => {
+    expect(bolt11FromText(`Pay: lightning:${BC}`)).toBe(BC);
+  });
+
+  it('lowercases so it compares equal to a payableBolt11 result', () => {
+    expect(bolt11FromText(`PAY ${BC.toUpperCase()} NOW`)).toBe(BC);
+  });
+
+  it('returns null for text with no invoice and for empty text', () => {
+    expect(bolt11FromText('just a normal message, no invoice here')).toBeNull();
+    expect(bolt11FromText('')).toBeNull();
+  });
+
+  it('ignores a too-short lnbc-shaped token (below the {50,} floor)', () => {
+    expect(bolt11FromText('here is lnbc1short for you')).toBeNull();
   });
 });

--- a/src/utils/orderEvents.ts
+++ b/src/utils/orderEvents.ts
@@ -276,7 +276,30 @@ export function payableBolt11(order: ParsedOrderEvent): string | null {
   const payment = order.payment;
   if (!payment || payment.method.toLowerCase() !== 'lightning') return null;
   const match = payment.value.trim().match(BOLT11_RE);
-  return match ? match[1] : null;
+  return match ? match[1].toLowerCase() : null;
+}
+
+// Non-anchored sibling of `BOLT11_RE`: pulls the FIRST bolt11 out of free-text
+// content (vs `BOLT11_RE`, which requires the whole string to be one invoice).
+// Kept in lock-step with `INVOICE_REGEX` in src/utils/messageContent.ts — same
+// `\b`-delimited shape — so the dedup below recognises exactly the invoice the
+// rest of the app parses. Dependency-light on purpose (no bolt11 decoder).
+const BOLT11_IN_TEXT_RE = /\b(?:lightning:)?(ln(?:bc|tb|ts|bs)[0-9a-z]{50,})\b/i;
+
+/**
+ * The first bolt11 invoice embedded in a free-text chat message, lowercased
+ * (bech32 is case-insensitive; canonical form is lower) with any `lightning:`
+ * prefix stripped, or `null` when the text carries none.
+ *
+ * Used to correlate a kind-14 "order invoice" chat-note fallback with the
+ * kind-16 order card that carries the SAME invoice (`payableBolt11`), so the
+ * redundant note can be suppressed. Both sides normalise to lowercase here so
+ * the comparison is exact regardless of how either client cased the invoice.
+ */
+export function bolt11FromText(text: string): string | null {
+  if (!text) return null;
+  const match = text.match(BOLT11_IN_TEXT_RE);
+  return match ? match[1].toLowerCase() : null;
 }
 
 /** One-line inbox preview, e.g. "🛒 Order Placed · 21 sats". */


### PR DESCRIPTION
## What & why

The order-service is being updated (separately) to deliver a marketplace order's Lightning invoice **two ways** for client compatibility:

- a **kind-16** Type-2 payment-request — the rich "order card" LP renders today, and
- a **kind-14** NIP-17 chat note carrying the same human-readable line + the **same raw BOLT11**, so generic DM clients that can't render kind-16 still get a payable invoice.

Both are gift-wrapped to the buyer and identify the same order. In a Gamma-aware client like LP, the buyer would otherwise see the **order card AND a duplicate chat bubble** with the same invoice. This suppresses that redundant kind-14 note.

## How it works

- When a conversation contains a kind-14 chat note whose BOLT11 equals a **payable** kind-16 order card's invoice, the note is **not rendered** — only the card.
- If there is **no** matching kind-16 card, the kind-14 note **still shows** (it's then the only invoice the buyer has — the whole point of the fallback).
- **Arrival order is irrelevant**: dedup is a pure selector over the assembled message set (`buildConversationItems`), not a drop-at-ingest, so the kind-14 may arrive before or after the kind-16.

## How I correlated the duplicate — BOLT11, not the `order` tag

I checked whether LP retains kind-14 rumor tags through storage: it does **not**. The `dm_messages` table (`src/services/dmDb.ts`) stores only `owner, event_id, conversation, created_at, sender, content, from_me, wire_kind` — no tags column. So the `["order", <id>]` tag isn't available at render time.

Rather than add a schema migration to the encrypted DB to retain the tag, I correlate by the **shared BOLT11**, which is:
- **retained on both sides** — the order card's `payment.value` (in the stored order JSON) and the kind-14 note's `content`; and
- an **exact, hard key** — it is literally the same invoice string, so there is no fuzzy matching.

This keeps the change a **pure derivation with zero storage/migration risk**. A kind-14 note is suppressed **only** when its bolt11 equals a payable order card's invoice, so a regular chat message — even one that happens to quote an unrelated invoice — is never dropped, and only genuine kind-14 NIP-17 notes are considered (a NIP-04 kind-4 row sharing the invoice is left alone).

## Where the dedup lives

`src/utils/conversationItems.ts` → new `suppressDuplicateOrderInvoiceNotes(items)`, applied inside `buildConversationItems` (the single 1:1-conversation assembly point, called once from `ConversationScreen`). Supporting helpers in `src/utils/orderEvents.ts`: `payableBolt11` now lowercases its result, and a new `bolt11FromText` pulls a normalised invoice out of free-text chat content (mirrors `INVOICE_REGEX`).

## Test plan

- `npm run typecheck` — pass (tsc --noEmit, 0 errors)
- `npm run lint` — pass (0 errors)
- `npm run format:check` — pass (prettier, all files match)
- `npm test` — **125 suites / 1459 tests pass**
- `bash scripts/check-file-size.sh` — pass (largest changed file 428 lines, well under the 1000 cap)

New tests cover: kind-14 suppressed when a matching kind-16 exists; kind-14 shown when no kind-16; suppression independent of arrival order; non-order kind-14 chat messages never suppressed; a non-payable order card (kind-16 type-1 placed) never shadows a note; a NIP-04 row sharing the invoice is not suppressed; plus unit tests for `bolt11FromText` (extract/strip-prefix/lowercase/too-short/no-invoice).

## Visual evidence

A real device/emulator screenshot was **not feasible in this headless worktree environment** (no running Metro/simulator wired up here), so — per the brief — I am not faking one. The dedup is verified by the new unit tests over the exact render-assembly selector the screen uses. Passing test output:

```
Test Suites: 125 passed, 125 total
Tests:       1459 passed, 1459 total
```

A before/after capture (duplicate note shown vs suppressed) can be added later if a market test order is run on a device.

## Release notes

I deliberately did **not** add a `RELEASE_NOTES_NEXT.md` bullet — v1.3.11 just shipped and its auto-reset PR may still be pending, so a bullet now risks colliding. A one-line note can be added once the reset lands.

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)
