### PR TITLE
chore: stop tracking accidental node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules/
+node_modules
 
 # Expo
 .expo/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/benweeks/GitHub/lightning-piggy-mobile/node_modules


### PR DESCRIPTION
## Summary

`node_modules` was accidentally committed on `main` as a **machine-specific symlink** (git mode `120000`) — its blob is the absolute path `/home/benweeks/GitHub/lightning-piggy-mobile/node_modules` on one developer's machine. It was almost certainly force-added (`git add -f`), which is how it slipped past the existing `.gitignore`.

This is a repo-hygiene bug: on any **fresh clone or CI runner**, git materializes that tracked symlink pointing at a path that doesn't exist there — a dangling/wrong link that shadows the real dependency install and can break tooling.

## What this PR does

- **`git rm --cached node_modules`** — stops tracking the symlink (index only; the on-disk directory/symlink is untouched). The commit records `delete mode 120000 node_modules`, confirming it was a symlink, not a real tree.
- **Extends `.gitignore`** with a slash-less `node_modules` entry. The existing `node_modules/` (trailing slash) only matches a real *directory*, so it never covered the *symlink* form — which is exactly why the symlink re-appeared as untracked after removal. Both lines are now present so either form is ignored.

## Test plan

- [x] `git ls-files node_modules` returns nothing (no longer tracked).
- [x] `git check-ignore -v node_modules` matches the new `.gitignore` line — `git status` is clean, no untracked re-appearance.
- [x] `bash scripts/check-file-size.sh` still passes (doesn't depend on tracked `node_modules`).
- A fresh clone no longer materializes a broken machine-specific symlink.
- `npm install` still populates `node_modules` locally (now correctly ignored); app build/dev flow unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdYLRTPracfFdRGsbbLB1n