### PR TITLE
fix(messages): retire plaintext DM blobs into the encrypted store (#850)

### DIFF
--- a/docs/DATA_STORAGE.adoc
+++ b/docs/DATA_STORAGE.adoc
@@ -37,10 +37,16 @@ changing how anything is stored.
 
 | `AsyncStorage`
   (Android: SQLite `RKStorage` in the app sandbox)
-| App settings, WoT tier, DM inbox summaries (`nostr_dm_inbox_v1`),
-  per-conversation caches, geo-cache blob (`@lp:nostr-caches-v1`), NIP-52
+| App settings, WoT tier, geo-cache blob (`@lp:nostr-caches-v1`), NIP-52
   events blob (`@lp:nostr-events-v1`), per-wallet tx caches, last-seen cursors
-| Mixed (mostly public/cache; DM *summaries* are decrypted snippets)
+  (bare timestamps). The plaintext DM inbox summaries (`nostr_dm_inbox_v1_*`)
+  and per-conversation caches (`nostr_dm_conv_v1_*`) are *retired* — #850
+  migrates them into the encrypted DB and deletes them (verified).
+  Remaining known plaintext: decrypted *group-chat* logs
+  (`group_messages_<groupId>`) and group previews
+  (`nostr_group_activity_<pubkey>`) — see the residual-risk note under
+  <<threat>>.
+| Mixed (mostly public/cache; group-chat plaintext is the known residual)
 | App sandbox + OS file-based encryption (FBE). *Not* app-level encrypted.
 
 | `expo-file-system`
@@ -53,14 +59,48 @@ changing how anything is stored.
 | App sandbox + OS FBE. *Not* app-level encrypted (nothing here needs it).
 
 | `op-sqlite` + SQLCipher
-  (`lightningpiggy.db`, #695/#848)
+  (`lightningpiggy.db`, #695/#848/#850)
 | Decrypted DM rows (`dm_messages`: NIP-17 rumors *and* NIP-04 plaintexts),
   one row per event, keyed `(owner, event_id)`, indexed
-  `(owner, conversation, created_at)`
+  `(owner, conversation, created_at)`. Since #850 the rows also carry the
+  per-relay delivery tick (`delivery_status`, #856), the NIP-17 rumor id
+  (`rumor_id`, #857) and the optimistic `local-` send rows — so the store is
+  the *only* at-rest home for 1:1 DM content; no plaintext side blobs.
 | *Decrypted DM plaintext* — the most sensitive bulk data on the device
 | *Whole-file SQLCipher encryption*, key in the OS keystore (#697). Signal's
   model — see <<keys>>.
 |===
+
+[[threat]]
+== Threat model: device seizure
+
+The at-rest design assumes the strongest realistic adversary for a travelling
+user: *the phone is seized (e.g. border control) and forensically imaged*,
+possibly while powered on and after first unlock.
+
+* *What the design protects:* every 1:1 DM ever decrypted — content, delivery
+  metadata, optimistic sends — exists on disk only inside `lightningpiggy.db`,
+  which is SQLCipher ciphertext end-to-end (content *and* metadata). The
+  256-bit DB key never touches disk outside the hardware keystore
+  (`expo-secure-store`, `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY` — excluded from
+  backups, not device-migratable). Imaging the flash yields ciphertext; the
+  key material is wrapped by the secure element and is not extractable
+  without defeating the hardware (or coercing the device unlock itself — no
+  app-level design survives a compelled unlock; see the app-lock follow-up).
+* *Wallet + identity secrets* (`nsec`, NWC URLs, mnemonics, xpubs, LNURL-w
+  bearers, the DB key) are individually keystore-wrapped — same story.
+* *Known residual plaintext (accepted, tracked):* decrypted *group-chat* logs
+  (`group_messages_<groupId>`, `nostr_group_activity_<pubkey>`) still live in
+  AsyncStorage — wiped on logout (#944) but readable from a seized unlocked
+  device until they get the same encrypted-store treatment (follow-up).
+  Public caches (places, profiles, geo-caches) are public data by
+  definition; the eventual move into the one encrypted DB is a metadata-
+  privacy nicety, not a confidentiality requirement.
+* *Out of scope at the app layer:* a compelled/observed device unlock, a
+  rooted device with the app running (RAM holds decrypted rows while the UI
+  displays them), and platform supply-chain compromise. Mitigations that
+  raise the bar further — an app-level lock gating the DB key read, a panic
+  wipe — are candidate follow-ups, not current features.
 
 == Gotcha: the 2 MB AsyncStorage row limit
 
@@ -86,12 +126,15 @@ is the case for <<target>>.
 [[target]]
 == Target architecture (#695): indexed, encrypted SQLite
 
-NOTE: *Status:* the DM slice of this architecture is *live* as of #848 —
+NOTE: *Status:* the DM slice of this architecture is *complete* as of #850 —
 `dm_messages` is wired into the inbox refresh, the live DM subscription and
 thread opens (ingest via `dmWrapIngest`/`dmIngest`, reads via `dmDb`'s indexed
-queries), with a one-time verified migration off the plaintext wrap-cache file
-(`dmStoreMigrationRunner`). Transactions/swaps and the public cache tables
-remain future slices.
+queries), and is the *sole* at-rest home for 1:1 DM content: the plaintext
+wrap-cache file was retired in #848 (`dmStoreMigrationRunner`) and the
+plaintext inbox/conversation AsyncStorage blobs in #850 (`dmBlobMigration`),
+each via a one-time verified populate → delete → verify migration.
+Transactions/swaps and the public cache tables remain future slices; group
+chat is the known plaintext residual (see <<threat>>).
 
 The blob/file caches don't scale (whole-blob parse, no indexes, the 2 MB trap).
 The target — matching how 0xchat / Damus persist Nostr data — is a single
@@ -181,11 +224,16 @@ the pubkey columns reference Nostr identities, not enforced foreign keys.
 ....
 erDiagram
     dm_messages {
+        TEXT owner PK
         TEXT event_id PK
         TEXT conversation
         INTEGER created_at
         TEXT sender
         TEXT content
+        INTEGER from_me
+        INTEGER wire_kind
+        TEXT delivery_status
+        TEXT rumor_id
     }
     group_messages {
         TEXT event_id PK
@@ -271,12 +319,25 @@ that isn't yours to wipe.
 
 === Migration (old store → new): import the decrypt memo, then delete
 
-Relays remain the *canonical source* for messages. But the old wrap-cache file
-was never independent data — it was purely a *memo of decryptions* this app
-already performed on relay-fetched wraps. So the one-time migration (#848,
-`dmStoreMigrationRunner`) imports that memo as rows, then deletes the
-plaintext file with verification (closing the at-rest gap, #690; ordering
-enforced by `dmStoreMigration`: populate → delete → verify → flag).
+Relays remain the *canonical source* for messages. But the old plaintext
+caches were never independent data — they were purely *memos of decryptions*
+this app already performed on relay-fetched events. So the one-time
+migrations import each memo as rows, then delete the plaintext with
+verification (ordering enforced by `dmStoreMigration`: populate → delete →
+verify → flag; a crash anywhere retries next launch, and plaintext is never
+deleted before the DB holds the rows):
+
+* *#848 (`dmStoreMigrationRunner`)* — the file-backed NIP-17 wrap cache
+  (closing the original at-rest gap, #690).
+* *#850 (`dmBlobMigration`)* — the last two plaintext blobs: the inbox
+  summaries (`nostr_dm_inbox_v1_*`) and the per-conversation threads
+  (`nostr_dm_conv_v1_*`). The conversation import is the only carrier of the
+  delivery ticks (#856), rumor ids (#857) and optimistic `local-` rows, so
+  the import is *fill-only*: an existing encrypted row always wins; the blob
+  only supplies rows the store lacks plus missing tick/rumor columns. The
+  delete step also removes any pre-#288 *unsuffixed* wrap-cache remnants
+  (delete-only: an unowned cache can't be attributed on a multi-account
+  device, and its content is re-fetchable).
 
 Why import rather than the originally-planned "re-fetch and re-decrypt"?
 Re-decrypting the whole inbox on migration day is exactly the cold-start
@@ -295,4 +356,6 @@ flowchart LR
     BM["BTC Map API"] -->|"refresh"| PC["Plain places cache"]
     OLD["Old plaintext wrap cache<br/>(decrypt memo, #689)"] -->|"one-time import (#848)"| DB
     OLD -.->|"then deleted, verified"| X["discarded"]
+    BLOB["Plaintext inbox + conv blobs<br/>(nostr_dm_inbox_v1_* / nostr_dm_conv_v1_*)"] -->|"one-time fill-only import (#850)"| DB
+    BLOB -.->|"then deleted, verified"| X
 ....

--- a/docs/SECURITY.adoc
+++ b/docs/SECURITY.adoc
@@ -36,7 +36,7 @@ The app uses two storage mechanisms with different security levels:
 
 ==== AsyncStorage (Unencrypted)
 
-`@react-native-async-storage/async-storage` stores mostly non-sensitive data — the keys below contain pubkeys, settings, and public profile metadata. The notable exception is decrypted DM + group-message plaintext, which the app caches under additional keys to power cold-start rendering; see <<Decrypted DM Plaintext at Rest (Threat Model)>> for the full inventory and rationale.
+`@react-native-async-storage/async-storage` stores mostly non-sensitive data — the keys below contain pubkeys, settings, and public profile metadata. Decrypted *1:1 DM* plaintext no longer lives here: as of #848/#850 it persists exclusively in the SQLCipher-encrypted local DB (see <<Message Content at Rest (Threat Model)>>). The remaining known exception is decrypted *group-chat* plaintext (`group_messages_<groupId>`, `nostr_group_activity_<pubkey>`) — see the residual-risk note in that section.
 
 [cols="2,3", options="header"]
 |===
@@ -62,7 +62,7 @@ The app uses two storage mechanisms with different security levels:
 
 |===
 
-NOTE: The app also stores **decrypted DM and group-message plaintext** in AsyncStorage to power cold-start rendering of both the Messages tab (DM + group previews) and `GroupConversationScreen` (per-group thread log under `group_messages_<groupId>`). See <<Decrypted DM Plaintext at Rest (Threat Model)>> below for the full inventory, threat model, and mitigation analysis.
+NOTE: The app still stores **decrypted group-message plaintext** in AsyncStorage to power `GroupConversationScreen` and the group previews on the Messages tab (`group_messages_<groupId>`, `nostr_group_activity_<pubkey>`). This is the known at-rest residual — 1:1 DM plaintext moved to the encrypted DB in #848/#850. See <<Message Content at Rest (Threat Model)>> below.
 
 === NWC URL Security
 
@@ -146,94 +146,51 @@ Cached contact data in AsyncStorage is also cleared.
 * Image uploads to nostr.build use HTTPS
 * LNURL-pay callbacks use HTTPS
 
-=== Decrypted DM Plaintext at Rest (Threat Model)
+=== Message Content at Rest (Threat Model)
 
-This section documents the threat model around decrypted direct-message and group-message plaintext that the app persists in AsyncStorage to power cold-start rendering, follow-up to issue #192.
+This section documents where decrypted Nostr message content lives on disk and what an adversary with the device can recover. It supersedes the original "document + accept" analysis (#192): the plaintext-in-AsyncStorage design it described was retired in #848/#850 in favour of app-level encryption at rest (the option-4 outcome that analysis recommended, delivered as a SQLCipher store rather than per-blob AES). The design threat model is a **seized device** — e.g. border control taking the phone for forensic imaging.
 
-==== What is stored, where, and how much
-
-Decrypted Nostr message plaintext lands on disk in six distinct AsyncStorage namespaces. None of these are encrypted at rest.
+==== Where message content lives now
 
 [cols="3,3,2", options="header"]
 |===
-| Key shape | Contents | Cap
+| Data | Where | At-rest protection
 
-| `amber_nip17_cache_v1`
-| `Record<wrapId, { wrapId, partnerPubkey, fromMe, createdAt, text, wireKind }>` — the plaintext of every NIP-17 gift-wrap (kind 1059) the Amber-signer path has decrypted from a followed sender.
-| 5000 entries (≈1–2 MB JSON blob worst-case)
+| 1:1 DM plaintext (NIP-17 rumors + legacy NIP-04), incl. delivery ticks, rumor ids and optimistic unsent rows
+| `dm_messages` table in `lightningpiggy.db` (op-sqlite + SQLCipher)
+| **Whole-file SQLCipher encryption**; 256-bit key held only in the OS keystore (`expo-secure-store`, `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`, excluded from backups). Every open asserts `PRAGMA cipher_version` and refuses a plaintext fallback.
 
-| `nsec_nip17_cache_v1`
-| Same shape as above, populated by the nsec-signer path. Both keys exist so that switching signer on one device doesn't leak plaintext between identities.
-| 5000 entries
+| Legacy plaintext DM caches (`amber_nip17_cache_v1*`, `nsec_nip17_cache_v1*` files; `nostr_dm_inbox_v1_*`, `nostr_dm_conv_v1_*` AsyncStorage blobs)
+| **Retired.** One-time migrations (#848 `dmStoreMigrationRunner`, #850 `dmBlobMigration`) import each cache into the encrypted DB, then delete it with verification (populate → delete → verify → flag; the flag is never set while plaintext survives). Pre-#288 unsuffixed remnants are deleted too.
+| n/a after migration — nothing writes these keys any more
 
-| `nostr_dm_inbox_v1_<userPubkey>`
-| Per-user inbox rollup of `DmInboxEntry` (`{ id, partnerPubkey, fromMe, createdAt, text, wireKind }`) — used to paint Messages from cache on cold start before the relay/decrypt round-trip resolves.
-| 1000 entries (~400 KB)
+| Group-chat plaintext (`group_messages_<groupId>`, `nostr_group_activity_<pubkey>`)
+| AsyncStorage (unencrypted)
+| **Known residual.** App sandbox + OS file-based encryption only. Wiped on logout/account-wipe (#944); moving it into the encrypted store is the tracked follow-up.
 
-| `nostr_dm_conv_v1_<userPubkey>_<peerPubkey>`
-| Per-conversation message log; one key per peer the user has opened a thread with.
-| 500 messages per peer (~150 KB)
-
-| `group_messages_<groupId>`
-| Per-group thread log (`GroupMessage[]` — `{ id, senderPubkey, text, createdAt }`).
-| 500 messages per group
-
-| `nostr_group_activity_<userPubkey>`
-| Per-user rollup of `GroupActivity` — most recently `lastText` (decrypted preview shown on the Messages tab list).
-| Bounded by group count
+| Last-seen cursors (`*_last_seen_*`)
+| AsyncStorage
+| Bare unix timestamps — no content.
 |===
 
-Aggregate worst-case footprint for a power user with a saturated cache: a few megabytes of decrypted DM and group-message plaintext, persisted indefinitely under the app's private data directory.
+==== Threat model: seized device (border control)
 
-==== Threat model
+What the design protects:
 
-In scope (what the current design protects against):
+* **Forensic imaging of the flash (device off or locked).** The DM store is SQLCipher ciphertext — content *and* metadata. The DB key is wrapped by the hardware keystore and is not present in any file an imaging tool can lift; it is also excluded from cloud/device-migration backups, so a backup-restore of the app data yields an unopenable ciphertext file (the app detects this and re-syncs from relays rather than shipping a key in the backup).
+* **Casual physical access / other apps.** Unchanged from before: app sandbox, no export UI.
+* **Cross-account leak on a shared install.** Logout wipes the signed-out owner's DB rows, every legacy cache key (suffixed *and* unsuffixed), the group-chat blobs, and — on last-identity logout — deletes the DB file *and* its keystore key (`wipeLocalDmStore`). A lone key or a lone ciphertext file is never left behind.
 
-* **Casual physical access.** Picking up an unlocked phone and tapping around the app does not expose stored plaintext beyond what's already on screen — the data lives in private app storage and isn't surfaced through any export UI.
-* **Other apps on the same device.** Android sandbox + iOS app-private container prevents arbitrary apps from reading another app's `databases/` or `Application Support/` directories.
-* **Cross-account leak on the same install.** Logout (`NostrContext.logout`) explicitly multi-removes every cache listed above, so signing in as another identity cannot read the previous identity's history. The single-blob NIP-17 caches, the per-user-keyed inbox/conv/activity caches, and every `group_messages_<groupId>` blob (collected via an `AsyncStorage.getAllKeys()` prefix scan) are all enumerated and cleared.
+What it cannot protect against (out of scope at the app layer):
 
-Out of scope (what the current design does **not** protect against):
+* **Compelled or observed device unlock.** After first unlock the keystore will serve the DB key to the app; an adversary who can compel the passcode (or seize the phone unlocked and keep it powered) operates as the user. Raising this bar needs an *app-level* lock that gates the DB-key read behind a separate credential/biometric, plus optionally a panic-wipe — tracked as follow-ups, deliberately not bundled into the storage migration.
+* **Rooted device with the app running.** Decrypted rows transit RAM while rendered.
+* **Group-chat residual.** Until group messages get the same treatment, `group_messages_*` is readable from an unlocked seized device.
+* **Relay-side copies.** At-rest encryption protects the device only; NIP-17 wraps remain on relays and are re-fetchable by anyone holding the nsec.
 
-* **Rooted / jailbroken device.** Any process running with root can read `/data/data/app.lightningpiggy/databases/RKStorage` (Android) or the equivalent iOS sandbox path. All stored DM plaintext is exposed.
-* **Forensic extraction.** Tools like Cellebrite, Magnet AXIOM, or `adb backup` against a debug-buildable device can pull AsyncStorage SQLite files even from a powered-off phone (depending on lock state and OS version). Plaintext is recoverable.
-* **Malicious OEM firmware / supply-chain compromise.** A compromised platform that bypasses sandbox enforcement reads plaintext.
-* **Stolen device with known passcode / no passcode.** File-system encryption keys derive from device credentials; an attacker with the passcode bypasses encryption-at-rest of the app sandbox.
-* **Lost device, no logout.** The cache lives on disk for the lifetime of the install. Most users never log out, so the cache accumulates indefinitely. Remote-wipe (e.g. Find My Device) is the only mitigation today.
+==== Rules for new code
 
-==== Mitigation options considered
-
-The four mitigations below were evaluated against the constraint that `expo-secure-store` (Keychain on iOS, EncryptedSharedPreferences backed by Android Keystore) is the natural target for hardware-backed encryption.
-
-[cols="1,3,2", options="header"]
-|===
-| Option | Approach | Verdict
-
-| 1. Document + accept
-| Keep AsyncStorage. Document threat model (this section). Rely on logout to clear caches; encourage users to set a strong device passcode.
-| **Recommended for now.** Honest framing. Zero migration risk.
-
-| 2. Move whole cache to SecureStore
-| Replace `AsyncStorage.{get,set}Item` with `SecureStore.{getItemAsync,setItemAsync}` for all six key shapes above.
-| **Not feasible as a single blob.** iOS Keychain items are intended for small secrets (Apple's guidance: keep entries small; performance and reliability suffer beyond a few KB). The 1–2 MB NIP-17 cache plus the 400 KB inbox blob would not write reliably across all iOS versions. Per-entry sharding into 5000+ Keychain items has its own performance and OS-limit concerns.
-
-| 3. Split storage: index in AsyncStorage, plaintext in SecureStore
-| Keep `wrapId → partnerPubkey` mapping in AsyncStorage (cheap to enumerate during inbox refresh). Store only the `text` field per wrap in SecureStore, keyed by `nip17_text_<wrapId>`.
-| **Possible but expensive.** Adds one SecureStore round-trip per cache probe during the refresh-inbox hot path (5000 reads on a saturated cache). Migration helper would have to copy and verify per-entry, then delete the AsyncStorage source. Per-entry SecureStore items are well within Keychain limits but the IO amplification is significant.
-
-| 4. Encrypt-at-rest with key in SecureStore
-| Generate a per-install AES-256 key, store the key in SecureStore, AES-GCM-encrypt every cache blob before `AsyncStorage.setItem`. Decrypt on read.
-| **Best long-term option.** Single SecureStore item (the key, ~32 bytes — well within all platform limits). Cache stays in AsyncStorage so existing IO patterns and size are unchanged. Hardware-backed key isolation provides similar protection to option 2 against forensic extraction. Cost: ~5–20 ms per cache load/save for crypto + a one-shot migration helper that decrypts the legacy plaintext blobs and re-writes them encrypted. Nsec-only signer can derive the key from `nsec`; Amber signer needs a randomly-generated key (Amber doesn't expose the secret key).
-|===
-
-==== Recommendation
-
-Adopt **option 1 (document + accept)** as the immediate response. The current design's protection — app sandbox + logout-clears-everything — is consistent with how most messaging apps on Android/iOS handle DM history at rest, and matches the threat model the user base experiences (single-user device with a passcode, app isn't installed on rooted dev hardware). Migrating to SecureStore speculatively pays a real performance and complexity cost for a threat model the typical user is not in.
-
-File **option 4 (encrypt-at-rest with SecureStore-held key)** as a follow-up issue and pull the trigger on it when any of the following change:
-
-* The user base expands into a regulated or enterprise context.
-* A concrete report surfaces of a Lightning Piggy install on a rooted / forensically-imaged device.
-* Threat-model survey data shows users routinely sharing devices.
-
-Logout-as-mitigation should also be made more discoverable. Consider a follow-up to surface a "Clear DM cache" action in the Messages tab settings that runs the same `multiRemove` logic the logout path uses, but without signing the user out — a low-cost lever for a paranoid user that doesn't require migration.
+* Decrypted DM/group content, or anything derived from it (previews, search indexes), goes in the encrypted DB — **never** AsyncStorage or a plain file.
+* Keys/credentials go in `expo-secure-store`; bulk data never does (Keychain items must stay small).
+* Any migration off a plaintext store must follow the `dmStoreMigration` ordering: populate the encrypted copy, delete the plaintext, **verify** it is gone, only then set the migrated flag.
+* Every wipe path (logout, account removal) must cover new keys — add them to `wipeAccountCaches` / `wipeDmStoresForAccount` in the same PR that introduces them.

--- a/src/contexts/accountCacheWipe.ts
+++ b/src/contexts/accountCacheWipe.ts
@@ -32,6 +32,7 @@ import {
 } from './nostrDmCache';
 import { wipeDmStoresForAccount } from './dmAccountWipe';
 import { dmStoreMigratedKey } from './dmStoreMigrationRunner';
+import { dmBlobMigratedKey } from './dmBlobMigration';
 import {
   CONTACTS_CACHE_KEY_BASE,
   PROFILES_CACHE_KEY_BASE,
@@ -83,9 +84,16 @@ export async function wipeAccountCaches(loggedOutPubkey: string | null): Promise
     perAccountKey(RELAY_LIST_TIMESTAMP_KEY_BASE, loggedOutPubkey),
     perAccountKey(AMBER_NIP17_CACHE_KEY_BASE, loggedOutPubkey),
     perAccountKey(NSEC_NIP17_CACHE_KEY_BASE, loggedOutPubkey),
-    // DM-store migration flag (#848) — a future re-login re-runs the
-    // (then no-op) migration check instead of trusting a stale flag.
+    // DM-store migration flags (#848 wrap cache, #850 blobs) — a future
+    // re-login re-runs the (then no-op) migration checks instead of
+    // trusting a stale flag.
     dmStoreMigratedKey(loggedOutPubkey),
+    dmBlobMigratedKey(loggedOutPubkey),
+    // Pre-#288 UNSUFFIXED wrap-cache rows (N9, #850) — plaintext predating
+    // per-account keys. Not attributable to an owner, so any account's
+    // wipe removes them (the content is re-fetchable from relays).
+    AMBER_NIP17_CACHE_KEY_BASE,
+    NSEC_NIP17_CACHE_KEY_BASE,
     // Pre-existing per-pubkey caches (already namespaced before #288)
     inboxCacheKey(loggedOutPubkey),
     inboxLastSeenKey(loggedOutPubkey),

--- a/src/contexts/conversationReadThrough.test.ts
+++ b/src/contexts/conversationReadThrough.test.ts
@@ -26,17 +26,23 @@ describe('mapStoredRowsToMessages', () => {
     expect(out).toEqual([{ id: 'x', fromMe: false, text: 'hi', createdAt: 7, wireKind: 14 }]);
   });
 
+  it('carries the delivery tick + rumorId columns (#850)', () => {
+    const status = { delivered: true, relayResults: {} };
+    const out = mapStoredRowsToMessages([
+      row({ eventId: 's1', fromMe: true, deliveryStatus: status, rumorId: 'rum1' }),
+    ]);
+    expect(out[0].deliveryStatus).toEqual(status);
+    expect(out[0].rumorId).toBe('rum1');
+  });
+
   it('returns [] for no rows', () => {
     expect(mapStoredRowsToMessages([])).toEqual([]);
   });
 });
 
-describe('loadInitialConversation (read-through #868)', () => {
-  it('returns the ingested store message even when the per-conversation cache is empty', async () => {
-    // This is the bug: the inbox already has the message in the store, but the
-    // conversation cache blob is empty, so the thread used to paint nothing.
+describe('loadInitialConversation (read-through #868, store-only #850)', () => {
+  it('returns the ingested store message — the store is the single at-rest source', async () => {
     const deps: InitialConversationDeps = {
-      getCachedConversation: async () => [],
       getStoredRows: async () => [row({ eventId: 'ingested', content: 'the preview message' })],
     };
     const out = await loadInitialConversation(PEER, deps);
@@ -50,7 +56,6 @@ describe('loadInitialConversation (read-through #868)', () => {
     // round-trip this test would hang and time out.
     const neverResolves = new Promise<ConversationMessage[]>(() => {});
     const deps: InitialConversationDeps = {
-      getCachedConversation: async () => [],
       getStoredRows: async () => [row({ eventId: 'fromStore' })],
     };
     const out = await Promise.race([
@@ -61,43 +66,49 @@ describe('loadInitialConversation (read-through #868)', () => {
     expect((out as ConversationMessage[])[0].id).toBe('fromStore');
   });
 
-  it('unions cache (optimistic local- row) with the store, deduping the echo', async () => {
-    // Cache carries an optimistic local- send; the store carries the relay echo
-    // of the same text. mergeConversationMessages collapses them to one bubble.
+  it('collapses a raced local- row + its echo to one bubble, inheriting the tick', async () => {
+    // The store-level retire in upsertDmMessages usually removes the local-
+    // row when the echo lands, but the optimistic append and the live-sub
+    // echo can race — a read may still see both. The read-side dedup keeps
+    // one bubble and carries the local- row's tick onto the echo.
+    const status = { delivered: true, relayResults: {} };
     const deps: InitialConversationDeps = {
-      getCachedConversation: async () => [
-        { id: 'local-1', fromMe: true, text: 'gm', createdAt: 200 },
-      ],
       getStoredRows: async () => [
+        row({
+          eventId: 'local-1',
+          content: 'gm',
+          fromMe: true,
+          createdAt: 200,
+          deliveryStatus: status,
+          rumorId: 'rum1',
+        }),
         row({ eventId: 'echo-1', content: 'gm', fromMe: true, createdAt: 201 }),
       ],
     };
     const out = await loadInitialConversation(PEER, deps);
     expect(out).toHaveLength(1);
     expect(out[0].id).toBe('echo-1');
+    expect(out[0].deliveryStatus).toEqual(status);
+    expect(out[0].rumorId).toBe('rum1');
   });
 
-  it('degrades to the store when the cache read throws', async () => {
+  it('keeps a pending local- row that has no echo yet', async () => {
     const deps: InitialConversationDeps = {
-      getCachedConversation: async () => {
-        throw new Error('cache unavailable');
-      },
-      getStoredRows: async () => [row({ eventId: 'still-here' })],
+      getStoredRows: async () => [
+        row({ eventId: 'local-pending', content: 'sending…', fromMe: true, createdAt: 300 }),
+      ],
     };
     const out = await loadInitialConversation(PEER, deps);
-    expect(out[0].id).toBe('still-here');
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('local-pending');
   });
 
-  it('degrades to the cache when the store read throws', async () => {
+  it('degrades to an empty paint when the store read throws', async () => {
     const deps: InitialConversationDeps = {
-      getCachedConversation: async () => [
-        { id: 'cache-only', fromMe: false, text: 'x', createdAt: 1 },
-      ],
       getStoredRows: async () => {
         throw new Error('db unavailable');
       },
     };
-    const out = await loadInitialConversation(PEER, deps);
-    expect(out[0].id).toBe('cache-only');
+    expect(await loadInitialConversation(PEER, deps)).toEqual([]);
   });
 });

--- a/src/contexts/conversationReadThrough.ts
+++ b/src/contexts/conversationReadThrough.ts
@@ -1,22 +1,19 @@
 import type { DmMessageRow } from '../services/dmDb';
-import { DM_CONV_CAP, mergeConversationMessages } from './nostrDmCache';
+import { DM_CONV_CAP, dedupeLocalEchoes } from './nostrDmCache';
 import type { ConversationMessage } from './nostrContextTypes';
 
-// Read-through for the conversation thread (#868). The Messages inbox preview
-// is fed from the encrypted `dm_messages` table (via getInboxLatest), but the
-// thread historically only painted from the per-conversation AsyncStorage cache
-// blob (convCacheKey). That blob is written by a thread open / send — NOT by an
-// inbox-wide refresh — so a message the inbox already ingested can be absent
-// from the blob, leaving the thread emptier than the preview until a second
-// relay-fetch+decrypt commits. This module reads the SAME rows the inbox holds
-// (getConversationMessages) and merges them with the cache so the thread paints
-// immediately and is never behind the preview. The relay fetch becomes a
-// background top-up, not a precondition for showing anything.
+// Read-through for the conversation thread (#868, single-sourced in #850).
+// The Messages inbox preview and the thread both read the SAME encrypted
+// `dm_messages` rows (getInboxLatest / getConversationMessages), so the
+// thread paints immediately and can never be behind the preview. The
+// per-conversation plaintext AsyncStorage blob this used to union in is
+// retired (#850): optimistic local- rows, delivery ticks (#856) and rumor
+// ids (#857) now live on the encrypted rows themselves, so one store read
+// carries everything. The relay fetch stays a background top-up, not a
+// precondition for showing anything.
 
 // Map encrypted-store rows (DmMessageRow) to the thread's ConversationMessage
-// shape. Pure. Used by the read-through here; nostrFetchConversation builds its
-// thread slice from decrypted relay events (a different input), so it keeps its
-// own projection rather than sharing this one.
+// shape, carrying the delivery tick + rumorId columns (#850). Pure.
 export function mapStoredRowsToMessages(rows: DmMessageRow[]): ConversationMessage[] {
   return rows.map((r) => ({
     id: r.eventId,
@@ -24,36 +21,28 @@ export function mapStoredRowsToMessages(rows: DmMessageRow[]): ConversationMessa
     text: r.content,
     createdAt: r.createdAt,
     wireKind: r.wireKind,
+    ...(r.deliveryStatus !== undefined ? { deliveryStatus: r.deliveryStatus } : {}),
+    ...(r.rumorId !== undefined ? { rumorId: r.rumorId } : {}),
   }));
 }
 
 export interface InitialConversationDeps {
-  /** Per-conversation AsyncStorage cache blob (optimistic local- rows +
-   * previously-merged thread). May lag the inbox for inbox-ingested messages. */
-  getCachedConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
-  /** The SAME encrypted-store rows the inbox preview is built from, peer-scoped.
-   * Guarantees the thread can't be emptier than the inbox for ingested DMs. */
+  /** This thread's slice of the encrypted store — the same rows the inbox
+   * preview is built from, peer-scoped. The only at-rest source (#850). */
   getStoredRows: (otherPubkey: string) => Promise<DmMessageRow[]>;
 }
 
 /**
- * The instant-paint set for a thread open: the union of the per-conversation
- * cache (carries optimistic local- rows + ticks) and the ingested store rows
- * (carries everything the inbox already decrypted). Merged via
- * `mergeConversationMessages` so local- echo dedup + delivery/rumorId carry-over
- * behave exactly as the relay-fetch merge does. Reads run in parallel; a failure
- * of either source degrades to the other rather than throwing.
+ * The instant-paint set for a thread open: the encrypted store's slice for
+ * this peer, oldest-first, with any raced local-echo pair collapsed to one
+ * bubble (`dedupeLocalEchoes` — the store-level retire in upsertDmMessages
+ * usually already did this; the read-side pass covers the append/echo race).
+ * A store failure degrades to an empty paint rather than throwing.
  */
 export async function loadInitialConversation(
   otherPubkey: string,
   deps: InitialConversationDeps,
 ): Promise<ConversationMessage[]> {
-  const [cached, rows] = await Promise.all([
-    deps.getCachedConversation(otherPubkey).catch(() => [] as ConversationMessage[]),
-    deps.getStoredRows(otherPubkey).catch(() => [] as DmMessageRow[]),
-  ]);
-  const stored = mapStoredRowsToMessages(rows);
-  // Cache first so its optimistic local- rows and persisted ticks are the base;
-  // stored rows merge on top (real-id echoes dedup the local- rows).
-  return mergeConversationMessages(cached, stored, DM_CONV_CAP);
+  const rows = await deps.getStoredRows(otherPubkey).catch(() => [] as DmMessageRow[]);
+  return dedupeLocalEchoes(mapStoredRowsToMessages(rows), DM_CONV_CAP);
 }

--- a/src/contexts/dmAccountWipe.ts
+++ b/src/contexts/dmAccountWipe.ts
@@ -34,11 +34,19 @@ export async function wipeDmStoresForAccount(pubkey: string): Promise<void> {
     AMBER_NIP17_SKIP_KEY_BASE,
     NSEC_NIP17_SKIP_KEY_BASE,
   ]) {
-    try {
-      const f = new File(Paths.document, wrapCacheFileName(perAccountKey(base, pubkey)));
-      if (f.exists) f.delete();
-    } catch {
-      // best-effort — non-fatal
+    for (const key of [
+      perAccountKey(base, pubkey),
+      // Pre-#288 UNSUFFIXED remnant (N9, #850) — a wrap-cache/skip file
+      // written before per-account keys. Not attributable to an owner, so
+      // any account's wipe removes it (content is re-fetchable from relays).
+      base,
+    ]) {
+      try {
+        const f = new File(Paths.document, wrapCacheFileName(key));
+        if (f.exists) f.delete();
+      } catch {
+        // best-effort — non-fatal
+      }
     }
   }
   // Await any in-flight migration first — wiping under it would let a late

--- a/src/contexts/dmBlobMigration.test.ts
+++ b/src/contexts/dmBlobMigration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the #850 one-shot blob migration: the LAST plaintext DM
+ * blobs (inbox previews + per-conversation threads) → fill-only rows in the
+ * encrypted store → verified delete → flag. Mirrors the #848 wrap-cache
+ * migration's safety story (strict populate → delete → verify ordering is
+ * covered generically by dmStoreMigration.test; these cover the wiring).
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const fileStore: Record<string, string> = {};
+
+jest.mock('expo-file-system', () => {
+  const MockFile = class {
+    private path: string;
+    constructor(_dir: string, name: string) {
+      this.path = name;
+    }
+    get exists(): boolean {
+      return Object.prototype.hasOwnProperty.call(fileStore, this.path);
+    }
+    async text(): Promise<string> {
+      return fileStore[this.path] ?? '';
+    }
+    delete(): void {
+      delete fileStore[this.path];
+    }
+    create(): void {
+      fileStore[this.path] = '';
+    }
+    write(content: string): void {
+      fileStore[this.path] = content;
+    }
+  };
+  return { File: MockFile, Paths: { document: '/mock-documents' } };
+});
+
+const mockImport = jest.fn();
+jest.mock('../services/dmDb', () => ({
+  importDmMessages: (...args: unknown[]) => mockImport(...args),
+  LOCAL_DM_ID_PREFIX: 'local-',
+  LOCAL_DM_ECHO_WINDOW_SECS: 30,
+}));
+
+import {
+  runDmBlobMigration,
+  dmBlobMigratedKey,
+  inboxEntryToRow,
+  convEntryToRow,
+} from './dmBlobMigration';
+import type { DmMessageRow } from '../services/dmDb';
+
+const OWNER = 'f'.repeat(64);
+const ALICE = 'a'.repeat(64);
+const BOB = 'b'.repeat(64);
+const INBOX_KEY = `nostr_dm_inbox_v1_${OWNER}`;
+const convKey = (peer: string) => `nostr_dm_conv_v1_${OWNER}_${peer}`;
+
+const importedRows = (): DmMessageRow[] =>
+  mockImport.mock.calls.flatMap((c) => c[0] as DmMessageRow[]);
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  mockImport.mockResolvedValue(undefined);
+  for (const k of Object.keys(fileStore)) delete fileStore[k];
+  await AsyncStorage.clear();
+});
+
+describe('runDmBlobMigration', () => {
+  it('imports inbox + conversation blobs (with ticks / rumor ids / local- rows), deletes them, sets the flag', async () => {
+    const status = { delivered: true, relayResults: {} };
+    await AsyncStorage.setItem(
+      INBOX_KEY,
+      JSON.stringify([
+        {
+          id: 'k4a',
+          partnerPubkey: ALICE,
+          fromMe: false,
+          createdAt: 10,
+          text: 'old kind-4',
+          wireKind: 4,
+        },
+      ]),
+    );
+    await AsyncStorage.setItem(
+      convKey(BOB),
+      JSON.stringify([
+        { id: 'w1', fromMe: false, text: 'hello', createdAt: 20, wireKind: 14 },
+        {
+          id: 'local-9',
+          fromMe: true,
+          text: 'pending send',
+          createdAt: 21,
+          deliveryStatus: status,
+          rumorId: 'rum9',
+        },
+      ]),
+    );
+    expect(await runDmBlobMigration(OWNER)).toBe(true);
+
+    const rows = importedRows();
+    expect(rows.map((r) => r.eventId).sort()).toEqual(['k4a', 'local-9', 'w1']);
+    const k4 = rows.find((r) => r.eventId === 'k4a')!;
+    expect(k4).toMatchObject({ owner: OWNER, conversation: ALICE, sender: ALICE, wireKind: 4 });
+    const local = rows.find((r) => r.eventId === 'local-9')!;
+    expect(local).toMatchObject({
+      conversation: BOB,
+      fromMe: true,
+      sender: OWNER,
+      deliveryStatus: status,
+      rumorId: 'rum9',
+    });
+
+    expect(await AsyncStorage.getItem(INBOX_KEY)).toBeNull();
+    expect(await AsyncStorage.getItem(convKey(BOB))).toBeNull();
+    expect(await AsyncStorage.getItem(dmBlobMigratedKey(OWNER))).toBe('1');
+  });
+
+  it('never deletes the blobs (or sets the flag) when the DB import fails', async () => {
+    await AsyncStorage.setItem(
+      convKey(ALICE),
+      JSON.stringify([{ id: 'w1', fromMe: false, text: 'hello', createdAt: 20 }]),
+    );
+    mockImport.mockRejectedValueOnce(new Error('db locked'));
+    await expect(runDmBlobMigration(OWNER)).rejects.toThrow('db locked');
+    expect(await AsyncStorage.getItem(convKey(ALICE))).not.toBeNull();
+    expect(await AsyncStorage.getItem(dmBlobMigratedKey(OWNER))).toBeNull();
+  });
+
+  it('short-circuits once the flag is set', async () => {
+    await AsyncStorage.setItem(dmBlobMigratedKey(OWNER), '1');
+    await AsyncStorage.setItem(INBOX_KEY, JSON.stringify([{ id: 'x' }]));
+    expect(await runDmBlobMigration(OWNER)).toBe(true);
+    expect(mockImport).not.toHaveBeenCalled();
+    // already-migrated: the delete step doesn't run either
+    expect(await AsyncStorage.getItem(INBOX_KEY)).not.toBeNull();
+  });
+
+  it('deletes a conv blob whose peer segment is malformed WITHOUT importing it', async () => {
+    const badKey = `nostr_dm_conv_v1_${OWNER}_not-a-pubkey`;
+    await AsyncStorage.setItem(badKey, JSON.stringify([{ id: 'w1', text: 'x', createdAt: 1 }]));
+    expect(await runDmBlobMigration(OWNER)).toBe(true);
+    expect(importedRows()).toHaveLength(0);
+    expect(await AsyncStorage.getItem(badKey)).toBeNull();
+  });
+
+  it("does not touch another account's blobs", async () => {
+    const otherInbox = `nostr_dm_inbox_v1_${BOB}`;
+    await AsyncStorage.setItem(otherInbox, JSON.stringify([]));
+    expect(await runDmBlobMigration(OWNER)).toBe(true);
+    expect(await AsyncStorage.getItem(otherInbox)).not.toBeNull();
+  });
+
+  it('N9: deletes pre-#288 unsuffixed wrap-cache rows AND files, without importing them', async () => {
+    await AsyncStorage.setItem('nsec_nip17_cache_v1', JSON.stringify({ w: { text: 'plain' } }));
+    fileStore['amber_nip17_cache_v1.json'] = '{}';
+    expect(await runDmBlobMigration(OWNER)).toBe(true);
+    expect(importedRows()).toHaveLength(0);
+    expect(await AsyncStorage.getItem('nsec_nip17_cache_v1')).toBeNull();
+    expect(fileStore['amber_nip17_cache_v1.json']).toBeUndefined();
+    expect(await AsyncStorage.getItem(dmBlobMigratedKey(OWNER))).toBe('1');
+  });
+
+  it('completes (flag set, no import) when there is nothing to migrate', async () => {
+    expect(await runDmBlobMigration(OWNER)).toBe(true);
+    expect(mockImport).not.toHaveBeenCalled();
+    expect(await AsyncStorage.getItem(dmBlobMigratedKey(OWNER))).toBe('1');
+  });
+});
+
+describe('inboxEntryToRow', () => {
+  const base = {
+    id: 'i1',
+    partnerPubkey: ALICE,
+    fromMe: false,
+    createdAt: 5,
+    text: 'p',
+    wireKind: 14,
+  };
+
+  it('maps a valid entry, carrying rumorId', () => {
+    const row = inboxEntryToRow(OWNER, { ...base, rumorId: 'r1' });
+    expect(row).toMatchObject({ eventId: 'i1', conversation: ALICE, rumorId: 'r1' });
+  });
+
+  it('skips order previews (kind 16/17) — the blob held the preview line, not the order JSON', () => {
+    expect(inboxEntryToRow(OWNER, { ...base, wireKind: 16 })).toBeNull();
+    expect(inboxEntryToRow(OWNER, { ...base, wireKind: 17 })).toBeNull();
+  });
+
+  it('rejects malformed entries', () => {
+    expect(inboxEntryToRow(OWNER, { ...base, partnerPubkey: 'nope' })).toBeNull();
+    expect(inboxEntryToRow(OWNER, { ...base, text: 7 as unknown as string })).toBeNull();
+    expect(inboxEntryToRow(OWNER, { ...base, id: '' })).toBeNull();
+  });
+});
+
+describe('convEntryToRow', () => {
+  it('maps a valid message, defaulting wireKind to 14', () => {
+    const row = convEntryToRow(OWNER, ALICE, { id: 'm1', fromMe: true, text: 't', createdAt: 3 });
+    expect(row).toMatchObject({ conversation: ALICE, sender: OWNER, wireKind: 14 });
+  });
+
+  it('rejects malformed messages', () => {
+    expect(
+      convEntryToRow(OWNER, ALICE, { id: 'm1', fromMe: true, text: 't', createdAt: NaN }),
+    ).toBeNull();
+    expect(
+      convEntryToRow(OWNER, ALICE, { id: '', fromMe: true, text: 't', createdAt: 3 }),
+    ).toBeNull();
+  });
+});

--- a/src/contexts/dmBlobMigration.ts
+++ b/src/contexts/dmBlobMigration.ts
@@ -1,0 +1,212 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { File, Paths } from 'expo-file-system';
+import { migrateDmStore } from '../services/dmStoreMigration';
+import { importDmMessages, type DmMessageRow } from '../services/dmDb';
+import type { DmInboxEntry } from '../utils/conversationSummaries';
+import type { ConversationMessage } from './nostrContextTypes';
+import {
+  AMBER_NIP17_CACHE_KEY_BASE,
+  NSEC_NIP17_CACHE_KEY_BASE,
+  DM_CONV_CACHE_PREFIX,
+  inboxCacheKey,
+  wrapCacheFileName,
+} from './nostrDmCache';
+
+// One-time migration of the LAST plaintext DM blobs into the encrypted store
+// (#850, second half of the at-rest story #848 started). Two AsyncStorage
+// namespaces still held decrypted plaintext after the wrap-cache migration:
+//
+//   nostr_dm_inbox_v1_<owner>          — inbox previews (up to 1000 entries)
+//   nostr_dm_conv_v1_<owner>_<peer>    — full threads (up to 500 msgs / peer)
+//
+// Their content is imported as `dm_messages` rows (fill-only: an existing
+// encrypted row always wins; the import only supplies rows the store lacks —
+// e.g. pre-#848 kind-4 threads — plus the delivery ticks (#856), rumor ids
+// (#857) and optimistic local- rows the blobs were the sole carrier of).
+// Then the blobs are deleted with verification, same strict ordering as #848
+// (dmStoreMigration: populate → delete → verify → flag).
+//
+// N9 (#850): the migration's delete step also removes any pre-#288
+// UNSUFFIXED wrap-cache remnants (`nsec_nip17_cache_v1` /
+// `amber_nip17_cache_v1` without the `_<pubkey>` suffix, row or file). The
+// #288 per-account migration renames them on its first run, but a rename
+// that never completed would leave plaintext the suffixed-key wipes miss.
+// They are deleted WITHOUT import: an unsuffixed cache can't be attributed
+// to an owner on a multi-account device, and importing another identity's
+// plaintext into this owner's rows would be worse than re-fetching from
+// relays (the content is always re-fetchable + decrypt-once).
+
+const BLOB_MIGRATED_FLAG_PREFIX = 'dm_blob_migrated_v1_';
+export const dmBlobMigratedKey = (pubkey: string): string => BLOB_MIGRATED_FLAG_PREFIX + pubkey;
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+const UNSUFFIXED_WRAP_BASES = [NSEC_NIP17_CACHE_KEY_BASE, AMBER_NIP17_CACHE_KEY_BASE] as const;
+
+function safeParseArray<T>(raw: string | null): T[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** A legacy inbox-preview entry → fill-only store row, or null if malformed.
+ * Order previews (kind 16/17) are skipped: the blob held the *preview line*,
+ * not the order JSON the store schema expects — the store either already has
+ * the real row (live-sub upsert) or the order re-fetches from relays. */
+export function inboxEntryToRow(owner: string, e: DmInboxEntry): DmMessageRow | null {
+  if (!e || typeof e !== 'object') return null;
+  if (typeof e.id !== 'string' || e.id.length === 0) return null;
+  if (typeof e.partnerPubkey !== 'string' || !HEX_64.test(e.partnerPubkey)) return null;
+  if (typeof e.text !== 'string' || !Number.isFinite(e.createdAt)) return null;
+  const wireKind = typeof e.wireKind === 'number' ? e.wireKind : 14;
+  if (wireKind === 16 || wireKind === 17) return null;
+  return {
+    owner,
+    eventId: e.id,
+    conversation: e.partnerPubkey,
+    createdAt: e.createdAt,
+    sender: e.fromMe ? owner : e.partnerPubkey,
+    content: e.text,
+    fromMe: e.fromMe === true,
+    wireKind,
+    ...(typeof e.rumorId === 'string' && e.rumorId.length > 0 ? { rumorId: e.rumorId } : {}),
+  };
+}
+
+/** A legacy per-conversation blob entry → fill-only store row (carrying the
+ * delivery tick / rumorId / optimistic local- rows), or null if malformed. */
+export function convEntryToRow(
+  owner: string,
+  peer: string,
+  m: ConversationMessage,
+): DmMessageRow | null {
+  if (!m || typeof m !== 'object') return null;
+  if (typeof m.id !== 'string' || m.id.length === 0) return null;
+  if (typeof m.text !== 'string' || !Number.isFinite(m.createdAt)) return null;
+  return {
+    owner,
+    eventId: m.id,
+    conversation: peer,
+    createdAt: m.createdAt,
+    sender: m.fromMe ? owner : peer,
+    content: m.text,
+    fromMe: m.fromMe === true,
+    wireKind: typeof m.wireKind === 'number' ? m.wireKind : 14,
+    ...(m.deliveryStatus ? { deliveryStatus: m.deliveryStatus } : {}),
+    ...(typeof m.rumorId === 'string' && m.rumorId.length > 0 ? { rumorId: m.rumorId } : {}),
+  };
+}
+
+/** This owner's per-conversation blob keys, with the peer parsed off each. */
+async function listConvBlobKeys(pubkey: string): Promise<{ key: string; peer: string }[]> {
+  const prefix = DM_CONV_CACHE_PREFIX + pubkey + '_';
+  const allKeys = await AsyncStorage.getAllKeys();
+  const out: { key: string; peer: string }[] = [];
+  for (const key of allKeys) {
+    if (!key.startsWith(prefix)) continue;
+    const peer = key.slice(prefix.length);
+    if (HEX_64.test(peer)) out.push({ key, peer });
+    else out.push({ key, peer: '' }); // malformed peer — delete-only, no import
+  }
+  return out;
+}
+
+async function deleteUnsuffixedWrapCaches(): Promise<void> {
+  for (const base of UNSUFFIXED_WRAP_BASES) {
+    try {
+      const f = new File(Paths.document, wrapCacheFileName(base));
+      if (f.exists) f.delete();
+    } catch {
+      // verify step below decides whether this blocks the flag
+    }
+    await AsyncStorage.removeItem(base).catch(() => {});
+  }
+}
+
+async function unsuffixedWrapCachesGone(): Promise<boolean> {
+  for (const base of UNSUFFIXED_WRAP_BASES) {
+    try {
+      if (new File(Paths.document, wrapCacheFileName(base)).exists) return false;
+    } catch {
+      return false; // can't prove it's gone → treat as still present
+    }
+    if ((await AsyncStorage.getItem(base).catch(() => null)) != null) return false;
+  }
+  return true;
+}
+
+/**
+ * Run the one-time plaintext-blob → encrypted-store migration for `pubkey`.
+ * Same contract as the #848 wrap-cache migration: idempotent, interruption-
+ * safe (flag only after a verified delete), never throws content away before
+ * the DB import completed. Returns whether the migration is complete.
+ */
+export async function runDmBlobMigration(pubkey: string): Promise<boolean> {
+  const result = await migrateDmStore({
+    isMigrated: async () => (await AsyncStorage.getItem(dmBlobMigratedKey(pubkey))) === '1',
+    setMigrated: async () => {
+      await AsyncStorage.setItem(dmBlobMigratedKey(pubkey), '1');
+    },
+    populateEncryptedDb: async () => {
+      let imported = 0;
+      let dropped = 0;
+      // Inbox previews. An unreadable row (>2 MB CursorWindow cap) parses to
+      // [] — nothing to import, and the delete step removes it regardless.
+      const inboxRaw = await AsyncStorage.getItem(inboxCacheKey(pubkey)).catch(() => null);
+      const inboxRows: DmMessageRow[] = [];
+      for (const entry of safeParseArray<DmInboxEntry>(inboxRaw)) {
+        const row = inboxEntryToRow(pubkey, entry);
+        if (row) inboxRows.push(row);
+        else dropped++;
+      }
+      if (inboxRows.length > 0) await importDmMessages(inboxRows);
+      imported += inboxRows.length;
+      // Per-conversation threads — the richer source (full text + ticks +
+      // rumor ids + optimistic local- rows), imported after the inbox so its
+      // fill-only rows land on top of any preview-only gap fills.
+      for (const { key, peer } of await listConvBlobKeys(pubkey)) {
+        if (!peer) continue; // malformed key — delete-only
+        const raw = await AsyncStorage.getItem(key).catch(() => null);
+        const rows: DmMessageRow[] = [];
+        for (const entry of safeParseArray<ConversationMessage>(raw)) {
+          const row = convEntryToRow(pubkey, peer, entry);
+          if (row) rows.push(row);
+          else dropped++;
+        }
+        if (rows.length > 0) await importDmMessages(rows);
+        imported += rows.length;
+      }
+      console.log(
+        `[DmStore] blob migration: imported ${imported} inbox/conversation entries into the` +
+          ` encrypted DB (dropped ${dropped} malformed) for ${pubkey.slice(0, 8)}`,
+      );
+      return { completed: true };
+    },
+    deletePlaintextCaches: async () => {
+      const keys = [inboxCacheKey(pubkey), ...(await listConvBlobKeys(pubkey)).map((c) => c.key)];
+      // Individual removes (not multiRemove) so one failure doesn't abort the
+      // rest; the verify step catches anything that survived.
+      for (const key of keys) await AsyncStorage.removeItem(key).catch(() => {});
+      await deleteUnsuffixedWrapCaches(); // N9
+    },
+    verifyPlaintextGone: async () => {
+      if ((await AsyncStorage.getItem(inboxCacheKey(pubkey)).catch(() => 'unreadable')) != null) {
+        return false;
+      }
+      if ((await listConvBlobKeys(pubkey)).length > 0) return false;
+      return unsuffixedWrapCachesGone();
+    },
+    warn: (msg) => console.warn(`[DmStore] ${msg}`),
+  });
+  if (result.ok && result.status === 'migrated') {
+    console.log(
+      `[DmStore] blob migration complete for ${pubkey.slice(0, 8)}: plaintext inbox/conversation` +
+        ` blobs deleted (verified)`,
+    );
+  }
+  return result.ok;
+}

--- a/src/contexts/dmStoreMigrationRunner.test.ts
+++ b/src/contexts/dmStoreMigrationRunner.test.ts
@@ -37,8 +37,12 @@ jest.mock('expo-file-system', () => {
 });
 
 const mockUpsert = jest.fn();
+const mockImport = jest.fn();
 jest.mock('../services/dmDb', () => ({
   upsertDmMessages: (...args: unknown[]) => mockUpsert(...args),
+  importDmMessages: (...args: unknown[]) => mockImport(...args),
+  LOCAL_DM_ID_PREFIX: 'local-',
+  LOCAL_DM_ECHO_WINDOW_SECS: 30,
 }));
 
 import {
@@ -46,7 +50,9 @@ import {
   forgetDmStoreMigration,
   dmStoreMigratedKey,
   wrapCacheEntryToRow,
+  MIGRATION_RETRY_BACKOFF_MS,
 } from './dmStoreMigrationRunner';
+import { dmBlobMigratedKey } from './dmBlobMigration';
 import type { Nip17CacheEntry } from './nostrDmCache';
 import type { DmMessageRow } from '../services/dmDb';
 
@@ -68,6 +74,7 @@ const entry = (id: string, over: Partial<Nip17CacheEntry> = {}): Nip17CacheEntry
 beforeEach(async () => {
   jest.clearAllMocks();
   mockUpsert.mockResolvedValue(undefined);
+  mockImport.mockResolvedValue(undefined);
   for (const k of Object.keys(fileStore)) delete fileStore[k];
   await AsyncStorage.clear();
   forgetDmStoreMigration(OWNER);
@@ -117,17 +124,60 @@ describe('dmStoreMigrationRunner', () => {
     expect(mockUpsert).toHaveBeenCalledTimes(1); // already-migrated path
   });
 
-  it('leaves the plaintext + flag intact when the DB write fails, then retries', async () => {
+  it('leaves the plaintext + flag intact when the DB write fails, then retries after the backoff (N7)', async () => {
     fileStore[NSEC_FILE] = JSON.stringify({ w1: entry('w1') });
     mockUpsert.mockRejectedValueOnce(new Error('db locked'));
     await ensureDmStoreMigrated(OWNER);
     expect(fileStore[NSEC_FILE]).toBeDefined(); // never delete before the DB has the rows
     expect(await AsyncStorage.getItem(dmStoreMigratedKey(OWNER))).toBeNull();
 
-    await ensureDmStoreMigrated(OWNER); // retry succeeds
+    // Inside the backoff window a re-trigger is skipped (N7) — a wedged
+    // storage subsystem must not re-run the populate on every DM entry point.
+    await ensureDmStoreMigrated(OWNER);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+
+    // Past the window the retry runs and succeeds.
+    await ensureDmStoreMigrated(OWNER, () => Date.now() + MIGRATION_RETRY_BACKOFF_MS + 1);
     expect(mockUpsert).toHaveBeenCalledTimes(2);
     expect(fileStore[NSEC_FILE]).toBeUndefined();
     expect(await AsyncStorage.getItem(dmStoreMigratedKey(OWNER))).toBe('1');
+  });
+
+  it('also runs the #850 blob migration: imports + deletes the inbox/conv blobs, sets both flags', async () => {
+    const inboxKey = `nostr_dm_inbox_v1_${OWNER}`;
+    const convKey = `nostr_dm_conv_v1_${OWNER}_${ALICE}`;
+    await AsyncStorage.setItem(
+      inboxKey,
+      JSON.stringify([
+        {
+          id: 'i1',
+          partnerPubkey: ALICE,
+          fromMe: false,
+          createdAt: 5,
+          text: 'preview',
+          wireKind: 4,
+        },
+      ]),
+    );
+    await AsyncStorage.setItem(
+      convKey,
+      JSON.stringify([{ id: 'm1', fromMe: true, text: 'full', createdAt: 6, wireKind: 14 }]),
+    );
+    await ensureDmStoreMigrated(OWNER);
+    const imported = mockImport.mock.calls.flatMap((c) => c[0] as DmMessageRow[]);
+    expect(imported.map((r) => r.eventId).sort()).toEqual(['i1', 'm1']);
+    expect(await AsyncStorage.getItem(inboxKey)).toBeNull();
+    expect(await AsyncStorage.getItem(convKey)).toBeNull();
+    expect(await AsyncStorage.getItem(dmBlobMigratedKey(OWNER))).toBe('1');
+  });
+
+  it('N9: deletes pre-#288 unsuffixed wrap-cache remnants during the blob migration', async () => {
+    await AsyncStorage.setItem('nsec_nip17_cache_v1', '{}');
+    fileStore['amber_nip17_cache_v1.json'] = '{}';
+    await ensureDmStoreMigrated(OWNER);
+    expect(await AsyncStorage.getItem('nsec_nip17_cache_v1')).toBeNull();
+    expect(fileStore['amber_nip17_cache_v1.json']).toBeUndefined();
+    expect(await AsyncStorage.getItem(dmBlobMigratedKey(OWNER))).toBe('1');
   });
 
   describe('wrapCacheEntryToRow', () => {

--- a/src/contexts/dmStoreMigrationRunner.ts
+++ b/src/contexts/dmStoreMigrationRunner.ts
@@ -3,6 +3,7 @@ import { File, Paths } from 'expo-file-system';
 import { migrateDmStore } from '../services/dmStoreMigration';
 import { upsertDmMessages, type DmMessageRow } from '../services/dmDb';
 import { perAccountKey } from '../services/perAccountStorage';
+import { runDmBlobMigration } from './dmBlobMigration';
 import {
   AMBER_NIP17_CACHE_KEY_BASE,
   NSEC_NIP17_CACHE_KEY_BASE,
@@ -108,28 +109,52 @@ async function runMigration(pubkey: string): Promise<boolean> {
       `[DmStore] migration complete for ${pubkey.slice(0, 8)}: plaintext wrap cache deleted (verified)`,
     );
   }
-  return result.ok;
+  if (!result.ok) return false;
+  // Second phase (#850): retire the plaintext inbox/conversation blobs into
+  // the encrypted store. Own flag, same populate → delete → verify ordering.
+  // Sequenced AFTER the wrap-cache import so both plaintext sources are gone
+  // before any caller trusts "migrated".
+  return runDmBlobMigration(pubkey);
 }
 
 // Single-flight + success memo per account. A failed/incomplete run clears
 // its entry so the next DM entry point retries; a successful run stays
-// memoised for the session (the AsyncStorage flag covers later sessions).
+// memoised for the session (the AsyncStorage flags cover later sessions).
 const migrationRuns = new Map<string, Promise<void>>();
 
+// N7 (#850): session backoff for a persistently failing migration. Without
+// it, a broken delete/verify (e.g. a wedged storage subsystem) re-runs the
+// full populate on EVERY DM entry point — inbox refresh, thread open,
+// live-sub open — burning I/O in a hot loop. One retry per backoff window is
+// plenty; the AsyncStorage flags make an eventual success durable.
+export const MIGRATION_RETRY_BACKOFF_MS = 60_000;
+const migrationFailedAt = new Map<string, number>();
+
 /**
- * Ensure the one-time DM-store migration has run for `pubkey`. Never rejects
- * — a failure is logged and retried on the next call, so callers can fire it
+ * Ensure the one-time DM-store migrations (#848 wrap cache + #850 blobs)
+ * have run for `pubkey`. Never rejects — a failure is logged and retried on
+ * a later call (after MIGRATION_RETRY_BACKOFF_MS), so callers can fire it
  * inline on hot paths (inbox refresh / thread open / live-sub open).
  */
-export function ensureDmStoreMigrated(pubkey: string): Promise<void> {
+export function ensureDmStoreMigrated(pubkey: string, now: () => number = Date.now): Promise<void> {
   const existing = migrationRuns.get(pubkey);
   if (existing) return existing;
+  const failedAt = migrationFailedAt.get(pubkey);
+  if (failedAt !== undefined && now() - failedAt < MIGRATION_RETRY_BACKOFF_MS) {
+    return Promise.resolve(); // still inside the backoff window — skip (N7)
+  }
   const run = runMigration(pubkey)
     .then((ok) => {
-      if (!ok) migrationRuns.delete(pubkey);
+      if (!ok) {
+        migrationRuns.delete(pubkey);
+        migrationFailedAt.set(pubkey, now());
+      } else {
+        migrationFailedAt.delete(pubkey);
+      }
     })
     .catch((e) => {
       migrationRuns.delete(pubkey);
+      migrationFailedAt.set(pubkey, now());
       if (__DEV__) console.warn('[DmStore] migration failed (will retry):', e);
     });
   migrationRuns.set(pubkey, run);
@@ -140,6 +165,7 @@ export function ensureDmStoreMigrated(pubkey: string): Promise<void> {
  * the per-account flag instead of trusting a stale "done" from this session. */
 export function forgetDmStoreMigration(pubkey: string): void {
   migrationRuns.delete(pubkey);
+  migrationFailedAt.delete(pubkey);
 }
 
 /** The in-flight migration for `pubkey`, if any — so a logout wipe can await

--- a/src/contexts/mergeConversationDelivery.test.ts
+++ b/src/contexts/mergeConversationDelivery.test.ts
@@ -1,4 +1,9 @@
-import { mergeConversationMessages, reconcileDeliveryStatus, DM_CONV_CAP } from './nostrDmCache';
+import {
+  mergeConversationMessages,
+  reconcileDeliveryStatus,
+  dedupeLocalEchoes,
+  DM_CONV_CAP,
+} from './nostrDmCache';
 import type { ConversationMessage } from './nostrContextTypes';
 import type { DeliveryStatus } from '../utils/dmDeliveryStatus';
 
@@ -104,6 +109,28 @@ describe('reconcileDeliveryStatus — in-memory carry-over (#856)', () => {
     const next: ConversationMessage[] = [{ id: 'r', fromMe: false, text: 'hi', createdAt: 5 }];
     const out = reconcileDeliveryStatus(prev, next);
     expect(out[0].deliveryStatus).toBeUndefined();
+  });
+});
+
+describe('dedupeLocalEchoes — single-list read-side dedup (#850)', () => {
+  it('collapses a local- row and its echo from ONE store read into one bubble with the tick', () => {
+    // Both rows can coexist in the encrypted store briefly (append/echo race);
+    // a single read must still render one bubble carrying the local- tick.
+    const out = dedupeLocalEchoes([local('gm', 1000), echo('gm', 1001)]);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('real-1001');
+    expect(out[0].deliveryStatus).toEqual(delivery);
+  });
+
+  it('keeps a pending local- row that has no echo', () => {
+    const out = dedupeLocalEchoes([local('unsent', 1000)]);
+    expect(out.map((m) => m.id)).toEqual(['local-1000']);
+  });
+
+  it('sorts ascending and leaves unrelated rows alone', () => {
+    const recv: ConversationMessage = { id: 'r1', fromMe: false, text: 'hi', createdAt: 999 };
+    const out = dedupeLocalEchoes([echo('later', 1500), recv]);
+    expect(out.map((m) => m.id)).toEqual(['r1', 'real-1500']);
   });
 });
 

--- a/src/contexts/nostrDmCache.ts
+++ b/src/contexts/nostrDmCache.ts
@@ -2,7 +2,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { File, Paths } from 'expo-file-system';
 import { utf8ByteSize } from '../utils/byteSize';
 import type { DmInboxEntry } from '../utils/conversationSummaries';
+import { LOCAL_DM_ID_PREFIX, LOCAL_DM_ECHO_WINDOW_SECS } from '../services/dmDb';
 import type { ConversationMessage } from './nostrContextTypes';
+
+// Re-export the echo-window constant from its single source of truth (dmDb —
+// the store-level echo retire and this in-memory merge must agree, #850).
+export { LOCAL_DM_ECHO_WINDOW_SECS };
 
 // Legacy keys for the plaintext NIP-17 wrap caches (#176/#687/#689 — RETIRED
 // in #848). Decrypted rumors now persist as rows in the encrypted SQLCipher
@@ -117,15 +122,19 @@ export const DM_INBOX_REFRESH_TTL_MS = 30_000;
 export const COLD_INITIAL_WRAP_LIMIT = 200;
 
 /**
- * Persisted inbox + per-peer message caches (PR B).
+ * LEGACY plaintext inbox + per-peer conversation blobs — RETIRED in #850.
  *
- * Key shape: `<prefix>_<userPubkeyHex>` — per-user so multiple nsec
- * identities on the same device don't share or overwrite each other.
- * On logout the three blobs are removed via `AsyncStorage.multiRemove`
- * alongside the NIP-17 wrap caches.
+ * `nostr_dm_inbox_v1_*` and `nostr_dm_conv_v1_*` held decrypted DM plaintext
+ * (up to DM_INBOX_CAP summaries / DM_CONV_CAP messages per peer) in
+ * UNENCRYPTED AsyncStorage, duplicating what the SQLCipher store protects.
+ * Nothing writes them any more: conversations + inbox serve purely from the
+ * encrypted store (dmDb), which now also carries deliveryStatus / rumorId /
+ * optimistic local- rows. The key constants remain so the one-time migration
+ * (dmBlobMigrationRunner) can import + delete an existing install's blobs,
+ * and so logout wipes clean up stragglers.
  *
- * Storage cap: `DM_INBOX_CAP` keeps the serialised JSON under ~400 KB
- * even with verbose messages (≈1000 entries × ~400 bytes each).
+ * The `*_last_seen_*` cursor keys stay LIVE — they hold only a unix
+ * timestamp (no plaintext) and still drive the kind-4 `since` delta fetch.
  */
 export const DM_INBOX_CACHE_PREFIX = 'nostr_dm_inbox_v1_';
 export const DM_INBOX_LAST_SEEN_PREFIX = 'nostr_dm_inbox_last_seen_v1_';
@@ -203,28 +212,6 @@ export async function safeGetDmCacheItem(key: string): Promise<string | null> {
   }
 }
 
-/** Read the persisted DM inbox for a user. Used during session restore /
- * post-login so the Messages tab paints from cache on cold start instead
- * of waiting for the relay round-trip + NIP-17 decrypt loop (3-5 s). The
- * shape mirrors what `refreshDmInbox` already writes at the end of every
- * successful refresh — so this is purely a read-side hoist of work that
- * was already happening, just earlier in the lifecycle.
- *
- * No follow-list filter is applied here. The next `refreshDmInbox` call
- * (fires via Messages-tab focus) re-applies the filter against current
- * follows, so a since-last-session unfollow never persists to the UI for
- * more than the brief render window before that re-filter happens. */
-export async function loadDmInboxFromCache(pubkey: string): Promise<DmInboxEntry[]> {
-  try {
-    const raw = await safeGetDmCacheItem(inboxCacheKey(pubkey));
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
 export async function loadLastSeen(key: string): Promise<number | undefined> {
   const raw = await AsyncStorage.getItem(key);
   if (!raw) return undefined;
@@ -263,12 +250,6 @@ export function mergeInboxEntries(
   }
   return result;
 }
-
-// Window in seconds to match a fresh real-id message against a pending
-// optimistic local- echo (same fromMe + same text). Mirrors
-// appendGroupMessage's LOCAL_ECHO_MATCH_WINDOW_SECS so the same UX
-// invariant — one bubble per send, not two — holds across 1:1 + group.
-export const LOCAL_DM_ECHO_WINDOW_SECS = 30;
 
 export function mergeConversationMessages(
   cached: ConversationMessage[],
@@ -337,6 +318,24 @@ export function mergeConversationMessages(
     result = result.slice(drop);
   }
   return result;
+}
+
+/**
+ * Read-side echo dedup for a single store read (#850). `upsertDmMessages`
+ * retires a matched local- row when its echo lands, but the two writes can
+ * race (optimistic append vs live-sub echo), so a read may still see both
+ * rows. Splitting the list into local- vs real and merging real OVER local
+ * reuses `mergeConversationMessages`' exact pairing (fromMe + text + echo
+ * window) — one bubble per send, ticks/rumorId inherited — without a second
+ * implementation of the rule.
+ */
+export function dedupeLocalEchoes(
+  messages: ConversationMessage[],
+  cap: number = DM_CONV_CAP,
+): ConversationMessage[] {
+  const locals = messages.filter((m) => m.id.startsWith(LOCAL_DM_ID_PREFIX));
+  const reals = messages.filter((m) => !m.id.startsWith(LOCAL_DM_ID_PREFIX));
+  return mergeConversationMessages(locals, reals, cap);
 }
 
 /**

--- a/src/contexts/nostrFetchConversation.ts
+++ b/src/contexts/nostrFetchConversation.ts
@@ -6,6 +6,7 @@ import { unwrapWrapNsec, unwrapWrapViaNip44, type DecodedRumor } from '../utils/
 import {
   getConversationMessages,
   hasStoredWraps,
+  selectKnownEventIds,
   upsertDmMessages,
   type DmMessageRow,
 } from '../services/dmDb';
@@ -14,12 +15,12 @@ import { yieldToEventLoop, DECRYPT_YIELD_EVERY } from './nostrDecryptPacing';
 import {
   DM_CONV_CAP,
   inboxLastSeenKey,
-  convCacheKey,
   convLastSeenKey,
-  safeGetDmCacheItem,
   loadLastSeen,
   mergeConversationMessages,
+  dedupeLocalEchoes,
 } from './nostrDmCache';
+import { mapStoredRowsToMessages } from './conversationReadThrough';
 import { ingestInboxWraps } from './dmWrapIngest';
 import { ensureDmStoreMigrated } from './dmStoreMigrationRunner';
 import type { ConversationMessage } from './nostrContextTypes';
@@ -29,9 +30,11 @@ import type { ConversationMessage } from './nostrContextTypes';
  * standalone async function (#703) — `useDmInbox` threads in the active
  * identity (`pubkey`, `isLoggedIn`, `signerType`), the relay resolver
  * (`getReadRelays`), and the per-signer NIP-04 decrypt closure
- * (`decryptNip04ViaSigner`). The NIP-17 portion of a thread is served from
- * the encrypted DM store's indexed (owner, conversation, created_at) slice
- * (#848) — the plaintext wrap-cache file this used to scan is retired.
+ * (`decryptNip04ViaSigner`). The whole at-rest side of a thread is the
+ * encrypted DM store's indexed (owner, conversation, created_at) slice
+ * (#848/#850) — the plaintext wrap-cache file AND the per-conversation
+ * AsyncStorage blob this used to read/write are retired. Fresh relay
+ * decrypts are persisted to the store and merged in memory only.
  */
 export interface FetchConversationParams {
   pubkey: string | null;
@@ -64,9 +67,9 @@ export async function fetchConversationFor(
   const normalized = otherPubkey.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(normalized)) return [];
 
-  // One-time plaintext→encrypted store migration (#848) — memoised, so this
-  // is a Map lookup after the first call. A notification deep-link can open
-  // a thread before any inbox refresh ran, so the trigger lives here too.
+  // One-time plaintext→encrypted store migration (#848/#850) — memoised, so
+  // this is a Map lookup after the first call. A notification deep-link can
+  // open a thread before any inbox refresh ran, so the trigger lives here too.
   await ensureDmStoreMigrated(pubkey);
 
   // Perf instrumentation — unconditional (not __DEV__ gated) so we
@@ -74,46 +77,52 @@ export async function fetchConversationFor(
   // compare cold-store vs warm-store thread opens. Numbers are
   // counts-only — no plaintext / pubkey logged beyond a short id.
   const perfStart = performance.now();
-  let nip17CacheHits = 0;
+  let nip17StoreHits = 0;
   let nip17FreshDecrypts = 0;
+  let nip04StoreHits = 0;
   let nip04CacheHits = 0;
+  let nip04DbKnown = 0;
   let nip04FreshDecrypts = 0;
 
   const readRelays = getReadRelays();
   const decrypted: ConversationMessage[] = [];
 
-  // PR B: load persisted per-peer conversation + per-peer last-seen.
-  // Merge cached-and-fresh at the end; keep the cache for the next
-  // open so we only ever re-decrypt the (typically 0-few) events
-  // that arrived since last open.
-  const [convRaw, convLastSeen] = await Promise.all([
-    safeGetDmCacheItem(convCacheKey(pubkey, normalized)),
-    loadLastSeen(convLastSeenKey(pubkey, normalized)),
-  ]);
-  const cachedConv: ConversationMessage[] = convRaw
-    ? (() => {
-        try {
-          const parsed = JSON.parse(convRaw);
-          return Array.isArray(parsed) ? parsed : [];
-        } catch {
-          return [];
-        }
-      })()
-    : [];
+  // The at-rest thread slice: everything any surface ever decrypted for this
+  // peer, straight from the encrypted store's indexed read (#850 — this
+  // replaces BOTH the plaintext conv blob and the separate store read the
+  // pre-#850 flow merged). Carries the optimistic local- rows + delivery
+  // ticks + rumor ids the blob used to be the only home for.
+  let storedMessages: ConversationMessage[] = [];
+  let storeHasWraps = false;
+  try {
+    const threadRows = await getConversationMessages(pubkey, normalized, { limit: DM_CONV_CAP });
+    for (const r of threadRows) {
+      if (r.wireKind === 4) nip04StoreHits++;
+      else nip17StoreHits++;
+    }
+    storedMessages = dedupeLocalEchoes(mapStoredRowsToMessages(threadRows), DM_CONV_CAP);
+    storeHasWraps = await hasStoredWraps(pubkey);
+  } catch (e) {
+    // Store unavailable — degrade to the relay fetch below.
+    if (__DEV__) console.warn('[DmStore] thread slice read failed:', e);
+  }
+
+  const convLastSeen = await loadLastSeen(convLastSeenKey(pubkey, normalized));
 
   // NIP-04 — peer-scoped fetch, two directions, filtered by since.
   const kind4Events = await nostrService.fetchDirectMessageEvents(pubkey, normalized, readRelays, {
     since: convLastSeen,
   });
-  // Two-pass decrypt with module-level LRU cache:
-  //  1. Pull plaintext synchronously for events already in the
-  //     cache — no decrypt round-trip, no Amber IPC, no CPU.
-  //  2. Decrypt the misses in parallel (`Promise.all`). For nsec
-  //     this drains the JS queue faster than a serial for-await
-  //     loop; for Amber the IPC round-trips pipeline. Chunk the
-  //     Promise.all in slices of DECRYPT_YIELD_EVERY to yield to
-  //     the UI thread between batches on very long threads.
-  const freshDecryptTargets: {
+  // Three-pass decrypt:
+  //  1. Pull plaintext synchronously for events already in the RAM LRU —
+  //     no decrypt round-trip, no Amber IPC, no CPU.
+  //  2. DB known-id gate (#850, closes the N6 asymmetry with the inbox
+  //     path): RAM misses whose decrypts are already encrypted-store rows
+  //     need no signer round-trip — `storedMessages` above already carries
+  //     them. One chunked indexed query.
+  //  3. Decrypt the remaining misses in parallel (`Promise.all`), chunked
+  //     in slices of DECRYPT_YIELD_EVERY to yield to the UI thread.
+  const ramMisses: {
     idx: number;
     counterparty: string;
     ev: (typeof kind4Events)[0];
@@ -133,9 +142,18 @@ export async function fetchConversationFor(
       nip04CacheHits++;
       cachedPlaintexts.push({ idx: i, fromMe, text: hit, ev });
     } else {
-      freshDecryptTargets.push({ idx: i, counterparty, ev });
+      ramMisses.push({ idx: i, counterparty, ev });
     }
   }
+  const k4Known =
+    ramMisses.length > 0
+      ? await selectKnownEventIds(
+          pubkey,
+          ramMisses.map((t) => t.ev.id),
+        ).catch(() => new Set<string>())
+      : new Set<string>();
+  nip04DbKnown = k4Known.size;
+  const freshDecryptTargets = ramMisses.filter((t) => !k4Known.has(t.ev.id));
   // Parallel decrypt of misses, in yield-able chunks.
   const freshResults: ({
     idx: number;
@@ -208,13 +226,12 @@ export async function fetchConversationFor(
   }
   for (const m of orderedByIndex) if (m !== null) decrypted.push(m);
 
-  // NIP-17 — partner pubkey is hidden inside the encrypted rumor, so
-  // we can't peer-scope at the relay. The encrypted DM store memoises
-  // every wrap the inbox ever decrypted (#848), so serve THIS thread's
-  // slice straight from the indexed (owner, conversation, created_at)
-  // read — and if the store holds ANY wraps (an inbox-wide ingest has
-  // run before), skip the expensive inbox-wide relay fetch entirely
-  // (#190).
+  // NIP-17 — partner pubkey is hidden inside the encrypted rumor, so we
+  // can't peer-scope at the relay. The encrypted DM store memoises every
+  // wrap the inbox ever decrypted (#848), and `storedMessages` above already
+  // holds THIS thread's slice — so if the store holds ANY wraps (an
+  // inbox-wide ingest has run before), skip the expensive inbox-wide relay
+  // fetch entirely (#190).
   //
   // Cold-store fallback: if the store has no wraps at all (first app
   // run post-login, or just-logged-out-logged-back-in) we still hit
@@ -224,28 +241,10 @@ export async function fetchConversationFor(
   // Staleness tradeoff: a wrap that arrived in the last <30s and
   // hasn't been pulled by refreshDmInbox yet won't show until the
   // next tab focus. For a chat UX that's a non-issue.
-  let skippedInboxFetch = false;
-  try {
-    const threadRows = await getConversationMessages(pubkey, normalized, { limit: DM_CONV_CAP });
-    for (const r of threadRows) {
-      if (r.wireKind === 4) nip04CacheHits++;
-      else nip17CacheHits++;
-      decrypted.push({
-        id: r.eventId,
-        fromMe: r.fromMe,
-        text: r.content,
-        createdAt: r.createdAt,
-        wireKind: r.wireKind,
-      });
-    }
-    skippedInboxFetch = await hasStoredWraps(pubkey);
-  } catch (e) {
-    // Store unavailable — fall back to the relay path below.
-    if (__DEV__) console.warn('[DmStore] thread slice read failed:', e);
-  }
+  const skippedInboxFetch = storeHasWraps;
   // Aborted mid-fetch (back-press during the kind-4 decrypt) — skip the
   // inbox-wide wrap fetch entirely and return what the store already gave us
-  // (#868). The store rows above are already pushed into `decrypted`.
+  // (#868).
   const skipWrapFetch = skippedInboxFetch || (signal?.aborted ?? false);
   const inboxLastSeenForWraps = skipWrapFetch
     ? undefined
@@ -288,7 +287,7 @@ export async function fetchConversationFor(
         onSkip,
         signal,
       });
-      nip17CacheHits += r.alreadyKnown;
+      nip17StoreHits += r.alreadyKnown;
       nip17FreshDecrypts += r.misses;
       // Render-side filter to this thread's partner only — the rest were
       // stored for later opens of their own threads.
@@ -306,49 +305,46 @@ export async function fetchConversationFor(
     }
   }
 
-  // PR B: merge fresh decrypt results with what we had cached
-  // from previous opens. Fresh takes precedence via `mergeConversationMessages`
-  // Map semantics so re-ordered or edited events (rare) land right.
-  const merged = mergeConversationMessages(cachedConv, decrypted, DM_CONV_CAP);
+  // Merge fresh decrypt results over the stored slice. Fresh takes precedence
+  // via `mergeConversationMessages` Map semantics (and retires any optimistic
+  // local- row its relay echo just replaced — the store-side upsert did the
+  // same for the persisted rows).
+  const merged = mergeConversationMessages(storedMessages, decrypted, DM_CONV_CAP);
 
   // Aborted mid-fetch (Copilot #869): the kind-4 decrypt loop bails between
   // batches, so `decrypted` may omit events the abort skipped — but
   // `kind4Events` still holds them all. Persisting `convLastSeen` from the full
   // `kind4Events` set would advance the per-peer `since` cursor PAST those
   // never-decrypted events, permanently skipping them on the next open. Return
-  // the store-backed `merged` (already painted) WITHOUT any cache/cursor write,
-  // so an aborted run has no durable side effects.
+  // the store-backed `merged` (already painted) WITHOUT any cursor write, so an
+  // aborted run has no durable side effects.
   if (signal?.aborted) return merged;
 
   // Single-line perf summary — grep `[Perf] fetchConversation` out
   // of logcat to compare cold-store vs warm-store thread opens.
-  // Cold store shows `hits=0, fresh=N` — whole inbox decrypted.
-  // Warm store shows `hits≈N, fresh=0` — all store short-circuits.
+  // Cold store shows `store=0, fresh=N` — whole inbox decrypted.
+  // Warm store shows `store≈N, fresh=0` — all store short-circuits.
   console.log(
     `[Perf] fetchConversation(${normalized.slice(0, 8)}): ` +
       `${(performance.now() - perfStart).toFixed(0)}ms, ` +
-      `k4=${kind4Events.length} (hits=${nip04CacheHits}, fresh=${nip04FreshDecrypts}), ` +
-      `k1059=${nip17CacheHits + nip17FreshDecrypts} (hits=${nip17CacheHits}, fresh=${nip17FreshDecrypts}, skippedFetch=${skippedInboxFetch}), ` +
+      `k4=${kind4Events.length} (ram=${nip04CacheHits}, dbKnown=${nip04DbKnown}, fresh=${nip04FreshDecrypts}, store=${nip04StoreHits}), ` +
+      `k1059 (store=${nip17StoreHits}, fresh=${nip17FreshDecrypts}, skippedFetch=${skippedInboxFetch}), ` +
       `since=${convLastSeen ?? 0}, ` +
-      `cached=${cachedConv.length}, ` +
       `merged=${merged.length}`,
   );
 
-  // Persist merged list + new per-peer last-seen so next open of
-  // THIS thread sees only the delta. Fire-and-forget; the caller
-  // gets its data immediately via `merged`. kind-1059 deliberately
-  // excluded — wrap timestamps are randomized per NIP-59 and would
-  // poison the kind-4 since cursor (same reasoning as the inbox
-  // path; see fetchInboxDmEvents + refreshDmInbox).
+  // Persist the new per-peer last-seen so the next open of THIS thread sees
+  // only the delta. A bare timestamp — the messages themselves live ONLY in
+  // the encrypted store now (#850; the plaintext conv-blob write is gone).
+  // kind-1059 deliberately excluded — wrap timestamps are randomized per
+  // NIP-59 and would poison the kind-4 since cursor (same reasoning as the
+  // inbox path; see fetchInboxDmEvents + refreshDmInbox).
   const newConvLastSeen = Math.max(convLastSeen ?? 0, ...kind4Events.map((e) => e.created_at));
-  Promise.all([
-    AsyncStorage.setItem(convCacheKey(pubkey, normalized), JSON.stringify(merged)).catch(() => {}),
-    newConvLastSeen > (convLastSeen ?? 0)
-      ? AsyncStorage.setItem(convLastSeenKey(pubkey, normalized), String(newConvLastSeen)).catch(
-          () => {},
-        )
-      : Promise.resolve(),
-  ]).catch(() => {});
+  if (newConvLastSeen > (convLastSeen ?? 0)) {
+    AsyncStorage.setItem(convLastSeenKey(pubkey, normalized), String(newConvLastSeen)).catch(
+      () => {},
+    );
+  }
 
   return merged;
 }

--- a/src/contexts/nostrFetchConversationAbort.test.ts
+++ b/src/contexts/nostrFetchConversationAbort.test.ts
@@ -21,6 +21,10 @@ jest.mock('../services/dmDb', () => ({
   getConversationMessages: jest.fn(async () => []),
   hasStoredWraps: jest.fn(async () => false),
   upsertDmMessages: jest.fn(async () => undefined),
+  // DB known-id gate for thread-open kind-4 decrypts (#850, N6).
+  selectKnownEventIds: jest.fn(async () => new Set<string>()),
+  LOCAL_DM_ID_PREFIX: 'local-',
+  LOCAL_DM_ECHO_WINDOW_SECS: 30,
 }));
 
 jest.mock('./dmStoreMigrationRunner', () => ({
@@ -121,5 +125,26 @@ describe('fetchConversationFor abort (#868)', () => {
       key.includes('conv_last_seen'),
     );
     expect(wroteCursor).toBe(true);
+  });
+
+  it('never writes decrypted plaintext to AsyncStorage (#850 at-rest invariant)', async () => {
+    // A full, successful run that decrypts fresh kind-4 events. The ONLY
+    // AsyncStorage write allowed is the bare-timestamp last-seen cursor —
+    // the plaintext conversation/inbox blobs are retired; decrypted content
+    // persists exclusively in the encrypted store (upsertDmMessages).
+    const setItem = AsyncStorage.setItem as jest.Mock;
+    (nostrService.fetchDirectMessageEvents as jest.Mock).mockResolvedValue([
+      { id: 'e1', pubkey: PEER, content: 'ct', created_at: 1000 },
+    ]);
+    (getConversationMessages as jest.Mock).mockResolvedValue([]);
+    (hasStoredWraps as jest.Mock).mockResolvedValue(true);
+
+    await fetchConversationFor(baseParams());
+
+    for (const [key, value] of setItem.mock.calls as [string, string][]) {
+      expect(key).toContain('last_seen'); // cursors only — no content blobs
+      expect(value).not.toContain('plaintext'); // the decrypted text never lands
+    }
+    expect(setItem.mock.calls.length).toBeGreaterThan(0); // the cursor did write
   });
 });

--- a/src/contexts/nostrLiveDmSub.ts
+++ b/src/contexts/nostrLiveDmSub.ts
@@ -13,7 +13,12 @@ import {
   type DecodedRumor,
 } from '../utils/nip17Unwrap';
 import { listPersistedGroupWrapIds } from '../services/groupMessagesStorageService';
-import { selectDmWrapIds, upsertDmMessages, type DmMessageRow } from '../services/dmDb';
+import {
+  selectDmWrapIds,
+  upsertDmMessages,
+  hasConversationWith,
+  type DmMessageRow,
+} from '../services/dmDb';
 import {
   parseOrderEvent,
   serializeOrder,
@@ -32,9 +37,7 @@ import type { LiveSubFollowGateBuffer, DeferredFollowGateEntry } from './liveSub
 import {
   COLD_INITIAL_WRAP_LIMIT,
   DM_INBOX_CAP,
-  inboxCacheKey,
   inboxLastSeenKey,
-  safeGetDmCacheItem,
   loadLastSeen,
   mergeInboxEntries,
 } from './nostrDmCache';
@@ -55,24 +58,6 @@ import { ensureDmStoreMigrated } from './dmStoreMigrationRunner';
  * reading them through the bundle keeps the gate + dedup behaviour
  * byte-for-byte identical.
  */
-
-/**
- * Parse the persisted inbox cache, dropping malformed entries. A corrupt cache
- * (null entries, non-objects, or a missing `partnerPubkey`) must not crash the
- * later `.some(...)` / `mergeInboxEntries` and break live order/DM ingest.
- */
-function parseCachedInboxEntries(raw: string | null): DmInboxEntry[] {
-  if (!raw) return [];
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (e) => e && typeof e === 'object' && typeof e.partnerPubkey === 'string',
-    ) as DmInboxEntry[];
-  } catch {
-    return [];
-  }
-}
 
 export interface LiveDmSubscriptionParams {
   viewerPubkey: string;
@@ -311,10 +296,11 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
         wireKind: 4,
       };
       // Persist the decrypted kind-4 to the encrypted store (#848 — the RAM
-      // LRU dies with the session) plus the inbox preview blob. Same
-      // writeChain as kind-1059 to serialize concurrent inbox writes. Also
-      // bump inboxLastSeenKey so refreshDmInbox's kind-4 `since` filter
-      // advances and doesn't re-fetch already-seen events on the next refresh.
+      // LRU dies with the session). The store is the ONLY at-rest home now
+      // (#850; the plaintext inbox-preview blob is retired). Same writeChain
+      // as kind-1059 to serialize concurrent store writes. Also bump
+      // inboxLastSeenKey (a bare timestamp) so refreshDmInbox's kind-4
+      // `since` filter advances and doesn't re-fetch already-seen events.
       const k4Row: DmMessageRow = {
         owner: viewerPubkey,
         eventId: ev.id,
@@ -328,20 +314,17 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
       writeChain = writeChain
         .then(async () => {
           if (cancelled) return;
-          await upsertDmMessages([k4Row]).catch((e) => {
-            if (__DEV__) console.warn('[DmStore] live kind-4 upsert failed:', e);
-          });
-          const inboxRaw = await safeGetDmCacheItem(inboxCacheKey(viewerPubkey));
-          const cachedInbox: DmInboxEntry[] = parseCachedInboxEntries(inboxRaw);
-          const merged = mergeInboxEntries(cachedInbox, [k4InboxEntry], DM_INBOX_CAP);
-          // Re-check after the await: logout may have multiRemove'd these keys while we were reading. Without this, a freshly-decrypted DM would re-populate disk after the user signed out.
-          if (cancelled) return;
-          await AsyncStorage.setItem(inboxCacheKey(viewerPubkey), JSON.stringify(merged)).catch(
-            () => {},
-          );
+          // N5 (#850): a store failure THROWS here (caught by the trailing
+          // .catch), so the lastSeen bump below never runs for a row the DB
+          // failed to keep — aligned with the kind-1059 path. The next
+          // refresh's `since` floor then re-fetches the event instead of
+          // silently skipping past an unpersisted message.
+          await upsertDmMessages([k4Row]);
           const lastSeenRaw = await AsyncStorage.getItem(inboxLastSeenKey(viewerPubkey));
           const lastSeen = lastSeenRaw ? Number(lastSeenRaw) : 0;
           if (ev.created_at > lastSeen) {
+            // Re-check after the awaits: logout may have wiped these stores
+            // while we were writing.
             if (cancelled) return;
             await AsyncStorage.setItem(inboxLastSeenKey(viewerPubkey), String(ev.created_at)).catch(
               () => {},
@@ -422,27 +405,25 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
       // by `#p`, so any sender can craft an order-shaped kind-16/17 to the
       // viewer. To avoid OS-level notification spam, only raise a push when the
       // market is already trusted: followed, OR an existing conversation in the
-      // inbox cache. Unknown senders are still stored + surfaced in-app silently.
+      // encrypted store (#850 — replaces the retired plaintext inbox blob scan).
+      // Unknown senders are still stored + surfaced in-app silently.
       // (Follow-up: record markets the user actively ordered from — e.g. via the
       // Explore Market checkout — into a trust set so a first legitimate order
-      // notifies too.) `partnerKnown` is read from the inbox BEFORE this event
-      // merges in, so the very first order from a stranger can't self-qualify.
+      // notifies too.) `partnerKnown` is checked BEFORE this event's own upsert,
+      // so the very first order from a stranger can't self-qualify.
       const partnerFollowed = followPubkeysRef.current.has(partnerPubkey);
       let partnerKnown = partnerFollowed;
       writeChain = writeChain
         .then(async () => {
           if (cancelled) return;
+          if (!partnerKnown) {
+            partnerKnown = await hasConversationWith(viewerPubkey, partnerPubkey).catch(
+              () => false,
+            );
+          }
           await upsertDmMessages([orderRow]).catch((e) => {
             if (__DEV__) console.warn('[DmStore] live order upsert failed:', e);
           });
-          const inboxRaw = await safeGetDmCacheItem(inboxCacheKey(viewerPubkey));
-          const cachedInbox: DmInboxEntry[] = parseCachedInboxEntries(inboxRaw);
-          if (cachedInbox.some((e) => e.partnerPubkey === partnerPubkey)) partnerKnown = true;
-          const merged = mergeInboxEntries(cachedInbox, [orderInboxEntry], DM_INBOX_CAP);
-          if (cancelled) return;
-          await AsyncStorage.setItem(inboxCacheKey(viewerPubkey), JSON.stringify(merged)).catch(
-            () => {},
-          );
         })
         .catch((e) => {
           if (__DEV__) console.warn('[Nostr] live order persist failed:', e);
@@ -626,7 +607,7 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
       rumorId: partnership.fromMe ? rumorEventId(rumor) : undefined,
     };
 
-    // Serialise store-upsert + inbox-blob write so concurrent live wraps don't race each other.
+    // Serialise store upserts so concurrent live wraps don't race each other.
     // The trailing `.catch` is load-bearing: without it a single throw leaves `writeChain` rejected and every later `.then(...)` skips its onFulfilled.
     writeChain = writeChain
       .then(async () => {
@@ -634,19 +615,10 @@ export function startLiveDmSubscription(params: LiveDmSubscriptionParams): () =>
         // Encrypted store write (#848) — idempotent by (owner, event_id), so
         // a wrap delivered by both the live sub and a near-simultaneous
         // refresh lands as one row (the old file read→merge→write dance and
-        // its #811 clobbering hazard are gone).
+        // its #811 clobbering hazard are gone). The store is the ONLY
+        // at-rest persistence (#850) — the plaintext inbox blob is retired.
         await upsertDmMessages([wrapRow]);
         knownWrapIds?.add(wrap.id);
-
-        // Re-check after each await: logout may have wiped these stores while we were writing. Without these guards a freshly-decrypted wrap would re-populate disk after the user signed out.
-        if (cancelled) return;
-        const inboxRaw = await safeGetDmCacheItem(inboxCacheKey(viewerPubkey));
-        const cachedInbox: DmInboxEntry[] = parseCachedInboxEntries(inboxRaw);
-        const merged = mergeInboxEntries(cachedInbox, [inboxEntry], DM_INBOX_CAP);
-        if (cancelled) return;
-        await AsyncStorage.setItem(inboxCacheKey(viewerPubkey), JSON.stringify(merged)).catch(
-          () => {},
-        );
       })
       .catch((e) => {
         if (__DEV__) console.warn('[Nostr] live wrap persist failed:', e);

--- a/src/contexts/nostrSecretKeyCache.ts
+++ b/src/contexts/nostrSecretKeyCache.ts
@@ -16,12 +16,11 @@ import { NSEC_KEY } from './nostrAuthKeys';
  */
 export const nip04PlaintextCache = new LRUCache<string, string>({ max: 1000 });
 
-// Per-(viewer,partner) serialization chain for the optimistic local-
-// message disk-cache writes. Without this, two rapid sends (e.g.
-// double-tap retry, or two sequential tap-share-from-attach) could
-// each read-modify-write the conversation blob concurrently — last
-// write wins, losing the prior optimistic row. Per Copilot review #509.
-export const appendLocalDmChains = new Map<string, Promise<void>>();
+// NOTE: the per-(viewer,partner) `appendLocalDmChains` serialization map
+// (Copilot review #509) was removed in #850 — the optimistic local- rows it
+// guarded moved from a read-modify-write AsyncStorage blob to atomic
+// (owner, event_id)-keyed upserts in the encrypted store, where two rapid
+// sends can't clobber each other.
 export function __clearNip04PlaintextCacheForTests() {
   nip04PlaintextCache.clear();
 }

--- a/src/contexts/useDmInbox.ts
+++ b/src/contexts/useDmInbox.ts
@@ -9,16 +9,13 @@ import { perAccountKey } from '../services/perAccountStorage';
 import {
   selectKnownEventIds,
   upsertDmMessages,
+  updateDmDeliveryStatuses,
   hasStoredWraps,
   getConversationMessages,
   type DmMessageRow,
 } from '../services/dmDb';
 import { loadInboxEntries } from '../services/dmInbox';
-import {
-  nip04PlaintextCache,
-  appendLocalDmChains,
-  getMemoisedSecretKey,
-} from './nostrSecretKeyCache';
+import { nip04PlaintextCache, getMemoisedSecretKey } from './nostrSecretKeyCache';
 import { yieldToEventLoop, DECRYPT_YIELD_EVERY } from './nostrDecryptPacing';
 import {
   AMBER_NIP17_SKIP_KEY_BASE,
@@ -26,11 +23,7 @@ import {
   COLD_INITIAL_WRAP_LIMIT,
   DM_INBOX_CAP,
   DM_CONV_CAP,
-  inboxCacheKey,
   inboxLastSeenKey,
-  convCacheKey,
-  safeGetDmCacheItem,
-  loadDmInboxFromCache,
   loadLastSeen,
   mergeInboxEntries,
 } from './nostrDmCache';
@@ -85,10 +78,10 @@ export interface UseDmInboxResult {
     otherPubkey: string,
     opts?: { signal?: AbortSignal },
   ) => Promise<ConversationMessage[]>;
-  getCachedConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
-  // Read-through (#868): the instant-paint set for a thread open — the union of
-  // the per-conversation cache and the SAME encrypted-store rows the inbox
-  // preview is built from. Guarantees the thread is never behind the preview.
+  // Read-through (#868, single-sourced in #850): the instant-paint set for a
+  // thread open — the SAME encrypted-store rows the inbox preview is built
+  // from (the plaintext per-conversation blob is retired). Guarantees the
+  // thread is never behind the preview.
   loadInitialConversation: (otherPubkey: string) => Promise<ConversationMessage[]>;
   appendLocalDmMessage: (otherPubkey: string, msg: ConversationMessage) => Promise<void>;
   persistDeliveryStatuses: (
@@ -147,7 +140,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
 
   // Single-flight guard: coalesce overlapping refreshDmInbox calls (e.g.
   // useFocusEffect firing while a pull-to-refresh is still in-flight) so
-  // they don't race on the skip-set file + inbox summary blob.
+  // they don't race on the skip-set file + encrypted-store writes.
   const dmInboxInFlight = useRef<{
     promise: Promise<void>;
     includeNonFollows: boolean;
@@ -158,18 +151,15 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
 
   /** Eagerly hydrate `dmInbox` so the Messages tab paints conversations on
    * cold start instead of staying blank for the relay-fetch + decrypt loop
-   * (~3-5 s). Sources: the encrypted DM store's indexed latest-per-
-   * conversation read (#848) unioned with the persisted inbox-summary blob
-   * (which still covers kind-4-only threads predating the store). Called
-   * from session-restore + post-login flows; refreshDmInbox handles its own
-   * cache read separately for the delta-fetch path. */
+   * (~3-5 s). Single source (#850): the encrypted DM store's indexed
+   * latest-per-conversation read — the plaintext inbox-summary blob is
+   * retired. The one-time migration runs first (memoised; a Map lookup once
+   * done) so a just-updated install hydrates the pre-#848 kind-4-only
+   * threads its blobs held. Called from session-restore + post-login flows. */
   const hydrateDmInboxFromCache = useCallback(async (pk: string) => {
-    const [cached, dbLatest] = await Promise.all([
-      loadDmInboxFromCache(pk),
-      loadInboxEntries(pk).catch(() => [] as DmInboxEntry[]),
-    ]);
-    const merged = mergeInboxEntries(dbLatest, cached, DM_INBOX_CAP);
-    if (merged.length > 0) setDmInbox(merged);
+    await ensureDmStoreMigrated(pk);
+    const dbLatest = await loadInboxEntries(pk).catch(() => [] as DmInboxEntry[]);
+    if (dbLatest.length > 0) setDmInbox(dbLatest);
   }, []);
 
   /**
@@ -216,126 +206,59 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
     [pubkey],
   );
 
-  const getCachedConversation = useCallback(
-    async (otherPubkey: string): Promise<ConversationMessage[]> => {
-      if (!pubkey) return [];
-      const normalized = otherPubkey.trim().toLowerCase();
-      if (!/^[0-9a-f]{64}$/.test(normalized)) return [];
-      try {
-        const raw = await safeGetDmCacheItem(convCacheKey(pubkey, normalized));
-        if (!raw) return [];
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) ? parsed : [];
-      } catch {
-        return [];
-      }
-    },
-    [pubkey],
-  );
-
+  // Persist the optimistic local- send row into the ENCRYPTED store (#850 —
+  // formerly a plaintext AsyncStorage blob write). The row carries the
+  // delivery tick (#856) + rumorId (#857); when the relay echo lands,
+  // upsertDmMessages retires the local- row and carries both onto the echo.
+  // Atomic by (owner, event_id), so the pre-#850 read-modify-write clobber
+  // hazard (Copilot review #509) no longer needs a serialization chain.
   const appendLocalDmMessage = useCallback(
     async (otherPubkey: string, msg: ConversationMessage): Promise<void> => {
       if (!pubkey) return;
       const normalized = otherPubkey.trim().toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(normalized)) return;
-      // Serialize concurrent appends to the same conversation. Without
-      // this, two rapid sends could both read the same `existing` array,
-      // each merge their msg, both write back — last write wins, the
-      // earlier optimistic row is silently lost. Per Copilot review #509.
-      const chainKey = `${pubkey}:${normalized}`;
-      const prev = appendLocalDmChains.get(chainKey) ?? Promise.resolve();
-      const next = prev.then(async () => {
-        try {
-          const key = convCacheKey(pubkey, normalized);
-          const raw = await AsyncStorage.getItem(key);
-          const existing: ConversationMessage[] = raw
-            ? (() => {
-                try {
-                  const parsed = JSON.parse(raw);
-                  return Array.isArray(parsed) ? parsed : [];
-                } catch {
-                  return [];
-                }
-              })()
-            : [];
-          // Dedup on id (same key would arise from a double-tap retry).
-          const map = new Map<string, ConversationMessage>();
-          for (const m of existing) map.set(m.id, m);
-          map.set(msg.id, msg);
-          const merged = Array.from(map.values()).sort((a, b) => a.createdAt - b.createdAt);
-          const capped =
-            merged.length <= DM_CONV_CAP ? merged : merged.slice(merged.length - DM_CONV_CAP);
-          await AsyncStorage.setItem(key, JSON.stringify(capped));
-        } catch {
-          // Swallow — the in-memory setMessages above already painted
-          // the bubble. The remount-after-back regression is precisely
-          // what this method exists to fix, so a write failure is
-          // unfortunate but not destructive (next relay echo will
-          // repopulate the cache).
-        }
-      });
-      // `.catch` on the chain entry so a single failure doesn't poison
-      // every subsequent append on this conversation.
-      appendLocalDmChains.set(
-        chainKey,
-        next.catch(() => {}),
-      );
-      await next;
+      try {
+        await upsertDmMessages([
+          {
+            owner: pubkey,
+            eventId: msg.id,
+            conversation: normalized,
+            createdAt: msg.createdAt,
+            sender: msg.fromMe ? pubkey : normalized,
+            content: msg.text,
+            fromMe: msg.fromMe,
+            wireKind: msg.wireKind ?? 14,
+            deliveryStatus: msg.deliveryStatus,
+            rumorId: msg.rumorId,
+          },
+        ]);
+      } catch (e) {
+        // Swallow — the in-memory setMessages already painted the bubble; a
+        // write failure is unfortunate but not destructive (the next relay
+        // echo repopulates the store).
+        if (__DEV__) console.warn('[DmStore] optimistic append failed:', e);
+      }
     },
     [pubkey],
   );
 
-  // Durably attach delivery status (#856) to persisted conv rows, keyed by row
-  // id. The optimistic `local-` row's tick is otherwise lost across a cold
-  // restart: when the relay echo replaces it, the on-disk merge can miss the
-  // carry-over (the local- write may not have committed before the echo's
-  // fetch read the cache), so the persisted real-id row has no tick. After the
-  // in-memory reconcile re-attaches the tick to the real-id row, this writes
-  // that back so the next cold start reads it. Shares the per-conversation
-  // chain lock so it can't race the append/echo writes.
+  // Durably attach delivery status (#856) to stored rows, keyed by row id —
+  // now a fill-only UPDATE on the encrypted store (#850). The optimistic
+  // `local-` row's tick is otherwise lost across a cold restart when the
+  // relay echo replaces it before the tick settled; after the in-memory
+  // reconcile re-attaches it to the real-id row, this writes it back so the
+  // next cold start reads it.
   const persistDeliveryStatuses = useCallback(
-    async (otherPubkey: string, statusById: Record<string, DeliveryStatus>): Promise<void> => {
+    async (_otherPubkey: string, statusById: Record<string, DeliveryStatus>): Promise<void> => {
       if (!pubkey) return;
-      const normalized = otherPubkey.trim().toLowerCase();
-      if (!/^[0-9a-f]{64}$/.test(normalized)) return;
       if (Object.keys(statusById).length === 0) return;
-      const chainKey = `${pubkey}:${normalized}`;
-      const prev = appendLocalDmChains.get(chainKey) ?? Promise.resolve();
-      const next = prev.then(async () => {
-        try {
-          const key = convCacheKey(pubkey, normalized);
-          const raw = await AsyncStorage.getItem(key);
-          if (!raw) return;
-          const existing: ConversationMessage[] = (() => {
-            try {
-              const parsed = JSON.parse(raw);
-              return Array.isArray(parsed) ? parsed : [];
-            } catch {
-              return [];
-            }
-          })();
-          let changed = false;
-          const updated = existing.map((m) => {
-            const s = statusById[m.id];
-            // Only write when it actually adds/changes a tick — avoids a
-            // needless rewrite (and keeps an existing richer status if equal).
-            if (s && !m.deliveryStatus) {
-              changed = true;
-              return { ...m, deliveryStatus: s };
-            }
-            return m;
-          });
-          if (changed) await AsyncStorage.setItem(key, JSON.stringify(updated));
-        } catch {
-          // Non-fatal — the in-memory tick already shows; worst case the next
-          // send/echo cycle re-persists it.
-        }
-      });
-      appendLocalDmChains.set(
-        chainKey,
-        next.catch(() => {}),
-      );
-      await next;
+      try {
+        await updateDmDeliveryStatuses(pubkey, statusById);
+      } catch (e) {
+        // Non-fatal — the in-memory tick already shows; worst case the next
+        // send/echo cycle re-persists it.
+        if (__DEV__) console.warn('[DmStore] delivery-status persist failed:', e);
+      }
     },
     [pubkey],
   );
@@ -357,15 +280,16 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
     [pubkey, isLoggedIn, signerType, getReadRelays, decryptNip04ViaSigner],
   );
 
-  // Read-through (#868): paint the thread from the union of the per-conversation
-  // cache and the encrypted store BEFORE the relay fetch resolves, so a DM the
-  // inbox already ingested shows immediately and the thread is never behind the
-  // preview. Reads the SAME rows the inbox list is built from (getInboxLatest /
-  // getConversationMessages both read dm_messages), so they can't disagree.
+  // Read-through (#868, single-sourced in #850): paint the thread from the
+  // encrypted store BEFORE the relay fetch resolves, so a DM the inbox
+  // already ingested shows immediately and the thread is never behind the
+  // preview. Reads the SAME rows the inbox list is built from (getInboxLatest
+  // / getConversationMessages both read dm_messages), so they can't disagree
+  // — and the rows now carry the optimistic local- sends + delivery ticks the
+  // retired plaintext blob used to.
   const loadInitialConversation = useCallback(
     (otherPubkey: string): Promise<ConversationMessage[]> =>
       loadInitialConversationFor(otherPubkey, {
-        getCachedConversation,
         getStoredRows: (peer) => {
           if (!pubkey) return Promise.resolve([] as DmMessageRow[]);
           const normalized = peer.trim().toLowerCase();
@@ -373,7 +297,7 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           return getConversationMessages(pubkey, normalized, { limit: DM_CONV_CAP });
         },
       }),
-    [pubkey, getCachedConversation],
+    [pubkey],
   );
 
   // Stable self-reference so the cold-start backfill can re-invoke
@@ -487,29 +411,22 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           // Pacing yields the ingest performed this refresh (#532/#788).
           let nip17YieldCount = 0;
 
-          // PR B: load persisted inbox + last-seen so we can (a) paint
-          // cached entries before the relay round-trip finishes and
-          // (b) only fetch events newer than the last one we saw.
-          const [cachedInboxRaw, lastSeen] = await Promise.all([
-            safeGetDmCacheItem(inboxCacheKey(refreshForPubkey)),
+          // Load the store's inbox + the last-seen cursor so we can (a) paint
+          // stored entries before the relay round-trip finishes and (b) only
+          // fetch events newer than the last one we saw. Single source
+          // (#850): the encrypted store's indexed latest-per-conversation
+          // read — the plaintext inbox blob is retired (the migration above
+          // already folded any legacy blob into the store).
+          const [storedInbox, lastSeen] = await Promise.all([
+            loadInboxEntries(refreshForPubkey).catch(() => [] as DmInboxEntry[]),
             loadLastSeen(inboxLastSeenKey(refreshForPubkey)),
           ]);
-          const cachedInbox: DmInboxEntry[] = cachedInboxRaw
-            ? (() => {
-                try {
-                  const parsed = JSON.parse(cachedInboxRaw);
-                  return Array.isArray(parsed) ? parsed : [];
-                } catch {
-                  return [];
-                }
-              })()
-            : [];
-          // Render the cached entries immediately so the Messages tab
+          // Render the stored entries immediately so the Messages tab
           // isn't blank while the relay fetches the delta. The followers
-          // set may have changed since the cache was written; re-apply
+          // set may have changed since the rows were written; re-apply
           // the filter here so unfollowed senders don't resurrect.
-          if (cachedInbox.length > 0) {
-            const filteredCache = cachedInbox.filter((e) => passesFollowGate(e.partnerPubkey));
+          if (storedInbox.length > 0) {
+            const filteredCache = storedInbox.filter((e) => passesFollowGate(e.partnerPubkey));
             setDmInbox(filteredCache);
           }
 
@@ -730,20 +647,17 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           const persistedFreshRows = nip17Stored > 0 || k4Rows.length > 0;
           if (effectiveSignal?.aborted && !persistedFreshRows) return;
 
-          // Merge sources for the inbox (#848): the encrypted store's
-          // indexed latest-per-conversation read (DB-known wraps / kind-4
-          // no longer re-emit per-event entries), the persisted summary
-          // blob (kind-4-only threads predating the store), and this
-          // refresh's fresh decrypts. Keep at most DM_INBOX_CAP entries
-          // (newest-first), then persist + update last-seen.
+          // Merge sources for the inbox (#848/#850): the encrypted store's
+          // indexed latest-per-conversation read (re-read AFTER the ingest so
+          // it includes this refresh's persisted rows; DB-known wraps /
+          // kind-4 no longer re-emit per-event entries) plus this refresh's
+          // fresh decrypts (which carry rumorId etc. the projection lacks).
+          // The plaintext summary blob is gone — the store is the only
+          // at-rest source. Keep at most DM_INBOX_CAP entries (newest-first).
           const dbLatest = await loadInboxEntries(refreshForPubkey).catch(
             () => [] as DmInboxEntry[],
           );
-          const merged = mergeInboxEntries(
-            mergeInboxEntries(dbLatest, cachedInbox, DM_INBOX_CAP),
-            entries,
-            DM_INBOX_CAP,
-          );
+          const merged = mergeInboxEntries(dbLatest, entries, DM_INBOX_CAP);
           const filteredFinal = merged.filter((e) => passesFollowGate(e.partnerPubkey));
 
           // Perf summary: one line per refresh, grep with `\[Perf\] refreshDmInbox`.
@@ -772,11 +686,9 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
 
           setDmInbox(filteredFinal);
 
-          // Persist the FILTERED list + new last-seen — `merged` may hold
-          // non-followed senders' plaintext (B1 thread-open rows surface via
-          // loadInboxEntries), which must stay off plaintext AsyncStorage
-          // (Archie review W2 on #849; matches the live-sub invariant).
-          // Only kind-4 contributes
+          // Advance the kind-4 last-seen cursor (a bare unix timestamp — no
+          // plaintext; the decrypted content itself persists ONLY in the
+          // encrypted store now, #850). Only kind-4 contributes
           // here — NIP-59 wraps have randomized timestamps (~2 days in
           // either direction of the real publish time) for plausible
           // deniability, so wrap.created_at can't be used as a
@@ -785,19 +697,14 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
           // forward-dated ts, then cause subsequent kind-4 since-filters
           // to drop legitimate recent NIP-04 messages. fetchInboxDmEvents
           // already drops the `since` filter for kind-1059 entirely (see
-          // the matching comment there); the cache dedupes wraps by id.
+          // the matching comment there); the store dedupes wraps by id.
           const newLastSeen = Math.max(lastSeen ?? 0, ...kind4.map((e) => e.created_at));
-          await Promise.all([
-            AsyncStorage.setItem(
-              inboxCacheKey(refreshForPubkey),
-              JSON.stringify(filteredFinal),
-            ).catch(() => {}),
-            newLastSeen > (lastSeen ?? 0)
-              ? AsyncStorage.setItem(inboxLastSeenKey(refreshForPubkey), String(newLastSeen)).catch(
-                  () => {},
-                )
-              : Promise.resolve(),
-          ]);
+          if (newLastSeen > (lastSeen ?? 0)) {
+            await AsyncStorage.setItem(
+              inboxLastSeenKey(refreshForPubkey),
+              String(newLastSeen),
+            ).catch(() => {});
+          }
           // A cold rebuild (effectiveSignal undefined) that reached here
           // finished its backlog → claim the full cursor stamp. A WARM
           // productive-but-aborted sweep painted from the DB but did NOT finish
@@ -975,7 +882,6 @@ export function useDmInbox(options: UseDmInboxOptions): UseDmInboxResult {
     dmInboxLoading,
     refreshDmInbox,
     fetchConversation,
-    getCachedConversation,
     loadInitialConversation,
     appendLocalDmMessage,
     persistDeliveryStatuses,

--- a/src/services/dmDb.test.ts
+++ b/src/services/dmDb.test.ts
@@ -17,10 +17,13 @@ jest.mock('./localDb', () => ({
 import {
   selectKnownEventIds,
   upsertDmMessages,
+  importDmMessages,
+  updateDmDeliveryStatuses,
   getConversationMessages,
   getInboxLatest,
   selectDmWrapIds,
   hasStoredWraps,
+  hasConversationWith,
   deleteDmMessagesForOwner,
   type DmMessageRow,
 } from './dmDb';
@@ -77,13 +80,116 @@ describe('dmDb', () => {
       expect(mockTransaction).not.toHaveBeenCalled();
     });
 
-    it('upserts each row in a single transaction with INSERT OR REPLACE', async () => {
+    it('upserts received rows in one transaction, keeping any existing tick (COALESCE)', async () => {
       await upsertDmMessages([row({ eventId: 'e1' }), row({ eventId: 'e2' })]);
       expect(mockTransaction).toHaveBeenCalledTimes(1);
+      // Received (fromMe=false) rows skip the local-echo lookup → one
+      // statement per row.
       expect(mockExecute).toHaveBeenCalledTimes(2);
       const [sql, params] = mockExecute.mock.calls[0];
-      expect(sql).toContain('INSERT OR REPLACE INTO dm_messages');
-      expect(params).toEqual([OWNER, 'e1', 'convA', 100, 's1', 'hi', 0, 14]);
+      expect(sql).toContain('INSERT INTO dm_messages');
+      expect(sql).toContain('ON CONFLICT(owner, event_id) DO UPDATE');
+      expect(sql).toContain('COALESCE(excluded.delivery_status, dm_messages.delivery_status)');
+      expect(sql).toContain('COALESCE(excluded.rumor_id, dm_messages.rumor_id)');
+      expect(params).toEqual([OWNER, 'e1', 'convA', 100, 's1', 'hi', 0, 14, null, null]);
+    });
+
+    it('serialises deliveryStatus / rumorId onto optimistic local- rows (#850)', async () => {
+      const status = { delivered: true, relayResults: { 'wss://r': 'ok' as const } };
+      await upsertDmMessages([
+        row({ eventId: 'local-1', fromMe: true, deliveryStatus: status, rumorId: 'rum1' }),
+      ]);
+      // local- rows never echo-match themselves (the lookup is skipped for
+      // local- ids), so a single INSERT.
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [, params] = mockExecute.mock.calls[0];
+      expect(params[8]).toBe(JSON.stringify(status));
+      expect(params[9]).toBe('rum1');
+    });
+
+    it('retires the matched local- row when its echo lands, inheriting tick + rumorId', async () => {
+      const status = { delivered: true, relayResults: {} };
+      // Echo lookup returns the pending local- row for this send.
+      mockExecute.mockResolvedValueOnce(
+        rowsResult([
+          {
+            event_id: 'local-42',
+            delivery_status: JSON.stringify(status),
+            rumor_id: 'rum42',
+            created_at: 99,
+          },
+        ]),
+      );
+      await upsertDmMessages([row({ eventId: 'wrap42', fromMe: true, createdAt: 100 })]);
+      // SELECT (echo lookup) + DELETE (retire local-) + INSERT (echo row)
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+      const [selectSql, selectParams] = mockExecute.mock.calls[0];
+      expect(selectSql).toContain(`event_id LIKE 'local-%'`);
+      expect(selectSql).toContain('from_me = 1');
+      expect(selectParams).toEqual([OWNER, 'convA', 'hi', 100]);
+      const [deleteSql, deleteParams] = mockExecute.mock.calls[1];
+      expect(deleteSql).toContain('DELETE FROM dm_messages');
+      expect(deleteParams).toEqual([OWNER, 'local-42']);
+      const [, insertParams] = mockExecute.mock.calls[2];
+      expect(insertParams[1]).toBe('wrap42');
+      expect(insertParams[8]).toBe(JSON.stringify(status)); // inherited tick
+      expect(insertParams[9]).toBe('rum42'); // inherited rumorId
+    });
+
+    it('does not retire a local- row outside the echo window', async () => {
+      // Lookup returns nothing (the SQL window filter excluded it) → no DELETE.
+      await upsertDmMessages([row({ eventId: 'wrap43', fromMe: true, createdAt: 100 })]);
+      expect(mockExecute).toHaveBeenCalledTimes(2); // SELECT + INSERT, no DELETE
+    });
+  });
+
+  describe('importDmMessages (blob migration, #850)', () => {
+    it('no-ops on empty input', async () => {
+      await importDmMessages([]);
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('fill-only: the EXISTING row wins; import only supplies a missing tick/rumorId', async () => {
+      const status = { delivered: true, relayResults: {} };
+      await importDmMessages([row({ eventId: 'e1', deliveryStatus: status, rumorId: 'r1' })]);
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockExecute.mock.calls[0];
+      // Reversed COALESCE order vs upsert: dm_messages (existing) first.
+      expect(sql).toContain('COALESCE(dm_messages.delivery_status, excluded.delivery_status)');
+      expect(sql).toContain('COALESCE(dm_messages.rumor_id, excluded.rumor_id)');
+      expect(params[8]).toBe(JSON.stringify(status));
+      expect(params[9]).toBe('r1');
+    });
+  });
+
+  describe('updateDmDeliveryStatuses (#856 tick persist, #850 store-backed)', () => {
+    it('no-ops on an empty map', async () => {
+      await updateDmDeliveryStatuses(OWNER, {});
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('fills only rows without an existing status (delivery_status IS NULL)', async () => {
+      const status = { delivered: true, relayResults: {} };
+      await updateDmDeliveryStatuses(OWNER, { e1: status });
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockExecute.mock.calls[0];
+      expect(sql).toContain('UPDATE dm_messages SET delivery_status = ?');
+      expect(sql).toContain('delivery_status IS NULL');
+      expect(params).toEqual([JSON.stringify(status), OWNER, 'e1']);
+    });
+  });
+
+  describe('hasConversationWith (#850 order-trust check)', () => {
+    it('is true when any row exists for (owner, conversation)', async () => {
+      mockExecute.mockResolvedValueOnce(rowsResult([{ present: 1 }]));
+      expect(await hasConversationWith(OWNER, 'convA')).toBe(true);
+      const [sql, params] = mockExecute.mock.calls[0];
+      expect(sql).toContain('WHERE owner = ? AND conversation = ? LIMIT 1');
+      expect(params).toEqual([OWNER, 'convA']);
+    });
+
+    it('is false when no row exists', async () => {
+      expect(await hasConversationWith(OWNER, 'convZ')).toBe(false);
     });
   });
 
@@ -128,6 +234,43 @@ describe('dmDb', () => {
       expect(sql).toContain('created_at < ?');
       expect(params).toEqual([OWNER, 'convA', 150, 20]);
     });
+
+    it('parses delivery_status JSON + rumor_id off the row; corrupt JSON degrades to none', async () => {
+      const status = { delivered: true, relayResults: {} };
+      mockExecute.mockResolvedValueOnce(
+        rowsResult([
+          {
+            owner: OWNER,
+            event_id: 'sent1',
+            conversation: 'convA',
+            created_at: 300,
+            sender: OWNER,
+            content: 'yo',
+            from_me: 1,
+            wire_kind: 14,
+            delivery_status: JSON.stringify(status),
+            rumor_id: 'rumX',
+          },
+          {
+            owner: OWNER,
+            event_id: 'sent2',
+            conversation: 'convA',
+            created_at: 301,
+            sender: OWNER,
+            content: 'yo2',
+            from_me: 1,
+            wire_kind: 14,
+            delivery_status: '{corrupt',
+            rumor_id: null,
+          },
+        ]),
+      );
+      const out = await getConversationMessages(OWNER, 'convA');
+      expect(out[0].deliveryStatus).toEqual(status);
+      expect(out[0].rumorId).toBe('rumX');
+      expect(out[1].deliveryStatus).toBeUndefined();
+      expect(out[1].rumorId).toBeUndefined();
+    });
   });
 
   describe('getInboxLatest', () => {
@@ -155,12 +298,13 @@ describe('dmDb', () => {
   });
 
   describe('selectDmWrapIds', () => {
-    it('returns NIP-17 wrap ids only (kind-4 rows excluded)', async () => {
+    it('returns NIP-17 wrap ids only (kind-4 + optimistic local- rows excluded)', async () => {
       mockExecute.mockResolvedValueOnce(rowsResult([{ event_id: 'w1' }, { event_id: 'w2' }]));
       const out = await selectDmWrapIds(OWNER);
       expect(out).toEqual(['w1', 'w2']);
       const [sql, params] = mockExecute.mock.calls[0];
       expect(sql).toContain('wire_kind != 4');
+      expect(sql).toContain(`event_id NOT LIKE 'local-%'`);
       expect(params).toEqual([OWNER]);
     });
   });
@@ -173,6 +317,8 @@ describe('dmDb', () => {
       const [sql] = mockExecute.mock.calls[0];
       expect(sql).toContain('LIMIT 1');
       expect(sql).toContain('wire_kind != 4');
+      // A first-ever optimistic send must not fake a completed ingest (#850).
+      expect(sql).toContain(`event_id NOT LIKE 'local-%'`);
     });
   });
 

--- a/src/services/dmDb.test.ts
+++ b/src/services/dmDb.test.ts
@@ -126,7 +126,9 @@ describe('dmDb', () => {
       const [selectSql, selectParams] = mockExecute.mock.calls[0];
       expect(selectSql).toContain(`event_id LIKE 'local-%'`);
       expect(selectSql).toContain('from_me = 1');
-      expect(selectParams).toEqual([OWNER, 'convA', 'hi', 100]);
+      // Sargable window (Copilot #990): BETWEEN, not ABS(created_at - ?).
+      expect(selectSql).toContain('created_at BETWEEN ? - 30 AND ? + 30');
+      expect(selectParams).toEqual([OWNER, 'convA', 'hi', 100, 100]);
       const [deleteSql, deleteParams] = mockExecute.mock.calls[1];
       expect(deleteSql).toContain('DELETE FROM dm_messages');
       expect(deleteParams).toEqual([OWNER, 'local-42']);

--- a/src/services/dmDb.ts
+++ b/src/services/dmDb.ts
@@ -132,12 +132,15 @@ async function upsertOne(tx: Executor, m: DmMessageRow): Promise<void> {
   // then delete the local- row so the store never shows two bubbles for one
   // send. Only sent rows can match (local- rows are always fromMe).
   if (m.fromMe && !m.eventId.startsWith(LOCAL_DM_ID_PREFIX)) {
+    // BETWEEN (not ABS(created_at - ?)) keeps the time-window predicate
+    // sargable, so the (owner, conversation, created_at) index narrows the
+    // scan as the table grows. Same ±LOCAL_DM_ECHO_WINDOW_SECS rule.
     const res = await tx.execute(
       `SELECT event_id, delivery_status, rumor_id, created_at FROM dm_messages
         WHERE owner = ? AND conversation = ? AND from_me = 1 AND content = ?
           AND event_id LIKE '${LOCAL_DM_ID_PREFIX}%'
-          AND ABS(created_at - ?) <= ${LOCAL_DM_ECHO_WINDOW_SECS};`,
-      [m.owner, m.conversation, m.content, m.createdAt],
+          AND created_at BETWEEN ? - ${LOCAL_DM_ECHO_WINDOW_SECS} AND ? + ${LOCAL_DM_ECHO_WINDOW_SECS};`,
+      [m.owner, m.conversation, m.content, m.createdAt, m.createdAt],
     );
     const candidates = res.rows ?? [];
     if (candidates.length > 0) {

--- a/src/services/dmDb.ts
+++ b/src/services/dmDb.ts
@@ -1,3 +1,4 @@
+import type { DeliveryStatus } from '../utils/dmDeliveryStatus';
 import { getLocalDb } from './localDb';
 
 // Data-access layer for the `dm_messages` table in the encrypted local DB
@@ -7,6 +8,13 @@ import { getLocalDb } from './localDb';
 // whole-blob parse + re-decrypt froze the Messages tab for ~52s (see
 // docs/DATA_STORAGE.adoc). All reads are indexed slice reads — never "load
 // the whole inbox into JS".
+//
+// #850: this store is now the ONLY at-rest home for decrypted DM content.
+// The plaintext AsyncStorage blobs (`nostr_dm_conv_v1_*` /
+// `nostr_dm_inbox_v1_*`) are retired; what only they used to carry —
+// deliveryStatus (#856), rumorId (#857) and the optimistic `local-` send
+// rows — lives in the delivery_status / rumor_id columns and in rows whose
+// event_id starts with LOCAL_DM_ID_PREFIX.
 
 export interface DmMessageRow {
   /** Account pubkey this row belongs to — every query is scoped by it. */
@@ -22,22 +30,66 @@ export interface DmMessageRow {
   /** The inner rumor / event kind (NIP-17 text = 14, file = 15, legacy NIP-04
    * = 4). Load-bearing: the inbox NIP-04/NIP-17 dedup keys on it. */
   wireKind: number;
+  /** Per-relay delivery breakdown for our own sent rows (#856). Persisted so
+   * the tick survives a cold restart without any plaintext side blob. */
+  deliveryStatus?: DeliveryStatus;
+  /** NIP-17 inner-rumor event id (#857) — the delivery-store key, stable
+   * across the optimistic local- row and the relay echo. Sent rows only. */
+  rumorId?: string;
 }
+
+/** Prefix of the optimistic send rows ConversationScreen appends before the
+ * relay echo lands. Kept as first-class rows (#850) so a send survives a cold
+ * restart; `upsertDmMessages` retires them when their echo arrives. */
+export const LOCAL_DM_ID_PREFIX = 'local-';
+
+/** Window in seconds to match a real-id echo against a pending optimistic
+ * local- row (same fromMe + same text). Single source of truth for both the
+ * in-memory merge (nostrDmCache) and the store-level echo retire below. */
+export const LOCAL_DM_ECHO_WINDOW_SECS = 30;
 
 // SQLite caps bound variables per statement (historically 999). Chunk IN()
 // lists well under that.
 const VAR_CHUNK = 500;
 
-const toRow = (r: Record<string, unknown>): DmMessageRow => ({
-  owner: String(r.owner),
-  eventId: String(r.event_id),
-  conversation: String(r.conversation),
-  createdAt: Number(r.created_at),
-  sender: String(r.sender),
-  content: String(r.content),
-  fromMe: Number(r.from_me) === 1,
-  wireKind: Number(r.wire_kind),
-});
+const parseDeliveryStatus = (raw: unknown): DeliveryStatus | undefined => {
+  if (typeof raw !== 'string' || raw.length === 0) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as DeliveryStatus;
+    }
+  } catch {
+    // Corrupt JSON → treat as no status (tick simply doesn't render).
+  }
+  return undefined;
+};
+
+const serializeDeliveryStatus = (s: DeliveryStatus | undefined): string | null => {
+  if (!s) return null;
+  try {
+    return JSON.stringify(s);
+  } catch {
+    return null;
+  }
+};
+
+const toRow = (r: Record<string, unknown>): DmMessageRow => {
+  const deliveryStatus = parseDeliveryStatus(r.delivery_status);
+  const rumorId = typeof r.rumor_id === 'string' && r.rumor_id.length > 0 ? r.rumor_id : undefined;
+  return {
+    owner: String(r.owner),
+    eventId: String(r.event_id),
+    conversation: String(r.conversation),
+    createdAt: Number(r.created_at),
+    sender: String(r.sender),
+    content: String(r.content),
+    fromMe: Number(r.from_me) === 1,
+    wireKind: Number(r.wire_kind),
+    ...(deliveryStatus !== undefined ? { deliveryStatus } : {}),
+    ...(rumorId !== undefined ? { rumorId } : {}),
+  };
+};
 
 /**
  * Of the given event ids, which are already stored for this owner. This is
@@ -60,20 +112,117 @@ export async function selectKnownEventIds(owner: string, eventIds: string[]): Pr
   return known;
 }
 
+// Minimal shape shared by the DB handle and a transaction context — both
+// expose `execute`, which is all the upsert body needs.
+type Executor = {
+  execute: (
+    sql: string,
+    params?: (string | number | null)[],
+  ) => Promise<{
+    rows?: Record<string, unknown>[];
+  }>;
+};
+
+async function upsertOne(tx: Executor, m: DmMessageRow): Promise<void> {
+  let deliveryStatus = m.deliveryStatus;
+  let rumorId = m.rumorId;
+  // Echo retire (#850, mirrors mergeConversationMessages): a real-id row we
+  // authored replaces its pending optimistic local- row — inherit the local-
+  // row's delivery tick (#856) + rumorId (#857) when the echo lacks its own,
+  // then delete the local- row so the store never shows two bubbles for one
+  // send. Only sent rows can match (local- rows are always fromMe).
+  if (m.fromMe && !m.eventId.startsWith(LOCAL_DM_ID_PREFIX)) {
+    const res = await tx.execute(
+      `SELECT event_id, delivery_status, rumor_id, created_at FROM dm_messages
+        WHERE owner = ? AND conversation = ? AND from_me = 1 AND content = ?
+          AND event_id LIKE '${LOCAL_DM_ID_PREFIX}%'
+          AND ABS(created_at - ?) <= ${LOCAL_DM_ECHO_WINDOW_SECS};`,
+      [m.owner, m.conversation, m.content, m.createdAt],
+    );
+    const candidates = res.rows ?? [];
+    if (candidates.length > 0) {
+      // Closest-in-time match wins, mirroring the in-memory merge.
+      const best = candidates.reduce((a, b) =>
+        Math.abs(Number(a.created_at) - m.createdAt) <= Math.abs(Number(b.created_at) - m.createdAt)
+          ? a
+          : b,
+      );
+      deliveryStatus = deliveryStatus ?? parseDeliveryStatus(best.delivery_status);
+      rumorId =
+        rumorId ??
+        (typeof best.rumor_id === 'string' && best.rumor_id.length > 0 ? best.rumor_id : undefined);
+      await tx.execute(`DELETE FROM dm_messages WHERE owner = ? AND event_id = ?;`, [
+        m.owner,
+        String(best.event_id),
+      ]);
+    }
+  }
+  // COALESCE keeps an existing tick/rumorId when a later re-ingest of the
+  // same event id supplies neither (#856/#857: a warm relay re-decrypt of an
+  // already-ticked echo must not strip the tick).
+  await tx.execute(
+    `INSERT INTO dm_messages
+       (owner, event_id, conversation, created_at, sender, content, from_me, wire_kind,
+        delivery_status, rumor_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(owner, event_id) DO UPDATE SET
+       conversation    = excluded.conversation,
+       created_at      = excluded.created_at,
+       sender          = excluded.sender,
+       content         = excluded.content,
+       from_me         = excluded.from_me,
+       wire_kind       = excluded.wire_kind,
+       delivery_status = COALESCE(excluded.delivery_status, dm_messages.delivery_status),
+       rumor_id        = COALESCE(excluded.rumor_id, dm_messages.rumor_id);`,
+    [
+      m.owner,
+      m.eventId,
+      m.conversation,
+      m.createdAt,
+      m.sender,
+      m.content,
+      m.fromMe ? 1 : 0,
+      m.wireKind,
+      serializeDeliveryStatus(deliveryStatus),
+      rumorId ?? null,
+    ],
+  );
+}
+
 /**
- * Upsert decrypted messages. Idempotent by (owner, event_id) (INSERT OR
- * REPLACE) and batched in one transaction so a large first-sync is a single
- * commit, not N.
+ * Upsert decrypted messages. Idempotent by (owner, event_id) and batched in
+ * one transaction so a large first-sync is a single commit, not N. Retires
+ * matched optimistic local- rows (see `upsertOne`) and never downgrades an
+ * existing delivery tick / rumorId to NULL.
  */
 export async function upsertDmMessages(rows: readonly DmMessageRow[]): Promise<void> {
   if (rows.length === 0) return;
   const db = await getLocalDb();
   await db.transaction(async (tx) => {
+    for (const m of rows) await upsertOne(tx as Executor, m);
+  });
+}
+
+/**
+ * Import rows without clobbering anything already stored (#850 blob
+ * migration): an existing row's content/metadata always wins; the import only
+ * fills a missing delivery_status / rumor_id (the two fields the retired
+ * plaintext conversation blobs were the sole carrier of). New ids insert
+ * whole. One transaction.
+ */
+export async function importDmMessages(rows: readonly DmMessageRow[]): Promise<void> {
+  if (rows.length === 0) return;
+  const db = await getLocalDb();
+  await db.transaction(async (tx) => {
     for (const m of rows) {
       await tx.execute(
-        `INSERT OR REPLACE INTO dm_messages
-           (owner, event_id, conversation, created_at, sender, content, from_me, wire_kind)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
+        `INSERT INTO dm_messages
+           (owner, event_id, conversation, created_at, sender, content, from_me, wire_kind,
+            delivery_status, rumor_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(owner, event_id) DO UPDATE SET
+           delivery_status = COALESCE(dm_messages.delivery_status, excluded.delivery_status),
+           rumor_id        = COALESCE(dm_messages.rumor_id, excluded.rumor_id);`,
         [
           m.owner,
           m.eventId,
@@ -83,7 +232,35 @@ export async function upsertDmMessages(rows: readonly DmMessageRow[]): Promise<v
           m.content,
           m.fromMe ? 1 : 0,
           m.wireKind,
+          serializeDeliveryStatus(m.deliveryStatus),
+          m.rumorId ?? null,
         ],
+      );
+    }
+  });
+}
+
+/**
+ * Attach delivery statuses (#856) to stored rows by event id, filling only
+ * rows that don't already carry one — mirrors the old persisted-blob rule
+ * ("only write when it adds a tick") so a settled breakdown is never
+ * overwritten by a later, thinner snapshot.
+ */
+export async function updateDmDeliveryStatuses(
+  owner: string,
+  statusById: Record<string, DeliveryStatus>,
+): Promise<void> {
+  const entries = Object.entries(statusById);
+  if (entries.length === 0) return;
+  const db = await getLocalDb();
+  await db.transaction(async (tx) => {
+    for (const [eventId, status] of entries) {
+      const serialized = serializeDeliveryStatus(status);
+      if (!serialized) continue;
+      await tx.execute(
+        `UPDATE dm_messages SET delivery_status = ?
+          WHERE owner = ? AND event_id = ? AND delivery_status IS NULL;`,
+        [serialized, owner, eventId],
       );
     }
   });
@@ -135,15 +312,31 @@ export async function getInboxLatest(owner: string): Promise<DmMessageRow[]> {
 }
 
 /**
+ * Whether this owner has ANY stored message for `conversation` — the
+ * live-sub's "is this marketplace partner already a conversation?" trust
+ * check (#850; replaces scanning the retired plaintext inbox blob).
+ */
+export async function hasConversationWith(owner: string, conversation: string): Promise<boolean> {
+  const db = await getLocalDb();
+  const res = await db.execute(
+    `SELECT 1 AS present FROM dm_messages WHERE owner = ? AND conversation = ? LIMIT 1;`,
+    [owner, conversation],
+  );
+  return (res.rows ?? []).length > 0;
+}
+
+/**
  * All stored NIP-17 wrap ids for this owner (kind-4 rows excluded — their ids
- * are kind-4 event ids, not wrap ids). Seeds the live-DM sub's in-memory
- * dedup Set so a relay backlog re-stream short-circuits without re-decrypting
- * (#505/#848). Ids only — no plaintext leaves the DB here.
+ * are kind-4 event ids, not wrap ids; optimistic local- rows excluded — their
+ * ids are synthetic, never relay-delivered). Seeds the live-DM sub's
+ * in-memory dedup Set so a relay backlog re-stream short-circuits without
+ * re-decrypting (#505/#848). Ids only — no plaintext leaves the DB here.
  */
 export async function selectDmWrapIds(owner: string): Promise<string[]> {
   const db = await getLocalDb();
   const res = await db.execute(
-    `SELECT event_id FROM dm_messages WHERE owner = ? AND wire_kind != 4;`,
+    `SELECT event_id FROM dm_messages
+      WHERE owner = ? AND wire_kind != 4 AND event_id NOT LIKE '${LOCAL_DM_ID_PREFIX}%';`,
     [owner],
   );
   return (res.rows ?? []).map((r) => String(r.event_id));
@@ -154,11 +347,14 @@ export async function selectDmWrapIds(owner: string): Promise<string[]> {
  * ingest has run before. Thread opens use this to decide whether the
  * inbox-wide relay wrap fetch can be skipped (the DB already memoises every
  * decrypted wrap), mirroring the old "cache has any entries" fast path (#190).
+ * Optimistic local- rows don't count — a first-ever send must not fake a
+ * completed ingest (#850).
  */
 export async function hasStoredWraps(owner: string): Promise<boolean> {
   const db = await getLocalDb();
   const res = await db.execute(
-    `SELECT 1 AS present FROM dm_messages WHERE owner = ? AND wire_kind != 4 LIMIT 1;`,
+    `SELECT 1 AS present FROM dm_messages
+      WHERE owner = ? AND wire_kind != 4 AND event_id NOT LIKE '${LOCAL_DM_ID_PREFIX}%' LIMIT 1;`,
     [owner],
   );
   return (res.rows ?? []).length > 0;

--- a/src/services/localDb.ts
+++ b/src/services/localDb.ts
@@ -8,27 +8,49 @@ import { getOrCreateLocalDbKey, clearLocalDbKey } from './localDbKey';
 // One DB, indexed rows: DM messages (private) plus public cached events.
 const DB_NAME = 'lightningpiggy.db';
 
-// Schema v2 (#848). One row per decrypted DM event, scoped by `owner` (the
-// signed-in account's pubkey): multi-account devices share one DB file, and a
-// kind-4 DM between two local accounts is the SAME event id seen by both — so
-// the primary key is (owner, event_id), not event_id alone. Indexed by
-// (owner, conversation, created_at) for paginated slice reads — the whole
-// point of moving off the single-blob cache that froze the Messages tab
+// Schema v3 (#848, extended by #850). One row per decrypted DM event, scoped
+// by `owner` (the signed-in account's pubkey): multi-account devices share one
+// DB file, and a kind-4 DM between two local accounts is the SAME event id
+// seen by both — so the primary key is (owner, event_id), not event_id alone.
+// Indexed by (owner, conversation, created_at) for paginated slice reads — the
+// whole point of moving off the single-blob cache that froze the Messages tab
 // (#695). Public cache tables (caches/events/places) land in a later slice.
+//
+// #850 columns — everything the retired plaintext AsyncStorage blobs
+// (`nostr_dm_conv_v1_*` / `nostr_dm_inbox_v1_*`) were previously the only
+// home for, so conversations + inbox now serve PURELY from this store:
+//   delivery_status — JSON-serialised DeliveryStatus (#856) for our own sent
+//                     rows (per-relay tick breakdown). NULL on received rows.
+//   rumor_id        — NIP-17 inner-rumor event id (#857), stable across the
+//                     optimistic local- row and the relay echo; keys the
+//                     delivery-status store. NULL on received / legacy rows.
+// Optimistic sends persist as rows whose event_id starts with 'local-' until
+// the relay echo replaces them (upsertDmMessages deletes the matched local-
+// row and carries its delivery_status / rumor_id onto the echo row).
 const SCHEMA: string[] = [
   `CREATE TABLE IF NOT EXISTS dm_messages (
-     owner        TEXT NOT NULL,
-     event_id     TEXT NOT NULL,
-     conversation TEXT NOT NULL,
-     created_at   INTEGER NOT NULL,
-     sender       TEXT NOT NULL,
-     content      TEXT NOT NULL,
-     from_me      INTEGER NOT NULL DEFAULT 0,
-     wire_kind    INTEGER NOT NULL DEFAULT 14,
+     owner           TEXT NOT NULL,
+     event_id        TEXT NOT NULL,
+     conversation    TEXT NOT NULL,
+     created_at      INTEGER NOT NULL,
+     sender          TEXT NOT NULL,
+     content         TEXT NOT NULL,
+     from_me         INTEGER NOT NULL DEFAULT 0,
+     wire_kind       INTEGER NOT NULL DEFAULT 14,
+     delivery_status TEXT,
+     rumor_id        TEXT,
      PRIMARY KEY (owner, event_id)
    );`,
   `CREATE INDEX IF NOT EXISTS idx_dm_owner_conversation_created
      ON dm_messages (owner, conversation, created_at DESC);`,
+];
+
+// Columns added after the v2 table shipped (#850). SQLite supports in-place
+// ADD COLUMN, so an existing install's table upgrades without a rebuild —
+// its rows (the decrypt-once memo) are preserved.
+const ADDED_COLUMNS: readonly { name: string; ddl: string }[] = [
+  { name: 'delivery_status', ddl: 'ALTER TABLE dm_messages ADD COLUMN delivery_status TEXT;' },
+  { name: 'rumor_id', ddl: 'ALTER TABLE dm_messages ADD COLUMN rumor_id TEXT;' },
 ];
 
 let dbPromise: Promise<DB> | null = null;
@@ -85,7 +107,19 @@ async function openLocalDbAttempt(): Promise<DB> {
   }
   await rebuildDmMessagesIfPreOwner(db);
   for (const stmt of SCHEMA) await db.execute(stmt);
+  await addMissingDmMessagesColumns(db);
   return db;
+}
+
+// v2 → v3 (#850): add the delivery_status / rumor_id columns to a table
+// created before they existed. CREATE TABLE IF NOT EXISTS is a no-op on an
+// existing table, so the SCHEMA pass alone doesn't add them.
+async function addMissingDmMessagesColumns(db: DB): Promise<void> {
+  const info = await db.execute('PRAGMA table_info(dm_messages);');
+  const have = new Set((info.rows ?? []).map((c) => String(c.name)));
+  for (const col of ADDED_COLUMNS) {
+    if (!have.has(col.name)) await db.execute(col.ddl);
+  }
 }
 
 // Schema v1 (pre-#848) had no `owner` column and keyed rows by event_id alone.


### PR DESCRIPTION
## Summary

Closes the at-rest data-privacy story for 1:1 DMs. The SQLCipher store (#848) already held decrypted DMs encrypted — but the app was **still writing the same plaintext to unencrypted AsyncStorage on every message**: full conversations (`nostr_dm_conv_v1_*`, up to 500 messages / 1.5 MB per peer) and inbox previews (`nostr_dm_inbox_v1_*`). This PR retires those blobs: the encrypted store becomes the **only** at-rest home for DM content, a one-shot verified migration moves existing installs' blobs into it, and the docs now accurately describe what is stored where.

### Threat model (device seizure)

Designed against: **the user's phone is seized (e.g. border control) and forensically imaged.**

- **After this PR**, every 1:1 DM ever decrypted — content, delivery ticks, optimistic unsent rows — exists on disk only inside `lightningpiggy.db`, which is SQLCipher ciphertext (content *and* metadata). Imaging the flash yields ciphertext.
- **The key is adequately protected**: 256-bit CSPRNG key held only in the hardware keystore (`expo-secure-store`, `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY` — excluded from backups and device migration, so a backup-restore ships an unopenable ciphertext file, which the app detects and heals by re-syncing from relays). Every DB open asserts `PRAGMA cipher_version` and refuses a plaintext fallback.
- **Known residual (documented, not regressed):** decrypted *group-chat* logs (`group_messages_<groupId>`, `nostr_group_activity_<pubkey>`) remain in AsyncStorage — wiped on logout (#944), but readable from a seized *unlocked* device until they get the same encrypted-store treatment (follow-up). Compelled device unlock is out of scope at the app layer; an app-lock gating the DB-key read + panic-wipe are noted as follow-ups in `docs/DATA_STORAGE.adoc`.

### What moved into the encrypted store

- `dm_messages` gains `delivery_status` (JSON, #856 per-relay tick) and `rumor_id` (#857 delivery-store key) columns — in-place `ALTER TABLE` for existing installs — and now persists the **optimistic `local-` send rows** as first-class rows. These three things were previously *only* carried by the plaintext conversation blob.
- `upsertDmMessages` retires a matched `local-` row when its relay echo lands (same fromMe + text + 30 s window as the in-memory merge), inheriting its tick + rumorId; `COALESCE` upserts never strip an existing tick. A read-side `dedupeLocalEchoes` covers the append/echo race.
- **Every read surface serves purely from `dmDb`**: `refreshDmInbox`, `hydrateDmInboxFromCache`, `fetchConversation`, `loadInitialConversation`, the live DM sub, and the delivery-status persist (`updateDmDeliveryStatuses`). Zero plaintext content writes to AsyncStorage remain — only bare-timestamp `*_last_seen_*` cursors (regression-tested).

### Migration (one-shot, verified — #848 pattern)

`dmBlobMigration` runs from every DM entry point (memoised, single-flighted per account) under the strict `dmStoreMigration` ordering: **populate → delete → verify → flag**. The import is *fill-only* (`importDmMessages`): an existing encrypted row always wins; the blobs only supply rows the store lacks (e.g. pre-#848 kind-4 threads) plus missing tick/rumor columns and `local-` rows. Plaintext is never deleted before the DB holds the rows, and the flag is never set while plaintext survives — a crash anywhere retries next launch.

### #850 sub-nits addressed

- **N5** — live kind-4 store failure now *throws* in the write chain (aligned with the kind-1059 path), so the `lastSeen` cursor is not advanced past an unpersisted message.
- **N6** — thread-open kind-4 decrypts gain the DB known-id gate (`selectKnownEventIds`), and the perf counters no longer double-count store rows as cache hits.
- **N7** — a failing migration now backs off 60 s between retries instead of re-running the populate on every DM entry point.
- **N9** — pre-#288 *unsuffixed* `nsec_nip17_cache_v1` / `amber_nip17_cache_v1` rows **and** files are deleted by the migration and by every wipe path (delete-only: an unowned cache can't be attributed on a multi-account device; content is re-fetchable from relays).

### Wipe paths (strengthened, never weakened)

`wipeAccountCaches` / `wipeDmStoresForAccount` additionally remove the new blob-migration flag and the unsuffixed legacy keys/files. All existing wipes (per-owner DB rows, last-identity DB-file + keystore-key deletion, conv/inbox blob removal) are untouched.

### Docs updated

- `docs/DATA_STORAGE.adoc` — storage-layer table corrected (DM blobs retired; group chat flagged as the residual), new **"Threat model: device seizure"** section, migration section + diagrams extended with the #850 blob migration, `dm_messages` schema updated.
- `docs/SECURITY.adoc` — the stale "Decrypted DM Plaintext at Rest" analysis (which recommended exactly this encrypt-at-rest outcome) replaced with **"Message Content at Rest (Threat Model)"** describing the post-#850 reality, the seized-device model, the group-chat residual, and rules for new code.

### Evidence

- Full suite: **146 suites / 1,675 tests pass**; `tsc --noEmit`, ESLint (0 errors), Prettier, `scripts/check-file-size.sh` all green.
- New regression test pins the core invariant: a full successful `fetchConversation` run performs **no AsyncStorage write other than the last-seen cursor**, and the decrypted plaintext never appears in any written value (`nostrFetchConversationAbort.test.ts` → "never writes decrypted plaintext to AsyncStorage (#850 at-rest invariant)").
- Migration correctness: `dmBlobMigration.test.ts` (import incl. ticks/rumor/local- rows, populate-failure leaves plaintext + flag intact, per-account scoping, N9 deletion) + `dmStoreMigrationRunner.test.ts` (both migrations wired, N7 backoff).
- Store round-trip: `dmDb.test.ts` (echo retire + inheritance, COALESCE no-downgrade, fill-only import, delivery-status fill, local- exclusion from wrap-id seeding).

### On-device validation (iOS Simulator — PASS)

Validated on a **signed** Release build (iPhone 17 Pro, iOS 26.2), signed in as a real account with DM history:

- **Login** succeeded → SecureStore works (definitive proof the DB key path is intact).
- **Inbox loaded from the encrypted store** — 5 conversations with last-message previews (incl. an "Order Placed · 21 sats" card); **thread history** rendered in chronological order with delivery ticks and date separators.
- **Send** — an outgoing DM appeared with the optimistic bubble → **double-tick delivery**, persisted to the encrypted store.
- **Migration clean** — both flags (`dm_store_migrated_v1_*`, `dm_blob_migrated_v1_*`) set after the full `populate → delete → verify → flag` sequence; **zero** plaintext DM content keys remain in AsyncStorage (only benign `*_last_seen_v1_*` cursors), no plaintext wrap-cache files.
- **Encrypted at rest, independently confirmed** — `lightningpiggy.db` is SQLCipher ciphertext (random header, `sqlite3` reports "not a database", `strings` finds zero message plaintext).
- No red-box / SQLCipher / unhandled-rejection errors in the native console.

Caveat: this was a fresh install, so no *legacy* plaintext blob existed to physically move — the on-device run exercised the already-clean path (flags set, nothing to import). The real populate-from-plaintext data movement is covered by the migration unit tests above.

## Test plan for QA

1. **Upgrade path (the migration):** On a device with an existing install that has DM history, update to this build and open the Messages tab. Expect the full history to appear as before (previews + threads + sent-message ticks). In logcat, expect one-time lines `[DmStore] blob migration: imported N …` and `blob migration complete … deleted (verified)`.
2. **No plaintext at rest:** After step 1, dump AsyncStorage: `adb shell "run-as com.lightningpiggy.app.dev sqlite3 /data/data/com.lightningpiggy.app.dev/databases/RKStorage \"SELECT key FROM catalystLocalStorage WHERE key LIKE 'nostr_dm_%' OR key LIKE '%nip17_cache%';\""` — expect **only** `*_last_seen_*` keys (timestamps); no `nostr_dm_inbox_v1_*`, no `nostr_dm_conv_v1_*`, no wrap-cache keys. Also confirm no `nsec_nip17_cache_v1*.json` / `amber_nip17_cache_v1*.json` under the app's documents dir.
3. **Send + tick survives restart:** Send a DM, see the optimistic bubble then the delivery tick; force-stop the app; reopen the thread — one bubble (no duplicate), tick still present.
4. **Receive live:** With the app open on Messages, have a peer send a DM — it appears live and (from another surface) raises a notification. Re-run step 2: still no plaintext keys.
5. **Read-only reopen:** Airplane mode → open the app → Messages tab and a thread paint fully from the encrypted store (no relays needed).
6. **Logout wipe:** Log out of the (last) account; confirm `lightningpiggy.db` is gone (`run-as … ls databases/`) and step 2's query returns nothing for the old pubkey.
7. **Marketplace order (kind-16/17):** Receive an order event from a market you have an existing conversation with → notification fires; from a stranger → stored + shown in-app, no notification.

Fixes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdYLRTPracfFdRGsbbLB1n

