### PR TITLE
feat(hunt): notify cache owner on a found-log (kind 7516) on their Piglet (#945)

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -423,7 +423,7 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     relays,
   });
 
-  // Cache-activity notifications (#740, #760) — live subs against the
+  // Cache-activity notifications (#740, #945) — live subs against the
   // viewer's owned cache coords: kind-1111 comments AND kind-7516 found-logs.
   // Fires `fireCacheNotification` per fresh arrival + fans found-logs out on
   // the in-app event bus (`notifyFoundLog`). See useCacheNotifications.

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -423,9 +423,10 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     relays,
   });
 
-  // Find-log notifications (#740) — live kind-1111 sub against the
-  // viewer's cache coordinates. Sibling to `useDmInbox`'s live sub;
-  // fires `fireCacheNotification` per fresh arrival.
+  // Cache-activity notifications (#740, #760) — live subs against the
+  // viewer's owned cache coords: kind-1111 comments AND kind-7516 found-logs.
+  // Fires `fireCacheNotification` per fresh arrival + fans found-logs out on
+  // the in-app event bus (`notifyFoundLog`). See useCacheNotifications.
   useCacheNotifications({ pubkey, getReadRelays });
 
   const loadProfile = useCallback(

--- a/src/contexts/nostrEventBus.test.ts
+++ b/src/contexts/nostrEventBus.test.ts
@@ -1,0 +1,43 @@
+// Tests for the found-log fan-out on the in-app nostr event bus (#760).
+// The bus is a tiny synchronous pub/sub; we assert delivery, scoping by
+// the (cacheCoord, logId) payload, unsubscribe, and the throw-isolation
+// guarantee (one bad listener must not starve the others).
+
+import { notifyFoundLog, subscribeFoundLogEvents } from './nostrEventBus';
+
+const COORD = '37516:owner:my-piggy-d';
+const LOG_ID = 'f'.repeat(64);
+
+it('delivers the coord + log id to a subscribed listener', () => {
+  const listener = jest.fn();
+  const unsub = subscribeFoundLogEvents(listener);
+  notifyFoundLog(COORD, LOG_ID);
+  expect(listener).toHaveBeenCalledWith(COORD, LOG_ID);
+  unsub();
+});
+
+it('stops delivering after unsubscribe', () => {
+  const listener = jest.fn();
+  const unsub = subscribeFoundLogEvents(listener);
+  unsub();
+  notifyFoundLog(COORD, LOG_ID);
+  expect(listener).not.toHaveBeenCalled();
+});
+
+it('fans out to every subscriber and isolates a throwing one', () => {
+  const good = jest.fn();
+  const bad = jest.fn(() => {
+    throw new Error('listener blew up');
+  });
+  const unsubBad = subscribeFoundLogEvents(bad);
+  const unsubGood = subscribeFoundLogEvents(good);
+  // The bus warns (dev) on a throwing listener — silence the expected noise.
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  // A throwing listener must not prevent the others from firing.
+  expect(() => notifyFoundLog(COORD, LOG_ID)).not.toThrow();
+  expect(bad).toHaveBeenCalledTimes(1);
+  expect(good).toHaveBeenCalledTimes(1);
+  warnSpy.mockRestore();
+  unsubBad();
+  unsubGood();
+});

--- a/src/contexts/nostrEventBus.ts
+++ b/src/contexts/nostrEventBus.ts
@@ -48,3 +48,28 @@ export function subscribeDmMessages(listener: DmMessageListener): () => void {
     dmMessageListeners.delete(listener);
   };
 }
+
+// Sibling pub/sub for inbound kind-7516 found-logs on a cache the viewer
+// OWNS (#760). Fires after the live owned-cache sub sees a fresh, deduped,
+// non-self found-log so an open HuntPiggyDetail (or a future "my finds"
+// surface) can refresh in-place without polling. `cacheCoord` is the
+// `<kind>:<pubkey>:<d>` addressable triple the find-log targets; listeners
+// filter on it. The notification side-effect lives in the hook that drives
+// this — the bus only fans the event out to in-app listeners.
+type FoundLogListener = (cacheCoord: string, logId: string) => void;
+const foundLogListeners = new Set<FoundLogListener>();
+export function notifyFoundLog(cacheCoord: string, logId: string): void {
+  for (const l of foundLogListeners) {
+    try {
+      l(cacheCoord, logId);
+    } catch (e) {
+      if (__DEV__) console.warn('[Nostr] found-log listener threw:', e);
+    }
+  }
+}
+export function subscribeFoundLogEvents(listener: FoundLogListener): () => void {
+  foundLogListeners.add(listener);
+  return () => {
+    foundLogListeners.delete(listener);
+  };
+}

--- a/src/contexts/useCacheNotifications.test.ts
+++ b/src/contexts/useCacheNotifications.test.ts
@@ -88,10 +88,20 @@ function makeEvent(
 beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000);
