### PR TITLE
chore(release): v1.3.16

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,19 +14,17 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
-- **Receive on-chain, land as Lightning.** Send Bitcoin to your on-chain address and the app swaps it to Lightning for you automatically (via a Boltz submarine swap) — no manual steps.
-- **A celebration when on-chain money lands.** Incoming on-chain payments now show a full-screen celebration overlay, the same as Lightning payments.
-- **Watch your transfer happen.** Sending a payment now replaces the form with a step-by-step progress display so you can see each stage.
-- **React to and zap individual messages.** Long-press any message in a chat to add a reaction or send it a zap.
-- **Full Spanish app.** Switch to Spanish (Account → Appearance → Language) and the whole app is translated, not just the tab labels.
-- **Pick where a received payment lands.** When creating an invoice you can now choose any of your wallets as the destination.
+- **Hunt community sections.** The Geo-caches screen now shows "Recently added" and "Recently found" rails, plus a Leaderboard page (top hiders and top finders) — Explore → Geo-caches → scroll down.
+- **Cover-flow card picker.** Wallet Settings → Card Design is now a swipeable cover-flow of all card themes.
+- **AI Robot wallet card.** A new chrome-and-green robot design in the card picker.
 
 ### Improved
 
-- Monogram tab backgrounds on Messages, Friends and Explore for a more branded look.
-- Smoother pink→purple brand fade behind the wallet card on Home.
+- Settings screens (Security, On-chain, Nearby merchants) now use white section icons and brand-pink toggles and selected rows.
+- Home feels snappier — wallet refreshes that change nothing no longer rebuild the transaction list.
+- Explore map pans more smoothly (marker layers no longer re-render on every GPS fix).
 
 ### Fixed
 
-- Logging out now wipes group-chat message text and the places cache from the device; removing a wallet clears its cached data.
-- Pasting or typing into the Send address / memo fields no longer drops or duplicates characters.
+- Tapping a sent group message no longer shows a false "Send failed" dialog — delivered messages now read "Message sent".
+- Geo-caches hidden in Lightning Piggy now always show the Piglet icon and pink map pin, even when they have no prize attached (existing caches fix themselves, no republish needed).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.14",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.14",
+      "version": "1.3.16",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.14",
+  "version": "1.3.16",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Release prep for v1.3.16: version bump + What-to-Test notes (the notes file still carried v1.3.13-era content — the v1.3.15 reset never merged — so it's been rewritten for what actually ships in this release).

Release contents since v1.3.15: hunt community rails + leaderboard page (#1001), cover-flow card picker (#975), AI robot card (#999), settings icon/toggle restyle (#1004), group "Send failed" info-sheet fix (#1023), Piglet client-tag classification (#1026), Home/Explore perf (#1017, #1019, #1018).

No linked issue — release chore (matches #1000, #991, #963).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6Z2rpoHvJeiXw5beozBUa

## Test plan

N/A — release chore (version bump + What-to-Test notes). The release workflow validates the tag → package.json flow; app changes were tested in their own PRs.
