### PR TITLE
chore(release): v1.3.13

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,21 +14,19 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
-- **Background message notifications (Android).** Turn on Account → Security → "Watch for messages in the background" and you'll get notified of new direct messages even when the app is closed or swiped away — no Google services needed. Only notifies for people you follow.
-- **Choose your language.** Account → Appearance → Language now lets you pick Spanish or follow your device language. The bottom tab labels are translated so far; more screens follow.
-- **Shop orders show as cards in your chats.** An order or receipt from a merchant now shows the item count, total in sats, and status — not raw text.
-- **Pay an order in a tap.** Order cards have a Pay button and a QR code to pay the invoice from the chat, or scan it with another wallet.
-- **Get notified when someone finds your Piglet.** Cache owners now get a notification when a finder logs a find on their cache.
-- **Publish a cache with no prize.** You can now publish a geo-cache without attaching a Lightning reward.
-- **See your swap on-chain.** Boltz swap details now link out to the mempool.space block explorer so you can follow confirmations.
-
-### Fixed
-
-- Typing fast into the Send address field no longer drops or duplicates characters.
+- **Receive on-chain, land as Lightning.** Send Bitcoin to your on-chain address and the app swaps it to Lightning for you automatically (via a Boltz submarine swap) — no manual steps.
+- **A celebration when on-chain money lands.** Incoming on-chain payments now show a full-screen celebration overlay, the same as Lightning payments.
+- **Watch your transfer happen.** Sending a payment now replaces the form with a step-by-step progress display so you can see each stage.
+- **React to and zap individual messages.** Long-press any message in a chat to add a reaction or send it a zap.
+- **Full Spanish app.** Switch to Spanish (Account → Appearance → Language) and the whole app is translated, not just the tab labels.
+- **Pick where a received payment lands.** When creating an invoice you can now choose any of your wallets as the destination.
 
 ### Improved
 
-- Transaction history now scrolls smoothly through long histories instead of a "show all" button.
-- Boltz swaps are hardened: the app verifies what the swap server returns before paying, and recovers stuck on-chain→Lightning swaps after a crash.
-- Faster Messages tab load; smoother pink→purple theme accents.
-- Fixed the amount keypad's "0" key being hidden behind the Android navigation bar.
+- Monogram tab backgrounds on Messages, Friends and Explore for a more branded look.
+- Smoother pink→purple brand fade behind the wallet card on Home.
+
+### Fixed
+
+- Logging out now wipes group-chat message text and the places cache from the device; removing a wallet clears its cached data.
+- Pasting or typing into the Send address / memo fields no longer drops or duplicates characters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Summary

Cuts the **v1.3.13** release. Bumps the marketing version (1.3.12 → 1.3.13, single source of truth in `package.json`, flows into `app.config.ts`) and refreshes `docs/RELEASE_NOTES_NEXT.md` with the tester-facing "What to Test" notes.

Once merged, publishing the `v1.3.13` GitHub Release (targeting main) fires `.github/workflows/release.yml` → EAS cloud builds for both platforms, iOS auto-submit to TestFlight, Android APK attached to the Release.

## What shipped since v1.3.12

On-chain → Lightning receive via Boltz submarine swap (#289), full-screen celebration overlay for incoming on-chain payments (#331), step-by-step transfer progress display (#343), long-press to react + zap individual messages (#326), full Spanish (es) translation across the app (#971), pick any wallet as the invoice destination (#973), logout/privacy wipe of group-chat plaintext + places cache (#944), monogram tab backgrounds (#966) and pink→purple home fade (#965), send-field keystroke fix (#951), plus README + Architecture docs (#956, #983).

## Why no screenshot

Version-bump + release-notes only; no UI change in this PR.

## Test plan

N/A — version bump and release-notes update only. The features it releases were each tested and reviewed in their own PRs. The release build itself is validated by the EAS cloud pipeline on publish.