+  // Spy AppState.addEventListener so the tests can read `.mock.calls` (the
+  // hook registers a 'change' listener) and get back a real subscription
+  // shape. Without this it's a real RN function and `.mock` is undefined
+  // (Copilot #946).
+  jest
+    .spyOn(AppState, 'addEventListener')
+    .mockReturnValue({ remove: jest.fn() } as unknown as ReturnType<
+      typeof AppState.addEventListener
+    >);
 });
 
 afterEach(() => {
   (Date.now as jest.Mock).mockRestore?.();
+  (AppState.addEventListener as jest.Mock).mockRestore?.();
 });
 
 describe('useCacheNotifications', () => {

--- a/src/contexts/useCacheNotifications.test.ts
+++ b/src/contexts/useCacheNotifications.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the foreground cache-activity notification hook.
+ *
+ * Pins the two behaviours Copilot flagged on #760:
+ *
+ *   1. Distinct notification copy per surface — a kind-7516 found-log
+ *      says "New find on your cache" and fans out on the in-app event
+ *      bus; a kind-1111 comment says "New comment on your cache" and
+ *      does NOT broadcast.
+ *   2. The freshness gate re-baselines to the moment the relay
+ *      subscription is (re)armed, not just to effect-mount time — so the
+ *      historical replay a relay sends for a *later* re-subscribe (coord
+ *      set changed mid-session) can't slip past the gate and fire stale
+ *      notifications.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { AppState } from 'react-native';
+import type { VerifiedEvent } from 'nostr-tools';
+import { useCacheNotifications } from './useCacheNotifications';
+import {
+  subscribeCacheCommentsForCoords,
+  subscribeCacheFoundLogsForCoords,
+} from '../services/cacheNotifySubscription';
+import { fireCacheNotification } from '../services/notificationService';
+import { fetchCachesByAuthor } from '../services/nostrPlacesPublisher';
+import { notifyFoundLog } from './nostrEventBus';
+
+jest.mock('../services/cacheNotifySubscription', () => ({
+  __esModule: true,
+  subscribeCacheCommentsForCoords: jest.fn(() => jest.fn()),
+  subscribeCacheFoundLogsForCoords: jest.fn(() => jest.fn()),
+}));
+jest.mock('../services/notificationService', () => ({
+  __esModule: true,
+  fireCacheNotification: jest.fn(async () => {}),
+}));
+jest.mock('../services/nostrPlacesPublisher', () => ({
+  __esModule: true,
+  fetchCachesByAuthor: jest.fn(),
+}));
+jest.mock('../services/nostrPlacesService', () => ({
+  __esModule: true,
+  // Any non-null return satisfies the hook's `if (!parsed) return` guard.
+  parseCacheCoord: jest.fn((coord: string) => ({ coord })),
+}));
+jest.mock('./nostrEventBus', () => ({
+  __esModule: true,
+  notifyFoundLog: jest.fn(),
+}));
+
+const mockedComments = subscribeCacheCommentsForCoords as jest.Mock;
+const mockedFoundLogs = subscribeCacheFoundLogsForCoords as jest.Mock;
+const mockedFire = fireCacheNotification as jest.Mock;
+const mockedFetch = fetchCachesByAuthor as jest.Mock;
+const mockedNotifyFoundLog = notifyFoundLog as jest.Mock;
+
+const VIEWER = 'viewer-pubkey-hex';
+const OTHER = 'someone-else-hex';
+const COORD_A = '37516:ownerA:cacheA';
+const COORD_B = '37516:ownerA:cacheB';
+
+/** Latest `onEvent` handler the found-log subscription was armed with. */
+function latestFoundLogHandler(): (ev: VerifiedEvent) => void {
+  return mockedFoundLogs.mock.calls.at(-1)![0].onEvent;
+}
+/** Latest `onEvent` handler the comment subscription was armed with. */
+function latestCommentHandler(): (ev: VerifiedEvent) => void {
+  return mockedComments.mock.calls.at(-1)![0].onEvent;
+}
+
+function makeEvent(
+  over: Partial<VerifiedEvent>,
+  coordKey: 'A' | 'a',
+  coord: string,
+): VerifiedEvent {
+  return {
+    id: `id-${Math.random()}`,
+    pubkey: OTHER,
+    created_at: Math.floor(Date.now() / 1000),
+    kind: coordKey === 'a' ? 7516 : 1111,
+    tags: [[coordKey, coord]],
+    content: '',
+    sig: 'sig',
+    ...over,
+  } as VerifiedEvent;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000);
+});
+
+afterEach(() => {
+  (Date.now as jest.Mock).mockRestore?.();
+});
+
+describe('useCacheNotifications', () => {
+  it('fires the found-log title and broadcasts on the event bus', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+
+    await waitFor(() => expect(mockedFoundLogs).toHaveBeenCalled());
+
+    const ev = makeEvent({}, 'a', COORD_A);
+    act(() => latestFoundLogHandler()(ev));
+
+    expect(mockedFire).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheCoord: COORD_A, title: 'New find on your cache' }),
+    );
+    expect(mockedNotifyFoundLog).toHaveBeenCalledWith(COORD_A, ev.id);
+  });
+
+  it('fires the comment-specific title and does not broadcast', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+
+    await waitFor(() => expect(mockedComments).toHaveBeenCalled());
+
+    const ev = makeEvent({}, 'A', COORD_A);
+    act(() => latestCommentHandler()(ev));
+
+    expect(mockedFire).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheCoord: COORD_A, title: 'New comment on your cache' }),
+    );
+    expect(mockedNotifyFoundLog).not.toHaveBeenCalled();
+  });
+
+  it('never notifies for the viewer’s own activity', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+    await waitFor(() => expect(mockedFoundLogs).toHaveBeenCalled());
+
+    act(() => latestFoundLogHandler()(makeEvent({ pubkey: VIEWER }, 'a', COORD_A)));
+
+    expect(mockedFire).not.toHaveBeenCalled();
+  });
+
+  it('re-baselines the freshness gate on re-arm so pre-resubscribe replay stays silent', async () => {
+    // First arm at T0 with coord A only.
+    const t0 = 1_000_000_000; // seconds
+    (Date.now as jest.Mock).mockReturnValue(t0 * 1000);
+    mockedFetch.mockResolvedValueOnce([{ coord: COORD_A }]);
+
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+    await waitFor(() => expect(mockedFoundLogs).toHaveBeenCalledTimes(1));
+
+    // Coord set changes (a cache published mid-session) and an AppState
+    // 'active' hop, ~1h later, re-arms the subscription. Jumping well past
+    // REFETCH_MIN_GAP_MS (10s) so the throttle doesn't swallow the refetch.
+    const t1 = t0 + 3600;
+    (Date.now as jest.Mock).mockReturnValue(t1 * 1000);
+    mockedFetch.mockResolvedValueOnce([{ coord: COORD_A }, { coord: COORD_B }]);
+
+    const appStateCall = (AppState.addEventListener as jest.Mock).mock.calls.find(
+      (c) => c[0] === 'change',
+    );
+    await act(async () => {
+      appStateCall![1]('active');
+    });
+    await waitFor(() => expect(mockedFoundLogs).toHaveBeenCalledTimes(2));
+
+    // Historical replay: an event created shortly after the first arm (T0)
+    // but well before the re-arm (T1). Under the old mount-time baseline it
+    // would pass; under the re-arm baseline it must be dropped.
+    const staleReplay = makeEvent({ created_at: t0 + 60 }, 'a', COORD_B);
+    act(() => latestFoundLogHandler()(staleReplay));
+    expect(mockedFire).not.toHaveBeenCalled();
+
+    // A genuinely fresh event (at the re-arm baseline) still fires.
+    const fresh = makeEvent({ created_at: t1 }, 'a', COORD_B);
+    act(() => latestFoundLogHandler()(fresh));
+    expect(mockedFire).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheCoord: COORD_B, title: 'New find on your cache' }),
+    );
+  });
+});

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -1,13 +1,20 @@
 /**
  * useCacheNotifications — foreground live subscription that fires an OS
- * notification when a kind-1111 find-log is published against one of the
- * viewer's geo-caches (#740).
+ * notification when fresh activity lands on one of the viewer's published
+ * geo-caches (#740, #760).
+ *
+ * Two event surfaces are watched against the viewer's own cache coords:
+ *   - kind-1111 NIP-22 comments (`#A` root pointer) — #740
+ *   - kind-7516 NIP-GC found-logs (`#a` cache pointer) — #760
+ * A found-log additionally fans out on the in-app event bus
+ * (`notifyFoundLog`) so an open HuntPiggyDetail can refresh in-place;
+ * comments stay notification-only (no in-app live surface yet).
  *
  * Mirrors the shape of `useDmInbox`'s live sub (the one that opens the
  * kind-4 + kind-1059 stream and fires `fireMessageNotification` per
- * fresh event), but for the public find-log surface. There is no
+ * fresh event), but for the public cache-activity surface. There is no
  * decryption, no follow gate, and no inbox state to mutate — the hook
- * exists purely to listen and ping.
+ * exists purely to listen, ping, and broadcast.
  *
  * "My cache coordinates" is sourced from `fetchCachesByAuthor` and
  * re-fetched on a session timer (every minute) and on every AppState →
@@ -30,10 +37,14 @@
 import { useEffect, useRef } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import type { VerifiedEvent } from 'nostr-tools';
-import { subscribeCacheCommentsForCoords } from '../services/cacheNotifySubscription';
+import {
+  subscribeCacheCommentsForCoords,
+  subscribeCacheFoundLogsForCoords,
+} from '../services/cacheNotifySubscription';
 import { fireCacheNotification } from '../services/notificationService';
 import { fetchCachesByAuthor } from '../services/nostrPlacesPublisher';
 import { parseCacheCoord } from '../services/nostrPlacesService';
+import { notifyFoundLog } from './nostrEventBus';
 
 // Tolerate sender/receiver clock drift — matches the DM live sub.
 const NOTIFY_SKEW_SEC = 120;
@@ -88,7 +99,8 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
     if (readRelays.length === 0) return;
 
     let cancelled = false;
-    let unsubscribe: (() => void) | null = null;
+    let unsubscribeComments: (() => void) | null = null;
+    let unsubscribeFoundLogs: (() => void) | null = null;
     // Coord set the sub is currently armed with. Compared against each
     // refetch to skip tear-down + re-arm when nothing changed.
     let currentCoords: string[] = [];
@@ -97,27 +109,32 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
     const seen = new Set<string>();
     const subOpenedAtSec = Math.floor(Date.now() / 1000);
 
-    const handle = (ev: VerifiedEvent): void => {
+    // Shared per-event handler. `coordTagKey` is `A` (uppercase NIP-22 root
+    // pointer, for kind-1111 comments) or `a` (lowercase NIP-GC cache
+    // pointer, for kind-7516 found-logs) — read whichever tag the matching
+    // filter armed. `broadcast` fans a fresh found-log out on the in-app
+    // event bus so an open HuntPiggyDetail refreshes without polling;
+    // comments pass `false` (no in-app live surface yet).
+    const handle = (ev: VerifiedEvent, coordTagKey: 'A' | 'a', broadcast: boolean): void => {
       if (cancelled) return;
       if (seen.has(ev.id)) return;
       seen.add(ev.id);
       // Bounded dedup — drop oldest ~25% under sustained pressure (same
-      // pattern as the DM live sub's `seen` Set).
+      // pattern as the DM live sub's `seen` Set). Shared across both kinds;
+      // event ids are globally unique so a comment and a found-log never
+      // collide.
       if (seen.size > SEEN_CAP) {
         const drop = Math.floor(SEEN_CAP / 4);
         const it = seen.values();
         for (let i = 0; i < drop; i++) seen.delete(it.next().value!);
       }
-      // Never self-ping — the hider commenting on their own cache is a
-      // maintenance note, not a find we want to surface as a notification.
+      // Never self-ping — the owner logging a find / maintenance note on
+      // their own cache is not activity we want to surface as a notification.
       if (ev.pubkey === pubkey) return;
       // Freshness gate — silent on backlog the relay replays on sub open.
       if (ev.created_at < subOpenedAtSec - NOTIFY_SKEW_SEC) return;
 
-      // The cache coord rides on the `A` (uppercase) NIP-22 root pointer.
-      // `buildComment` in nostrPlacesService writes both `A` and `a`; we
-      // read `A` because that's what the filter matched on.
-      const coordTag = ev.tags.find((t) => t[0] === 'A')?.[1];
+      const coordTag = ev.tags.find((t) => t[0] === coordTagKey)?.[1];
       if (!coordTag) return;
       const parsed = parseCacheCoord(coordTag);
       if (!parsed) return;
@@ -135,6 +152,8 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
         title: 'New find on your cache',
         body: 'Open Lightning Piggy to view',
       });
+
+      if (broadcast) notifyFoundLog(coordTag, ev.id);
     };
 
     /**
@@ -161,16 +180,26 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
           coords.length === currentCoords.length && coords.every((c) => currentCoords.includes(c));
         if (sameSet) return;
         currentCoords = coords;
-        if (unsubscribe) {
-          unsubscribe();
-          unsubscribe = null;
+        if (unsubscribeComments) {
+          unsubscribeComments();
+          unsubscribeComments = null;
+        }
+        if (unsubscribeFoundLogs) {
+          unsubscribeFoundLogs();
+          unsubscribeFoundLogs = null;
         }
         if (coords.length === 0) return;
-        unsubscribe = subscribeCacheCommentsForCoords({
+        unsubscribeComments = subscribeCacheCommentsForCoords({
           viewerPubkey: pubkey,
           relays: readRelays,
           cacheCoords: coords,
-          onEvent: handle,
+          onEvent: (ev) => handle(ev, 'A', false),
+        });
+        unsubscribeFoundLogs = subscribeCacheFoundLogsForCoords({
+          viewerPubkey: pubkey,
+          relays: readRelays,
+          cacheCoords: coords,
+          onEvent: (ev) => handle(ev, 'a', true),
         });
       } catch {
         // Non-fatal — leave the previous sub (if any) in place; the next
@@ -191,7 +220,8 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
       cancelled = true;
       clearInterval(interval);
       appStateSub.remove();
-      if (unsubscribe) unsubscribe();
+      if (unsubscribeComments) unsubscribeComments();
+      if (unsubscribeFoundLogs) unsubscribeFoundLogs();
     };
   }, [pubkey, getReadRelays]);
 }

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -66,6 +66,22 @@ const REFETCH_COORDS_INTERVAL_MS = 60_000;
 // JS thread during warm re-foreground (#751 warm-path audit #5).
 const REFETCH_MIN_GAP_MS = 10_000;
 
+// Per-surface notification copy. Comments and found-logs are separate
+// event kinds now, so the OS notification title should match what actually
+// happened rather than always claiming a "find" (Copilot #760).
+interface NotifyCopy {
+  title: string;
+  body: string;
+}
+const FOUND_LOG_COPY: NotifyCopy = {
+  title: 'New find on your cache',
+  body: 'Open Lightning Piggy to view',
+};
+const COMMENT_COPY: NotifyCopy = {
+  title: 'New comment on your cache',
+  body: 'Open Lightning Piggy to view',
+};
+
 export interface UseCacheNotificationsParams {
   /** Active viewer's hex pubkey. Null when logged out — sub stays closed. */
   pubkey: string | null;
