### PR TITLE
perf(resume): stagger the post-resume cache refetch so taps stay responsive (#554)

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -28,3 +28,4 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 - Tapping a sent group message no longer shows a false "Send failed" dialog — delivered messages now read "Message sent".
 - Geo-caches hidden in Lightning Piggy now always show the Piglet icon and pink map pin, even when they have no prize attached (existing caches fix themselves, no republish needed).
+- The app responds to taps immediately after waking from a long background pause.

--- a/src/contexts/useCacheNotifications.test.ts
+++ b/src/contexts/useCacheNotifications.test.ts
@@ -1,7 +1,8 @@
 /**
  * Unit tests for the foreground cache-activity notification hook.
  *
- * Pins the two behaviours Copilot flagged on #760:
+ * Pins the behaviours Copilot flagged on #760 and the resume-burst stagger
+ * fix from #554:
  *
  *   1. Distinct notification copy per surface — a kind-7516 found-log
  *      says "New find on your cache" and fans out on the in-app event
@@ -12,6 +13,10 @@
  *      historical replay a relay sends for a *later* re-subscribe (coord
  *      set changed mid-session) can't slip past the gate and fire stale
  *      notifications.
+ *   3. Resume-burst stagger (#554): on AppState → active the coord refetch
+ *      is delayed by RESUME_REFETCH_DELAY_MS (3 s) so it doesn't compete
+ *      with latency-sensitive work (DM re-arm, wallet refresh) on the JS
+ *      thread. Timer is cancelled by backgrounding and by unmount.
  */
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { AppState } from 'react-native';
@@ -86,9 +91,18 @@ function makeEvent(
   } as VerifiedEvent;
 }
 
+// Base wall-clock the fake-timer epoch is anchored to. A large value keeps
+// the created_at arithmetic in the freshness-gate tests positive and avoids
+// divide-by-zero / negative-timestamp edge cases in surrounding hook maths.
+const FAKE_NOW_BASE = 1_000_000_000_000;
+
 beforeEach(() => {
   jest.clearAllMocks();
-  jest.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000);
+  // Install fake timers and advance Date.now() together — `now` seeds
+  // the epoch so that jest.advanceTimersByTime(N) also moves Date.now()
+  // forward by N ms. This is required for the REFETCH_MIN_GAP_MS throttle
+  // (which calls Date.now() internally) to be controllable from tests (#554).
+  jest.useFakeTimers({ now: FAKE_NOW_BASE });
   // Spy AppState.addEventListener so the tests can read `.mock.calls` (the
   // hook registers a 'change' listener) and get back a real subscription
   // shape. Without this it's a real RN function and `.mock` is undefined
@@ -101,7 +115,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  (Date.now as jest.Mock).mockRestore?.();
+  jest.useRealTimers();
   (AppState.addEventListener as jest.Mock).mockRestore?.();
 });
 
@@ -156,9 +170,11 @@ describe('useCacheNotifications', () => {
   });
 
   it('re-baselines the freshness gate on re-arm so pre-resubscribe replay stays silent', async () => {
-    // First arm at T0 with coord A only.
+    // First arm at T0 with coord A only. Use setSystemTime to move the fake
+    // timer epoch — fake timers control Date.now() via jest.useFakeTimers({ now })
+    // so we must use setSystemTime (not spyOn) to shift it (#554 test refactor).
     const t0 = 1_000_000_000; // seconds
-    (Date.now as jest.Mock).mockReturnValue(t0 * 1000);
+    jest.setSystemTime(t0 * 1000);
     mockedFetch.mockResolvedValueOnce([{ coord: COORD_A }]);
 
     renderHook(() =>
@@ -168,9 +184,10 @@ describe('useCacheNotifications', () => {
 
     // Coord set changes (a cache published mid-session) and an AppState
     // 'active' hop, ~1h later, re-arms the subscription. Jumping well past
-    // REFETCH_MIN_GAP_MS (10s) so the throttle doesn't swallow the refetch.
+    // REFETCH_MIN_GAP_MS (10s) + RESUME_REFETCH_DELAY_MS (3s) so both
+    // throttle and stagger resolve in this tick.
     const t1 = t0 + 3600;
-    (Date.now as jest.Mock).mockReturnValue(t1 * 1000);
+    jest.setSystemTime(t1 * 1000);
     mockedFetch.mockResolvedValueOnce([{ coord: COORD_A }, { coord: COORD_B }]);
 
     const appStateCall = (AppState.addEventListener as jest.Mock).mock.calls.find(
@@ -178,6 +195,9 @@ describe('useCacheNotifications', () => {
     );
     await act(async () => {
       appStateCall![1]('active');
+      // Resume-burst stagger (#554): the refetch is deferred by 3 s — advance
+      // past it so the coord fetch actually runs within this test.
+      jest.advanceTimersByTime(3_100);
     });
     await waitFor(() => expect(mockedFoundLogs).toHaveBeenCalledTimes(2));
 
@@ -194,6 +214,94 @@ describe('useCacheNotifications', () => {
     expect(mockedFire).toHaveBeenCalledWith(
       expect.objectContaining({ cacheCoord: COORD_B, title: 'New find on your cache' }),
     );
+  });
+});
+
+describe('resume-burst stagger (#554)', () => {
+  /** Extract the AppState 'change' listener registered by the hook. */
+  function getAppStateListener(): (s: string) => void {
+    const call = (AppState.addEventListener as jest.Mock).mock.calls.find((c) => c[0] === 'change');
+    return call![1];
+  }
+
+  it('does NOT call refetchAndRearm before 3 s after AppState active', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+    // Wait for the mount-time refetch so fetch-call-count is stable.
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1));
+
+    // Advance past REFETCH_MIN_GAP_MS (10 s) so the throttle won't block,
+    // then fire 'active' and advance to just BEFORE the 3 s stagger fires.
+    jest.advanceTimersByTime(10_100);
+    await act(async () => {
+      getAppStateListener()('active');
+      jest.advanceTimersByTime(2_900); // 2.9 s — stagger has NOT fired yet
+    });
+
+    // No second fetch should have been triggered yet (#554 — tap-dead wedge).
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('DOES call refetchAndRearm after the 3 s stagger elapses', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1));
+
+    jest.advanceTimersByTime(10_100); // past REFETCH_MIN_GAP_MS
+    await act(async () => {
+      getAppStateListener()('active');
+      jest.advanceTimersByTime(3_100); // past RESUME_REFETCH_DELAY_MS
+    });
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('cancels the stagger timer when the app re-backgrounds before it fires', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+    renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1));
+
+    jest.advanceTimersByTime(10_100); // past REFETCH_MIN_GAP_MS
+    const listener = getAppStateListener();
+
+    await act(async () => {
+      listener('active'); // stagger timer starts (3 s)
+      jest.advanceTimersByTime(1_500); // mid-stagger
+      listener('background'); // re-backgrounded — timer must be cleared
+      jest.advanceTimersByTime(3_000); // stagger would have fired here
+    });
+
+    // The re-background must have cancelled the timer: no second fetch.
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the stagger timer on unmount so it does not fire after teardown', async () => {
+    mockedFetch.mockResolvedValue([{ coord: COORD_A }]);
+    const { unmount } = renderHook(() =>
+      useCacheNotifications({ pubkey: VIEWER, getReadRelays: () => ['wss://relay'] }),
+    );
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1));
+
+    jest.advanceTimersByTime(10_100); // past REFETCH_MIN_GAP_MS
+    const listener = getAppStateListener();
+
+    await act(async () => {
+      listener('active'); // stagger timer starts
+      jest.advanceTimersByTime(1_500); // mid-stagger
+    });
+    // Unmount (effect cleanup) must clear the timer.
+    unmount();
+    await act(async () => {
+      jest.advanceTimersByTime(3_000); // stagger would have fired
+    });
+
+    // No second fetch should have run after unmount.
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/contexts/useCacheNotifications.ts
+++ b/src/contexts/useCacheNotifications.ts
@@ -68,6 +68,16 @@ const REFETCH_COORDS_INTERVAL_MS = 15 * 60_000;
 // resume, each otherwise firing an overlapping fetchCachesByAuthor that piles
 // onto the JS thread during warm re-foreground (#751 warm-path audit #5).
 const REFETCH_MIN_GAP_MS = 10_000;
+// Resume-burst stagger (#554). On AppState → active, five concurrent handlers
+// fire (DM re-arm, wallet refresh, relay reconnect, …). fetchCachesByAuthor
+// against 7 relays costs 3–5 s of JS-thread time and starves tap-dispatch
+// queued during the background pause — users tap UI that feels dead.
+// Cache-coord refetch is latency-insensitive (the live sub stays armed with
+// the previous coord set; the refetch only matters if a NEW cache was
+// published while backgrounded, which is rare). A 3 s stagger yields to the
+// latency-sensitive work (DM re-arm, wallet refresh) and keeps the bridge
+// responsive on resume.
+const RESUME_REFETCH_DELAY_MS = 3_000;
 
 // Per-surface notification copy. Comments and found-logs are separate
 // event kinds now, so the OS notification title should match what actually
@@ -265,12 +275,33 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
       }
     };
 
+    // Staggered-resume timer. Populated when AppState fires 'active'; cleared
+    // on unmount and on the NEXT AppState event (background→active bounce must
+    // not stack timers or fire after re-backgrounding — see #554).
+    let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+
     void refetchAndRearm();
     const interval = setInterval(() => {
       void refetchAndRearm();
     }, REFETCH_COORDS_INTERVAL_MS);
     const appStateSub = AppState.addEventListener('change', (s: AppStateStatus) => {
-      if (s === 'active') void refetchAndRearm();
+      // Cancel any pending stagger from a prior 'active' event — a quick
+      // active→background→active bounce must not stack timers or fire the
+      // stale timer after the app re-enters the background (#554).
+      if (resumeTimer !== null) {
+        clearTimeout(resumeTimer);
+        resumeTimer = null;
+      }
+      if (s !== 'active') return;
+      // Resume-burst stagger (#554): defer the coord refetch so it doesn't
+      // compete with latency-sensitive work (DM re-arm, wallet refresh) that
+      // fires concurrently on resume. Cache-coord refetch is not
+      // latency-sensitive — the live sub stays armed; the refetch matters
+      // only if a cache was published while backgrounded (rare).
+      resumeTimer = setTimeout(() => {
+        resumeTimer = null;
+        void refetchAndRearm();
+      }, RESUME_REFETCH_DELAY_MS);
     });
     // Event-driven re-arm: this device just published / edited / expired /
     // deleted one of its own caches (#1016) — refresh the coord set now.
@@ -280,6 +311,10 @@ export function useCacheNotifications(params: UseCacheNotificationsParams): void
 
     return () => {
       cancelled = true;
+      if (resumeTimer !== null) {
+        clearTimeout(resumeTimer);
+        resumeTimer = null;
+      }
       clearInterval(interval);
       appStateSub.remove();
       unsubOwnCaches();


### PR DESCRIPTION
## What / Why

Closes #554

On `AppState → active`, five independent handlers fire concurrently. The most expensive is `useCacheNotifications` calling `refetchAndRearm()` → `fetchCachesByAuthor` against 7 relays (3–5 s each), seizing the JS thread and starving bridge tap-dispatch. Users who wake the app from a long background pause find the UI completely unresponsive to taps for several seconds — the "tap-dead wedge".

The cache-coord refetch is **latency-insensitive**: the live subscription stays armed with the previous coord set; the refetch only matters if a cache was published from another device while the app was backgrounded (rare). A 3 s stagger lets the latency-sensitive work (DM re-arm, wallet refresh) clear first, restoring tap responsiveness immediately on resume.

## How

- Added `RESUME_REFETCH_DELAY_MS = 3_000` constant with a `WHY` comment explaining the trade-off.
- On `AppState 'active'`, schedule `refetchAndRearm()` via `setTimeout(…, RESUME_REFETCH_DELAY_MS)` instead of calling it immediately.
- Stored the timer in a `resumeTimer` local variable; clear it **on unmount** and **on any subsequent AppState change** so `active→background→active` bounces don't stack timers or fire after re-backgrounding.
- Updated tests to use `jest.useFakeTimers({ now })` so `Date.now()` advances with `advanceTimersByTime` — required for the `REFETCH_MIN_GAP_MS` throttle to be testable.
- Added four new unit tests: `does-not-fire-before-3s`, `fires-after-3s`, `cancelled-by-background`, `cancelled-by-unmount`.

## Follow-up candidates

Other `AppState → active` handlers in the app that are similarly non-latency-sensitive and could benefit from the same stagger treatment in a follow-up PR:

- `useMapMarkers` — re-fetches nearby cache pins on resume; the map itself is already visible before this completes.
- `useWalletPolling` — the 30 s safety-net poll that re-fires immediately on resume; a short stagger (1–2 s) would let the wallet's push-notification path settle first.
- `usePeerPresence` — re-pings relay presence on resume; presence staleness is tolerated for longer than 3 s elsewhere.

These are deliberately **not changed here** — this PR is scoped to the identified root cause for #554.

## Test plan

- [ ] Render the hook, fire `AppState 'active'`, advance timers 2.9 s → `fetchCachesByAuthor` must NOT have been called a second time.
- [ ] Advance to 3.1 s → `fetchCachesByAuthor` must NOW have been called a second time.
- [ ] Fire `active`, advance 1.5 s, fire `background`, advance 3 s → no second fetch (timer cancelled).
- [ ] Fire `active`, advance 1.5 s, unmount → advance 3 s → no second fetch (cleanup cancelled timer).
- [ ] All 10 unit tests pass: `npx jest src/contexts/useCacheNotifications.test.ts --no-coverage`
- [ ] Manual: background the app for >10 s, foreground it, and tap any button — should respond immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6Z2rpoHvJeiXw5beozBUa