### PR TITLE
chore(release): v1.3.12

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,5 +14,17 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
+- **Background message notifications (Android).** Turn on Account → Security → "Watch for messages in the background" and you'll get notified of new direct messages even when the app is closed or swiped away — no Google services needed. Only notifies for people you follow.
+- **Choose your language.** Account → Appearance → Language now lets you pick Spanish or follow your device language. The bottom tab labels are translated so far; more screens follow.
 - **Shop orders show as cards in your chats.** An order or receipt from a merchant now shows the item count, total in sats, and status — not raw text.
 - **Pay an order in a tap.** Order cards have a Pay button and a QR code to pay the invoice from the chat, or scan it with another wallet.
+- **Get notified when someone finds your Piglet.** Cache owners now get a notification when a finder logs a find on their cache.
+- **Publish a cache with no prize.** You can now publish a geo-cache without attaching a Lightning reward.
+- **See your swap on-chain.** Boltz swap details now link out to the mempool.space block explorer so you can follow confirmations.
+
+### Improved
+
+- Transaction history now scrolls smoothly through long histories instead of a "show all" button.
+- Boltz swaps are hardened: the app verifies what the swap server returns before paying, and recovers stuck on-chain→Lightning swaps after a crash.
+- Faster Messages tab load; smoother pink→purple theme accents.
+- Fixed the amount keypad's "0" key being hidden behind the Android navigation bar.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Summary

Cuts the **v1.3.12** release. Bumps the marketing version (1.3.11 → 1.3.12, single source of truth in `package.json`, flows into `app.config.ts`) and populates `docs/RELEASE_NOTES_NEXT.md` with the tester-facing "What to Test" notes.

Once merged, publishing the `v1.3.12` GitHub Release (targeting main) fires `.github/workflows/release.yml` → EAS cloud builds for both platforms, iOS auto-submit to TestFlight, Android APK attached to the Release.

## What shipped since v1.3.11

Background DM notifications (#279), Spanish language picker / i18n infra (#137), found-log notifications (#945), no-prize caches (#954), Boltz swap hardening + mempool explorer links (#962), wallet infinite-scroll (#939), DM info shield + group support (#952), dependency security fixes (#959), plus theme polish and the amount-keypad fix.

## Why no screenshot

Version-bump + release-notes only; no UI change in this PR.

## Test plan

N/A — version bump and release-notes update only. The features it releases were each tested and reviewed in their own PRs. The release build itself is validated by the EAS cloud pipeline on publish.