### PR TITLE
chore(release): v1.3.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.12",
+  "version": "1.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.12",
+      "version": "1.3.14",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Marketing-version bump to **v1.3.14** for the next release.

## What's in v1.3.14 (18 PRs merged since v1.3.13)

**Features**
- Share NWC wallets in DMs (#988)
- NIP-46 Nostr Connect external signer — Clave / Aegis / nsec.app (#284)
- Structured NIP-88 polls, gift-wrapped in NIP-17 DMs (#327)
- Full Ukrainian (uk) translation (#979)
- 4 sports-themed wallet card designs — tennis / football / basketball / F1 (#342)
- Delete a Piglet (expiry-to-today + kind-5) (#985)
- Rename user-facing "Transfer" → "Move" (#980)

**Fixes & perf**
- Pull-to-refresh no longer blocks ~90s on profiles (#987)
- Modals edge-to-edge behind gesture nav bar (#984)
- Retire plaintext DM blobs into the encrypted store (#990)
- Monogram tab backgrounds visible on-device (#998)
- Keep "Zap message" input above the keyboard (#423)
- Keep live DM delivery alive on drop/resume (#986)
- Only alert on funded-unrecoverable swaps (#994)
- Friends scroll perf (#832); live-DM latency + startup perf (#989)
- expo 55.0.27 + worklets 0.7.4 bump (#974)

## Test plan for QA
- [x] `npx tsc --noEmit`, ESLint, Prettier (version-only change)
- Version label (drawer/About) reads 1.3.14 after the release build; `versionCode`/`buildNumber` auto-increment on EAS.

Once merged, a GitHub Release `v1.3.14` targeting this commit kicks off the EAS cloud builds (iOS → TestFlight, Android APK attached).