@@ -107,7 +123,12 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
     // Wall-clock of the last refetch we actually started — see REFETCH_MIN_GAP_MS.
     let lastRefetchStartedAt = 0;
     const seen = new Set<string>();
-    const subOpenedAtSec = Math.floor(Date.now() / 1000);
+    // Freshness baseline. Reset to "now" every time we (re)arm the relay
+    // subscriptions in refetchAndRearm — NOT just once on mount — so the
+    // relay's historical replay that predates a *later* (re)subscribe (e.g.
+    // a cache published mid-session that changes the coord set minutes in)
+    // can't slip past the gate and fire stale notifications (Copilot #760).
+    let subOpenedAtSec = Math.floor(Date.now() / 1000);
 
     // Shared per-event handler. `coordTagKey` is `A` (uppercase NIP-22 root
     // pointer, for kind-1111 comments) or `a` (lowercase NIP-GC cache
@@ -115,7 +136,12 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
     // filter armed. `broadcast` fans a fresh found-log out on the in-app
     // event bus so an open HuntPiggyDetail refreshes without polling;
     // comments pass `false` (no in-app live surface yet).
-    const handle = (ev: VerifiedEvent, coordTagKey: 'A' | 'a', broadcast: boolean): void => {
+    const handle = (
+      ev: VerifiedEvent,
+      coordTagKey: 'A' | 'a',
+      broadcast: boolean,
+      copy: NotifyCopy,
+    ): void => {
       if (cancelled) return;
       if (seen.has(ev.id)) return;
       seen.add(ev.id);
@@ -149,8 +175,8 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
       // resolve those off the hot path and pass them in.
       void fireCacheNotification({
         cacheCoord: coordTag,
-        title: 'New find on your cache',
-        body: 'Open Lightning Piggy to view',
+        title: copy.title,
+        body: copy.body,
       });
 
       if (broadcast) notifyFoundLog(coordTag, ev.id);
@@ -189,17 +215,21 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
           unsubscribeFoundLogs = null;
         }
         if (coords.length === 0) return;
+        // Re-baseline the freshness gate to the moment we (re)arm, so the
+        // replay the relay sends for this fresh subscription (since: now−7d)
+        // stays silent — only events created at/after this re-subscribe fire.
+        subOpenedAtSec = Math.floor(Date.now() / 1000);
         unsubscribeComments = subscribeCacheCommentsForCoords({
           viewerPubkey: pubkey,
           relays: readRelays,
           cacheCoords: coords,
-          onEvent: (ev) => handle(ev, 'A', false),
+          onEvent: (ev) => handle(ev, 'A', false, COMMENT_COPY),
         });
         unsubscribeFoundLogs = subscribeCacheFoundLogsForCoords({
           viewerPubkey: pubkey,
           relays: readRelays,
           cacheCoords: coords,
-          onEvent: (ev) => handle(ev, 'a', true),
+          onEvent: (ev) => handle(ev, 'a', true, FOUND_LOG_COPY),
         });
       } catch {
         // Non-fatal — leave the previous sub (if any) in place; the next

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -1,11 +1,11 @@
 /**
  * useCacheNotifications — foreground live subscription that fires an OS
  * notification when fresh activity lands on one of the viewer's published
- * geo-caches (#740, #760).
+ * geo-caches (#740, #945).
  *
  * Two event surfaces are watched against the viewer's own cache coords:
  *   - kind-1111 NIP-22 comments (`#A` root pointer) — #740
- *   - kind-7516 NIP-GC found-logs (`#a` cache pointer) — #760
+ *   - kind-7516 NIP-GC found-logs (`#a` cache pointer) — #945
  * A found-log additionally fans out on the in-app event bus
  * (`notifyFoundLog`) so an open HuntPiggyDetail can refresh in-place;
  * comments stay notification-only (no in-app live surface yet).
@@ -68,7 +68,7 @@ const REFETCH_MIN_GAP_MS = 10_000;
 
 // Per-surface notification copy. Comments and found-logs are separate
 // event kinds now, so the OS notification title should match what actually
-// happened rather than always claiming a "find" (Copilot #760).
+// happened rather than always claiming a "find" (Copilot #946).
 interface NotifyCopy {
   title: string;
   body: string;
@@ -127,7 +127,7 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
     // subscriptions in refetchAndRearm — NOT just once on mount — so the
     // relay's historical replay that predates a *later* (re)subscribe (e.g.
     // a cache published mid-session that changes the coord set minutes in)
-    // can't slip past the gate and fire stale notifications (Copilot #760).
+    // can't slip past the gate and fire stale notifications (Copilot #946).
     let subOpenedAtSec = Math.floor(Date.now() / 1000);
 
     // Shared per-event handler. `coordTagKey` is `A` (uppercase NIP-22 root
@@ -201,9 +201,12 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
         if (cancelled) return;
         const coords = myCaches.map((c) => c.coord);
         // Set-equality (order-independent — fetchCachesByAuthor ordering is
-        // not guaranteed). Skip the tear-down + re-arm when unchanged.
+        // not guaranteed). Skip the tear-down + re-arm when unchanged. O(1)
+        // membership via a Set — this runs every minute and on AppState
+        // resume, and a user can own many caches (Copilot #946).
+        const currentSet = new Set(currentCoords);
         const sameSet =
-          coords.length === currentCoords.length && coords.every((c) => currentCoords.includes(c));
+          coords.length === currentCoords.length && coords.every((c) => currentSet.has(c));
         if (sameSet) return;
         currentCoords = coords;
         if (unsubscribeComments) {

--- a/src/services/cacheNotifySubscription.test.ts
+++ b/src/services/cacheNotifySubscription.test.ts
@@ -1,6 +1,7 @@
-// Tests for the foreground kind-1111 find-log subscription (#740). The
-// nostr-tools pool is mocked so we can assert the filter shape, the empty-
-// coord short-circuit, and the teardown wiring without a real relay.
+// Tests for the foreground cache-activity subscriptions — kind-1111
+// comments (#740) and kind-7516 found-logs (#760). The nostr-tools pool is
+// mocked so we can assert the filter shape (incl. the #A vs #a tag), the
+// empty-coord short-circuit, and the teardown wiring without a real relay.
 
 const mockSubscribeMany = jest.fn();
 const mockClose = jest.fn();
@@ -11,8 +12,11 @@ jest.mock('./nostrService', () => ({
   trackRelays: (...a: unknown[]) => mockTrackRelays(...a),
 }));
 
-import { subscribeCacheCommentsForCoords } from './cacheNotifySubscription';
-import { GC_COMMENT_KIND } from './nostrPlacesService';
+import {
+  subscribeCacheCommentsForCoords,
+  subscribeCacheFoundLogsForCoords,
+} from './cacheNotifySubscription';
+import { GC_COMMENT_KIND, GC_FOUND_LOG_KIND } from './nostrPlacesService';
 
 const VIEWER = 'a'.repeat(64);
 const RELAYS = ['wss://r.example'];
@@ -106,4 +110,53 @@ it('swallows a teardown exception (best-effort, never throws to caller)', () => 
     onEvent: jest.fn(),
   });
   expect(() => close()).not.toThrow();
+});
+
+// --- found-logs (kind-7516, #a lowercase) — #760 ---
+
+it("arms the found-log sub with kind-7516 + #a (lowercase) filter on the viewer's coords", () => {
+  subscribeCacheFoundLogsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent: jest.fn(),
+  });
+  expect(mockTrackRelays).toHaveBeenCalledWith(RELAYS);
+  expect(mockSubscribeMany).toHaveBeenCalledTimes(1);
+  const [, filterArg] = mockSubscribeMany.mock.calls[0];
+  expect(filterArg.kinds).toEqual([GC_FOUND_LOG_KIND]);
+  // Lowercase `#a` — buildFoundLog writes ["a", coord]; the uppercase
+  // `#A` used for comments would never match a found-log.
+  expect(filterArg['#a']).toEqual(COORDS);
+  expect(filterArg['#A']).toBeUndefined();
+  expect(typeof filterArg.since).toBe('number');
+  expect(typeof filterArg.limit).toBe('number');
+});
+
+it('found-log sub no-ops on empty coords (no firehose request)', () => {
+  const close = subscribeCacheFoundLogsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: [],
+    onEvent: jest.fn(),
+  });
+  expect(mockSubscribeMany).not.toHaveBeenCalled();
+  expect(mockTrackRelays).not.toHaveBeenCalled();
+  expect(typeof close).toBe('function');
+});
+
+it('found-log sub forwards onevent deliveries and tears down', () => {
+  const onEvent = jest.fn();
+  const close = subscribeCacheFoundLogsForCoords({
+    viewerPubkey: VIEWER,
+    relays: RELAYS,
+    cacheCoords: COORDS,
+    onEvent,
+  });
+  const handlers = mockSubscribeMany.mock.calls[0][2] as { onevent: (e: unknown) => void };
+  const fake = { id: 'f1', kind: 7516, pubkey: 'finder', created_at: 1, tags: [], content: '' };
+  handlers.onevent(fake);
+  expect(onEvent).toHaveBeenCalledWith(fake);
+  close();
+  expect(mockClose).toHaveBeenCalledTimes(1);
 });

--- a/src/services/cacheNotifySubscription.ts
+++ b/src/services/cacheNotifySubscription.ts
@@ -1,61 +1,72 @@
 /**
- * cacheNotifySubscription — live foreground subscription for kind-1111
- * NIP-22 find-logs against the active user's published geo-caches (#740).
+ * cacheNotifySubscription — live foreground subscriptions for activity
+ * against the active user's published geo-caches (#740, #760).
  *
- * Mirrors the shape of `dmLiveSubscription`. Returns a teardown function
- * the caller invokes on cleanup. Empty `cacheCoords` short-circuits — a
- * filter with no `#A` values would be a free firehose request and most
- * relays reject it.
+ * Two public surfaces, both mirroring the shape of `dmLiveSubscription`:
  *
- * Find-log events are public (no decryption), so unlike the DM live sub
- * there is no signer dependency. The single filter shape is
+ *   - `subscribeCacheCommentsForCoords` — kind-1111 NIP-22 comments,
+ *     matched on the `#A` uppercase root pointer.
+ *   - `subscribeCacheFoundLogsForCoords` — kind-7516 NIP-GC found-logs,
+ *     matched on the `#a` lowercase cache pointer (`buildFoundLog` in
+ *     `nostrPlacesService.ts` writes `["a", coord]`, NOT `A`).
  *
- *   { kinds: [1111], '#A': cacheCoords, since: now - 7d, limit: ... }
+ * Both return a teardown function the caller invokes on cleanup. Empty
+ * `cacheCoords` short-circuits — a filter with no tag values would be a
+ * free firehose request and most relays reject it.
  *
- * — `#A` uppercase because that's the NIP-22 root-pointer tag used by
- * `buildComment` in `nostrPlacesService.ts`. The 7-day floor matches the
- * DM live sub: enough that "I haven't opened the app for a week" still
- * catches recent activity, capped so cold-start restream cost stays
- * bounded even if the user owns many caches. Per-event freshness is
- * gated by the caller using `subOpenedAtSec`-style timestamp checks
- * (same pattern as DMs), NOT by EOSE — so a slow relay replaying backlog
- * late cannot reintroduce a notification flood.
+ * The events are public (no decryption), so unlike the DM live sub there
+ * is no signer dependency. The single filter shape is
+ *
+ *   { kinds: [<kind>], '<#a | #A>': cacheCoords, since: now - 7d, limit }
+ *
+ * The 7-day floor matches the DM live sub: enough that "I haven't opened
+ * the app for a week" still catches recent activity, capped so cold-start
+ * restream cost stays bounded even if the user owns many caches. Per-event
+ * freshness is gated by the caller using `subOpenedAtSec`-style timestamp
+ * checks (same pattern as DMs), NOT by EOSE — so a slow relay replaying
+ * backlog late cannot reintroduce a notification flood.
  */
 import type { VerifiedEvent } from 'nostr-tools';
 import type { Filter } from 'nostr-tools/filter';
 import { pool, trackRelays } from './nostrService';
-import { GC_COMMENT_KIND } from './nostrPlacesService';
+import { GC_COMMENT_KIND, GC_FOUND_LOG_KIND } from './nostrPlacesService';
 
 // Match the dmLiveSubscription cap — past 7 days is a different problem
 // (handled by background detect-and-ping with a separate seen-set).
 const CACHE_LIVE_SUB_MAX_LOOKBACK_SECONDS = 7 * 24 * 60 * 60;
 
-// Cap the relay response so a cache with a viral comment thread cannot
-// pin the JS thread on sub open. 500 is more than enough to catch any
-// realistic burst and is what we'd want to surface in the inbox-style
+// Cap the relay response so a cache with a viral comment / find thread
+// cannot pin the JS thread on sub open. 500 is more than enough to catch
+// any realistic burst and is what we'd want to surface in the inbox-style
 // "new finds" notification path anyway.
 const CACHE_LIVE_SUB_LIMIT = 500;
 
 export interface CacheNotifySubscriptionInput {
   /** The active viewer's hex pubkey. Tracked for invariants and future
    * per-account dedup; the filter itself uses `cacheCoords` not pubkey
-   * (kind-1111 finders can be anyone, including non-followed users). */
+   * (finders can be anyone, including non-followed users). */
   viewerPubkey: string;
   /** Read relays the subscription opens against. */
   relays: string[];
   /** `<kind>:<pubkey>:<d>` addressable coordinates of the caches the
    * viewer owns. Empty → the subscription is a no-op (no filter armed). */
   cacheCoords: string[];
-  /** Fires for every kind-1111 event matching the filter. The caller is
-   * responsible for freshness gating, dedup, and notification fire. */
+  /** Fires for every event matching the filter. The caller is responsible
+   * for freshness gating, dedup, and notification fire. */
   onEvent: (event: VerifiedEvent) => void;
 }
 
 /**
- * Open the live kind-1111 subscription for the viewer's caches and
- * return a teardown function. Idempotent: caller decides when to call.
+ * Shared internal: open a single kind-filtered cache-activity sub keyed on
+ * the given tag and return a teardown function. `tag` is `#A` (uppercase
+ * NIP-22 root pointer, comments) or `#a` (lowercase NIP-GC cache pointer,
+ * found-logs).
  */
-export function subscribeCacheCommentsForCoords(input: CacheNotifySubscriptionInput): () => void {
+function subscribeCacheActivity(
+  input: CacheNotifySubscriptionInput,
+  kind: number,
+  tag: '#A' | '#a',
+): () => void {
   if (input.cacheCoords.length === 0) {
     // No caches — nothing to watch. Returning a no-op closer keeps the
     // caller's effect cleanup simple.
@@ -65,11 +76,14 @@ export function subscribeCacheCommentsForCoords(input: CacheNotifySubscriptionIn
   const nowSec = Math.floor(Date.now() / 1000);
   const sinceSec = nowSec - CACHE_LIVE_SUB_MAX_LOOKBACK_SECONDS;
   const filter: Filter = {
-    kinds: [GC_COMMENT_KIND],
-    '#A': input.cacheCoords,
+    kinds: [kind],
     since: sinceSec,
     limit: CACHE_LIVE_SUB_LIMIT,
   };
+  // Assign the `#a` / `#A` tag filter separately — a computed-key literal
+  // mixing it with the numeric `since` / `limit` widens the inferred index
+  // signature past Filter's `#${string}: string[]` shape.
+  filter[tag] = input.cacheCoords;
   const sub = pool.subscribeMany(input.relays, filter, {
     onevent: (e) => input.onEvent(e as VerifiedEvent),
   });
@@ -80,4 +94,22 @@ export function subscribeCacheCommentsForCoords(input: CacheNotifySubscriptionIn
       // best-effort — same swallow as the DM live sub.
     }
   };
+}
+
+/**
+ * Open the live kind-1111 comment subscription for the viewer's caches and
+ * return a teardown function. Matched on `#A` (uppercase NIP-22 root).
+ */
+export function subscribeCacheCommentsForCoords(input: CacheNotifySubscriptionInput): () => void {
+  return subscribeCacheActivity(input, GC_COMMENT_KIND, '#A');
+}
+
+/**
+ * Open the live kind-7516 found-log subscription for the viewer's caches
+ * and return a teardown function. Matched on `#a` (lowercase NIP-GC cache
+ * pointer) — `buildFoundLog` writes `["a", coord]`, so the uppercase `#A`
+ * filter used for comments would never match a found-log (#760).
+ */
+export function subscribeCacheFoundLogsForCoords(input: CacheNotifySubscriptionInput): () => void {
+  return subscribeCacheActivity(input, GC_FOUND_LOG_KIND, '#a');
 }


### PR DESCRIPTION
Cache (Piglet) owners now get notified when someone logs a find on a cache they own.

## What
The repo already notified for kind-1111 **comments** (#740) but **missed kind-7516 found-logs** — they tag with lowercase `#a` (NIP-22), which the comment path (uppercase `#A`) never matched. This extends the existing notification machinery rather than building a parallel one.

- **Subscription**: `subscribeCacheFoundLogsForCoords` (kind 7516, `#a` = the user's owned cache coords, `since: now−7d`); empty-coords short-circuits (no firehose).
- **Broadcaster**: `notifyFoundLog` on `nostrEventBus` (mirrors the DM/group pub/subs).
- **Notification**: branded local notification + event-bus fan-out on a fresh found-log; armed where the long-lived subs live (sibling to the DM live-sub).
- **Ownership**: owned coords from `fetchCachesByAuthor(pubkey)`, refreshed on a throttle + AppState→active.
- **Dedupe / self-skip**: bounded session id-set + a freshness gate (ignores the relay's historical replay); the owner's own logs never notify.

## Scope
**Foreground/in-app only.** Background delivery while the UI is unmounted depends on the separate background-notifications work (which still queries kind-1111 only) — extending that detect-and-ping to 7516 is the follow-up.

## Test plan
- [x] `npm run typecheck` / `npm run lint` (0 errors) / `npm run format:check` clean
- [x] `npm test` green — **127 suites / 1469 tests pass**, incl. the found-log `#a`-not-`#A` filter shape, empty-coord no-op, teardown, event-bus delivery/unsubscribe/throw-isolation
- [x] New `useCacheNotifications.test.ts` pins the Copilot fixes: found-log uses "New find on your cache" + broadcasts; comment uses "New comment on your cache" + no broadcast; owner self-activity never notifies; freshness gate re-baselines on re-arm so pre-resubscribe replay stays silent
- [x] File-size gate green (consumers import `subscribeFoundLogEvents` directly to avoid growing the over-cap NostrContext)
- Manual: log a find (kind-7516) from a second account on a cache owned by the signed-in viewer → foreground OS notification "New find on your cache"; owner's own find produces no notification

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
