### PR TITLE
perf(dm): send path uses the memoised secret key instead of hitting SecureStore per send (#1034)

### DIFF
--- a/src/contexts/useGroupMessaging.ts
+++ b/src/contexts/useGroupMessaging.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
-import * as SecureStore from 'expo-secure-store';
 import * as nostrService from '../services/nostrService';
 import * as amberService from '../services/amberService';
 import * as nostrConnectService from '../services/nostrConnectService';
+import { getMemoisedSecretKey } from './nostrSecretKeyCache';
 import { createGroupFileRumor } from '../services/nostrFileMessage';
 import type { EncryptedUpload } from '../services/imageUploadService';
 import type { RelayConfig, SignerType } from '../types/nostr';
-import { NSEC_KEY } from './nostrAuthKeys';
 
 /**
  * Provider-owned slices the group-messaging callbacks close over: the
@@ -94,9 +93,8 @@ export function useGroupMessaging(options: UseGroupMessagingOptions): UseGroupMe
             });
 
         if (signerType === 'nsec') {
-          const nsec = await SecureStore.getItemAsync(NSEC_KEY);
-          if (!nsec) return { success: false, error: 'Key not found' };
-          const { secretKey } = nostrService.decodeNsec(nsec);
+          const secretKey = await getMemoisedSecretKey(pubkey!);
+          if (!secretKey) return { success: false, error: 'Key not found' };
           const result = await nostrService.sendNip17ToManyWithNsec({
             senderSecretKey: secretKey,
             rumor,
@@ -234,9 +232,8 @@ export function useGroupMessaging(options: UseGroupMessagingOptions): UseGroupMe
         });
 
         if (signerType === 'nsec') {
-          const nsec = await SecureStore.getItemAsync(NSEC_KEY);
-          if (!nsec) return { success: false, error: 'Key not found' };
-          const { secretKey } = nostrService.decodeNsec(nsec);
+          const secretKey = await getMemoisedSecretKey(pubkey!);
+          if (!secretKey) return { success: false, error: 'Key not found' };
           await nostrService.signAndPublishEvent(event, secretKey, targetRelays);
           return { success: true };
         }

--- a/src/contexts/useGroupMessaging.ts
+++ b/src/contexts/useGroupMessaging.ts
@@ -93,7 +93,7 @@ export function useGroupMessaging(options: UseGroupMessagingOptions): UseGroupMe
             });
 
         if (signerType === 'nsec') {
-          const secretKey = await getMemoisedSecretKey(pubkey!);
+          const secretKey = await getMemoisedSecretKey(pubkey);
           if (!secretKey) return { success: false, error: 'Key not found' };
           const result = await nostrService.sendNip17ToManyWithNsec({
             senderSecretKey: secretKey,
@@ -232,7 +232,7 @@ export function useGroupMessaging(options: UseGroupMessagingOptions): UseGroupMe
         });
 
         if (signerType === 'nsec') {
-          const secretKey = await getMemoisedSecretKey(pubkey!);
+          const secretKey = await getMemoisedSecretKey(pubkey);
           if (!secretKey) return { success: false, error: 'Key not found' };
           await nostrService.signAndPublishEvent(event, secretKey, targetRelays);
           return { success: true };

--- a/src/contexts/useMessageSend.ts
+++ b/src/contexts/useMessageSend.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
-import * as SecureStore from 'expo-secure-store';
 import * as nostrService from '../services/nostrService';
 import * as amberService from '../services/amberService';
 import * as nostrConnectService from '../services/nostrConnectService';
-import { NSEC_KEY } from './nostrAuthKeys';
+import { getMemoisedSecretKey } from './nostrSecretKeyCache';
 import { createFileMessageRumor } from '../services/nostrFileMessage';
 import { directMessageRumorEventId } from '../services/dmRumorId';
 import { NWC_SHARE_KIND, serializeNwcShare, type NwcShareCard } from '../utils/nwcShareMessage';
@@ -106,9 +105,8 @@ export function useMessageSend({ pubkey, isLoggedIn, signerType, relays }: UseMe
         hooks?.onRumorReady?.({ eventId, kind: rumor.kind, relays: targetRelays });
 
         if (signerType === 'nsec') {
-          const nsec = await SecureStore.getItemAsync(NSEC_KEY);
-          if (!nsec) return { success: false, error: 'Key not found' };
-          const { secretKey } = nostrService.decodeNsec(nsec);
+          const secretKey = await getMemoisedSecretKey(pubkey);
+          if (!secretKey) return { success: false, error: 'Key not found' };
           const result = await nostrService.sendNip17ToManyWithNsec({
             senderSecretKey: secretKey,
             rumor,
@@ -227,9 +225,8 @@ export function useMessageSend({ pubkey, isLoggedIn, signerType, relays }: UseMe
         hooks?.onRumorReady?.({ eventId, kind: rumor.kind, relays: targetRelays });
 
         if (signerType === 'nsec') {
-          const nsec = await SecureStore.getItemAsync(NSEC_KEY);
-          if (!nsec) return { success: false, error: 'Key not found' };
-          const { secretKey } = nostrService.decodeNsec(nsec);
+          const secretKey = await getMemoisedSecretKey(pubkey);
+          if (!secretKey) return { success: false, error: 'Key not found' };
           const result = await nostrService.sendNip17ToManyWithNsec({
             senderSecretKey: secretKey,
             rumor,
@@ -309,9 +306,8 @@ export function useMessageSend({ pubkey, isLoggedIn, signerType, relays }: UseMe
         });
 
         if (signerType === 'nsec') {
-          const nsec = await SecureStore.getItemAsync(NSEC_KEY);
-          if (!nsec) return { success: false, error: 'Key not found' };
-          const { secretKey } = nostrService.decodeNsec(nsec);
+          const secretKey = await getMemoisedSecretKey(pubkey);
+          if (!secretKey) return { success: false, error: 'Key not found' };
           const result = await nostrService.sendNip17ToManyWithNsec({
             senderSecretKey: secretKey,
             rumor,
@@ -435,9 +431,8 @@ export function useMessageSend({ pubkey, isLoggedIn, signerType, relays }: UseMe
         };
 
         if (signerType === 'nsec') {
-          const nsec = await SecureStore.getItemAsync(NSEC_KEY);
-          if (!nsec) return { success: false, error: 'Key not found' };
-          const { secretKey } = nostrService.decodeNsec(nsec);
+          const secretKey = await getMemoisedSecretKey(pubkey);
+          if (!secretKey) return { success: false, error: 'Key not found' };
           const result = await nostrService.sendNip17ToManyWithNsec({
             senderSecretKey: secretKey,
             rumor,


### PR DESCRIPTION
## Summary

Closes #1034

The receive path (`nostrLiveDmSub`, `inboxNip17Ingest`, `nostrFetchConversation`, `useDmInbox`) already uses `getMemoisedSecretKey` from `nostrSecretKeyCache.ts` — reading disk + bech32-decoding only once per login, then serving from a module-scope `{ pubkey, secretKey }` memo. The send path was still hitting `SecureStore.getItemAsync(NSEC_KEY)` + `nostrService.decodeNsec(nsec)` on **every** send (~5–30 ms cold KeyStore read + a native bridge hop each time).

**Call sites migrated:**

| File | Function | Before | After |
|---|---|---|---|
| `useMessageSend.ts` | `sendDirectMessage` | `SecureStore.getItemAsync` + `decodeNsec` | `getMemoisedSecretKey(pubkey)` |
| `useMessageSend.ts` | `sendDirectRumor` | `SecureStore.getItemAsync` + `decodeNsec` | `getMemoisedSecretKey(pubkey)` |
| `useMessageSend.ts` | `sendFileMessage` | `SecureStore.getItemAsync` + `decodeNsec` | `getMemoisedSecretKey(pubkey)` |
| `useMessageSend.ts` | `sendNwcShare` | `SecureStore.getItemAsync` + `decodeNsec` | `getMemoisedSecretKey(pubkey)` |
| `useGroupMessaging.ts` | `sendGroupMessage` | `SecureStore.getItemAsync` + `decodeNsec` | `getMemoisedSecretKey(pubkey)` |
| `useGroupMessaging.ts` | `publishGroupState` | `SecureStore.getItemAsync` + `decodeNsec` | `getMemoisedSecretKey(pubkey)` |

**Cache invalidation:** `clearMemoisedSecretKey()` is already called in `NostrContext` on both logout (line 1193) and account-switch (line 1330), so the cached key is always evicted before a new identity's sends run. No gap in the send path's assumptions.

**Null/error semantics unchanged:** `getMemoisedSecretKey` returns `null` when SecureStore has no entry or the stored key belongs to a different pubkey — the same condition the previous code guarded against with `if (!nsec)`. Both paths return `{ success: false, error: 'Key not found' }`.

`expo-secure-store` and `NSEC_KEY` imports removed from both files (no longer needed).

## Test plan

- [ ] All 188 tests in `src/contexts/` pass (`npx jest src/contexts/ --no-coverage`)
- [ ] All 4 tests in `useConversationComposerActions.test.tsx` pass
- [ ] `tsc --noEmit` — no new errors beyond the pre-existing `WalletCardPicker.tsx` baseline
- [ ] `eslint` — clean on both changed files
- [ ] `prettier --check` — clean on both changed files
- [ ] Manual: send a DM as nsec user — message delivers as before (no regression)
- [ ] Manual: send a group message as nsec user — delivers as before
- [ ] Manual: logout and re-login — send still works (cache correctly invalidated and repopulated)