### PR TITLE
perf(messages): cut inbox-fetch timeout to 8s + defer contacts fetch off tab transition

### DIFF
--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -185,9 +185,15 @@ const FriendsScreen: React.FC = () => {
   // returns. Cheap (AsyncStorage read + a bit of Contacts API merge).
   useFocusEffect(
     useCallback(() => {
-      fetchPhoneContacts()
-        .then(setPhoneContacts)
-        .catch(() => {});
+      // Deferred like refreshProfile above: the Contacts API merge competes
+      // with the tab-transition animation for JS-thread time, so let the
+      // transition + first paint finish before it runs.
+      const handle = InteractionManager.runAfterInteractions(() => {
+        fetchPhoneContacts()
+          .then(setPhoneContacts)
+          .catch(() => {});
+      });
+      return () => handle.cancel();
     }, []),
   );
 

--- a/src/services/nostrService.ts
+++ b/src/services/nostrService.ts
@@ -1015,13 +1015,16 @@ export async function fetchInboxDmEvents(
   }
   const __t0 = performance.now();
   try {
-    // maxWait: per-relay EOSE timeout closes the sub at 15 s, so the cold-start
+    // maxWait: per-relay EOSE timeout closes the sub, so the cold-start
     // inbox fetch genuinely terminates — unlike withTimeout which only raced the
     // Promise and left the underlying subscribeEose sub running for up to ~60 s.
+    // 8 s (was 15 s): a slow/unresponsive relay shouldn't hold the inbox
+    // spinner for a quarter-minute that reads as a freeze. The live sub keeps
+    // delivering after this resolves, and pull-to-refresh re-runs the query.
     const [sentK4, receivedK4, wraps] = await Promise.all([
-      querySyncAbortable(pool, allRelays, sentK4Filter, { maxWait: 15000, signal: options.signal }),
-      querySyncAbortable(pool, allRelays, recvK4Filter, { maxWait: 15000, signal: options.signal }),
-      querySyncAbortable(pool, allRelays, wrapsFilter, { maxWait: 15000, signal: options.signal }),
+      querySyncAbortable(pool, allRelays, sentK4Filter, { maxWait: 8000, signal: options.signal }),
+      querySyncAbortable(pool, allRelays, recvK4Filter, { maxWait: 8000, signal: options.signal }),
+      querySyncAbortable(pool, allRelays, wrapsFilter, { maxWait: 8000, signal: options.signal }),
     ]);
     // [Perf] Cold-start freeze attribution (#751). querySync ingests every
     // returned event synchronously (JSON.parse + validateEvent + matchFilters)


### PR DESCRIPTION
## What

Two tab-freeze fixes from the performance/reliability audit (issue **#1** of the report — "occasional freezes between tabs").

### 1. Inbox-fetch relay timeout 15s → 8s
`fetchInboxDmEvents` ran three relay queries (`querySyncAbortable`), each capped at **15s** via `maxWait`. A slow or unresponsive relay therefore held the Messages inbox spinner for up to a quarter-minute, which reads as a freeze. Cut to **8s**.

Nothing is lost: the live subscription keeps delivering after the fetch resolves, and pull-to-refresh re-runs the query — the inbox just stops blocking on a dead relay.

### 2. Defer phone-contacts fetch off the tab-transition frame
`FriendsScreen` re-fetched phone contacts in a `useFocusEffect` with no deferral, so the Contacts API merge competed with the tab-transition animation for JS-thread time. Wrapped in `InteractionManager.runAfterInteractions`, mirroring the adjacent `refreshProfile` defer.

## What this PR does **not** include

The audit's issue **#2** ("messages going missing") findings were re-checked against the **current** code (post the merged #857 / #868 optimistic-send + ingested-store rework) and **do not hold as Stevie originally framed them**:
- **Partial-send → failure** is correct-as-designed (the sender's own copy is sealed first, so a partial send means the *recipient* didn't receive it; reporting failure + keeping a retry affordance is right).
- The **optimistic-drop race** is real but lives at the `fetchConversation` cache-write layer bypassing the `appendLocalDmChains` lock — **not** the composer `void appendLocalDmMessage`. That's a separate, carefully-scoped fix (tracked separately), not a one-line `await`.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `eslint` on changed files — 0 errors (only pre-existing warnings)
- [ ] On-device: confirm Messages tab no longer hangs when a relay is slow; Friends tab transition stays smooth on focus

No UI change → no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #936