### PR TITLE
ci(perf): gate perf anti-patterns; codify the performance authoring rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: bash scripts/check-file-size.sh
+
+  perf-antipatterns:
+    name: Perf anti-patterns
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-perf-antipatterns.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,21 @@
 - Use the branded `Alert` from `src/components/BrandedAlert.tsx`, not React Native's native `Alert.alert` — the branded one matches the app's theme (pink/blue) and is testable via `id: 'branded-alert-button-N'` in Maestro flows. ESLint enforces this via `no-restricted-imports`.
 - Use the branded `Toast` from `src/components/BrandedToast.tsx`, not `react-native-toast-message` directly — matches the app's pink/blue theme. ESLint enforces this via `no-restricted-imports`.
 
+## Performance rules
+
+Everything below exists because the app runs on ONE JS thread — relay events, crypto, and tap dispatch all queue behind each other (see #554's dead-tap wedge). `bash scripts/check-perf-antipatterns.sh` gates the mechanical rules in CI (grandfathered baseline — shrink counts, never grow them). Full rationale + the audit methodology: `docs/PERFORMANCE.adoc` → "Authoring best practices".
+
+- **Never `setState` per relay/emitter event.** Batch ingest through `src/utils/useCoalescedMap.ts` (≤150 ms coalesced flush). Per-event `new Map(prev)` clones are CI-gated.
+- **Screens arm subscriptions with `useFocusEffect`**, never bare `useEffect` — blurred tabs must not keep relay subs alive. One hook instance owns a subscription; sibling screens receive data via params/context, never a duplicate sub (#1028).
+- **AppState `active` handlers stagger.** Only latency-sensitive work (DM re-arm) fires immediately on resume; everything else (cache refetches, polls) schedules via a cancellable ~3 s `setTimeout` (pattern: `useCacheNotifications`, #554/#1031). Never add an unstaggered resume handler.
+- **Relay filters are always bounded** — `limit` plus a `since` window where semantics allow. Exception: kind-1059 gift wraps must NOT use `since` (NIP-59 randomises `created_at` up to 48 h back — #469); bound those by `limit` and reconcile on re-arm.
+- **Heavy loops yield.** Multi-recipient crypto / batch decrypt uses the budget-gated `createYieldScheduler` (`src/services/nostrDecryptPacing.ts`) between units — not unconditional `yieldToEventLoop()` (a forced 16 ms RAF per item).
+- **List rows are `React.memo`'d** with stable props; images in lists use `expo-image` with `cachePolicy="memory-disk"` (bare react-native `Image` is CI-gated); long lists use `FlatList`/`FlashList` with `keyExtractor`, never `ScrollView` over unbounded data.
+- **Context provider `value`s are `useMemo`'d, handlers `useCallback`'d** — one inline object literal re-renders every consumer.
+- **New screens are `lazyScreen`'d** in `AppNavigator`; heavy native modules never import eagerly from tab screens.
+- **Don't add crypto to hot paths.** All Nostr crypto is pure-JS today; the fix is the native pipeline (epic #1036, Stage 1 JSI crypto → Stage 2 rust-nostr engine via the bdk-rn UniFFI pattern), not more JS-thread work.
+- **Perf-sensitive PRs prove it:** `[PerfBlock]` markers (preview builds set `EXPO_PUBLIC_KEEP_PERF_LOGS=1`) or a `scripts/perf-*.sh` p50/p95 before/after in the PR body. Perf reviews go to Stevie (T-Minus-15 plugin agent).
+
 ## Signers
 
 The app supports three Nostr signers, branched on `signerType` in `NostrContext.tsx`:

--- a/docs/PERFORMANCE.adoc
+++ b/docs/PERFORMANCE.adoc
@@ -395,6 +395,81 @@ real behaviour.
 - CI-driven regression gating is *out of scope* for now per #611's revised
   dev-only scope.
 
+== Authoring best practices (the rules)
+
+The condensed version lives in `CLAUDE.md` -> "Performance rules" (what every
+contributor and agent reads); this section carries the rationale. The
+mechanical subset is CI-gated by `scripts/check-perf-antipatterns.sh`
+(grandfathered per-file baseline, mirroring `check-file-size.sh` - shrink the
+counts, never grow them). The rules map 1:1 onto Stevie's 12-category audit,
+so a clean audit and a rule-following codebase are the same thing.
+
+[cols="1,3,2"]
+|===
+|Rule |Why |Canonical example
+
+|Batch event ingest (never per-event `setState`)
+|A relay burst delivers 50+ events synchronously; a `new Map(prev)` clone per
+event is O(N) copy + React commit x50, pinning the JS thread for seconds
+(#554's wedge mechanism).
+|`src/utils/useCoalescedMap.ts` (<=150 ms coalesced flush; leading-edge for
+the first event)
+
+|Focus-gated subscriptions, one owner per dataset
+|Blurred tabs holding live relay subs waste JS-thread parse work forever;
+sibling screens opening duplicate subs double it.
+|`useFocusEffect` arming in `useHuntCommunity`; data-via-params fix in #1028
+
+|Staggered resume handlers
+|Five independent `AppState 'active'` handlers firing concurrently after a
+long Doze is the #554 storm. Latency-insensitive work waits ~3 s (cancellable
+timer); only the DM re-arm is immediate.
+|`useCacheNotifications` stagger (#1031)
+
+|Bounded relay filters
+|An unbounded REQ backfills the relay's whole index through the JS thread on
+every mount. Always `limit`, plus `since` where event semantics allow. NIP-59
+gift wraps randomise `created_at` up to 48 h back, so kind-1059 must NOT use
+`since` (#469) - bound by `limit` and reconcile on re-arm instead.
+|30-day window on recent-caches queries (#1029)
+
+|Budget-gated yielding in heavy loops
+|An unconditional `yieldToEventLoop()` costs a 16 ms RAF per item - 3x the
+cost of the work it paces on single items. The scheduler yields only when the
+~4 ms frame budget is spent.
+|`createYieldScheduler` (`src/services/nostrDecryptPacing.ts`)
+
+|Memoised rows, expo-image, virtualized lists
+|Unmemoised rows re-execute the whole list per trickling profile fetch; bare
+RN `Image` re-decodes per mount; `ScrollView` renders everything eagerly.
+|`React.memo(LeaderboardRow)` (#1028); `expo-image` +
+`cachePolicy="memory-disk"`
+
+|Memoised context values
+|One inline `value={{...}}` literal re-renders every consumer on every parent
+render - the classic invisible cascade.
+|`NostrContext` / `WalletContext` provider values
+
+|Lazy screens
+|Eager imports of detail screens put their parse cost (and their native-module
+imports) on cold start.
+|`lazyScreen(...)` in `AppNavigator.tsx`
+
+|No new crypto on the JS thread
+|All Nostr crypto is pure-JS (`nostr-tools` + `@noble/*`) today: 2x NIP-44
+decrypts per received wrap, 2x(N+1) sign+encrypt per group send. The ceiling
+fix is native (epic #1036: Stage 1 JSI crypto primitives, Stage 2 rust-nostr
+engine via the bdk-rn UniFFI pattern - one Rust core, generated Kotlin AND
+Swift bindings). Until then, treat every added crypto call in a hot path as a
+regression.
+|`bdk-rn` as the in-repo precedent
+
+|Prove perf-sensitive changes
+|Means hide regressions; a claim without p50/p95 is a vibe.
+|`[PerfBlock]` markers (preview builds), `scripts/perf-*.sh` before/after in
+the PR body
+|===
+
 == Stevie's project notes (plugin agent)
 
 The performance-audit agent *Stevie the Speedster* now ships generically in

--- a/scripts/check-perf-antipatterns.sh
+++ b/scripts/check-perf-antipatterns.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Enforce the mechanically-greppable subset of the performance authoring rules
+# (CLAUDE.md → Performance rules; docs/PERFORMANCE.adoc → Authoring best
+# practices). Two checks:
+#
+#   1. Per-event Map clones (`new Map(prev`) outside `src/utils/useCoalescedMap.ts`
+#      — cloning a Map inside a relay-subscription / event callback fires an
+#      O(N) copy + React commit PER EVENT; a burst of 50 events pins the JS
+#      thread. The sanctioned pattern is `useCoalescedMap` (which is exempt —
+#      its internal clone runs once per ≤150 ms flush, not per event).
+#
+#   2. `Image` imported from 'react-native' — hot lists must use `expo-image`
+#      (`cachePolicy="memory-disk"`); bare RN Image re-decodes on every mount.
+#
+# Grandfather-aware, mirroring check-file-size.sh: existing occurrences are
+# baselined per file and MUST NOT GROW. Shrink counts over time; delete the
+# entry at zero; never raise a number. New files with either pattern fail.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Check 1: per-event Map clones
+declare -A MAP_CLONE_BASELINE=(
+  ["src/contexts/LiveLocationContext.tsx"]=1
+  ["src/screens/EventsScreen.tsx"]=1
+  ["src/screens/ExploreHomeScreen.tsx"]=3
+  ["src/screens/HuntPiggyDetailScreen.tsx"]=3
+  ["src/screens/HuntScreen.tsx"]=2
+  ["src/screens/MessagesScreen.tsx"]=1
+  ["src/screens/MyPigletsScreen.tsx"]=3
+)
+
+# Check 2: react-native Image imports
+declare -A RN_IMAGE_BASELINE=(
+  ["src/components/BootSplash.tsx"]=1
+  ["src/components/DecryptedImage.tsx"]=1
+  ["src/components/HuntRecentlyAddedSection.tsx"]=1
+  ["src/components/WalletCard.tsx"]=1
+  ["src/screens/account/ProfileScreen.tsx"]=1
+  ["src/screens/CourseDetailScreen.tsx"]=1
+  ["src/screens/LessonsScreen.tsx"]=1
+  ["src/screens/MissionDetailScreen.tsx"]=1
+  ["src/screens/UnsupportedEntityScreen.tsx"]=1
+)
+
+emit_error() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::error file=$1::$2"; else echo "ERROR: $1 — $2"; fi
+}
+
+fail=0
+
+check_pattern() {
+  # $1 = check name, $2 = grep output "file:count" lines, $3 = baseline array name, $4 = fix hint
+  local name="$1" hint="$4"
+  local -n baseline="$3"
+  while IFS=: read -r f count; do
+    [ -n "$f" ] || continue
+    local base="${baseline[$f]:-0}"
+    if [ "$count" -gt "$base" ]; then
+      emit_error "$f" "$name: $count occurrence(s), baseline allows $base. $hint"
+      fail=1
+    fi
+  done <<< "$2"
+}
+
+# Count occurrences per tracked source file (tests excluded — test fixtures may
+# legitimately build Maps).
+map_clones=$(git ls-files 'src/**/*.ts' 'src/**/*.tsx' \
+  | grep -v '\.test\.' | grep -v '^src/utils/useCoalescedMap\.ts$' \
+  | xargs grep -c "new Map(prev" 2>/dev/null | grep -v ':0$' || true)
+check_pattern "per-event Map clone" "$map_clones" MAP_CLONE_BASELINE \
+  "Batch relay/event ingest with src/utils/useCoalescedMap.ts instead of cloning per event."
+
+rn_images=$(git ls-files 'src/**/*.tsx' \
+  | grep -v '\.test\.' \
+  | xargs grep -cE "^import[^;]*[{,][[:space:]]*Image[[:space:],}][^;]*from 'react-native'" 2>/dev/null \
+  | grep -v ':0$' || true)
+check_pattern "react-native Image import" "$rn_images" RN_IMAGE_BASELINE \
+  "Use expo-image with cachePolicy=\"memory-disk\" (see docs/PERFORMANCE.adoc)."
+
+if [ "$fail" -eq 0 ]; then
+  echo "perf anti-pattern gate: OK"
+fi
+exit "$fail"

--- a/scripts/check-perf-antipatterns.sh
+++ b/scripts/check-perf-antipatterns.sh
@@ -29,16 +29,29 @@ declare -A MAP_CLONE_BASELINE=(
   ["src/screens/MyPigletsScreen.tsx"]=3
 )
 
-# Check 2: react-native Image imports
+# Check 2: react-native Image imports (multi-line aware — full sweep 2026-07-11)
 declare -A RN_IMAGE_BASELINE=(
+  ["src/components/AddWalletWizard.tsx"]=1
   ["src/components/BootSplash.tsx"]=1
   ["src/components/DecryptedImage.tsx"]=1
   ["src/components/HuntRecentlyAddedSection.tsx"]=1
+  ["src/components/TransferSheet.tsx"]=1
   ["src/components/WalletCard.tsx"]=1
+  ["src/screens/account/AboutScreen.tsx"]=1
+  ["src/screens/account/AccountScreenLayout.tsx"]=1
   ["src/screens/account/ProfileScreen.tsx"]=1
   ["src/screens/CourseDetailScreen.tsx"]=1
+  ["src/screens/EventDetailScreen.tsx"]=1
+  ["src/screens/EventsScreen.tsx"]=1
+  ["src/screens/ExploreHomeScreen.tsx"]=1
+  ["src/screens/GroupsScreen.tsx"]=1
+  ["src/screens/HomeScreen.tsx"]=1
+  ["src/screens/HuntCreateScreen.tsx"]=1
+  ["src/screens/HuntPiggyDetailScreen.tsx"]=1
+  ["src/screens/HuntScreen.tsx"]=1
   ["src/screens/LessonsScreen.tsx"]=1
   ["src/screens/MissionDetailScreen.tsx"]=1
+  ["src/screens/MyPigletsScreen.tsx"]=1
   ["src/screens/UnsupportedEntityScreen.tsx"]=1
 )
 
@@ -70,9 +83,12 @@ map_clones=$(git ls-files 'src/**/*.ts' 'src/**/*.tsx' \
 check_pattern "per-event Map clone" "$map_clones" MAP_CLONE_BASELINE \
   "Batch relay/event ingest with src/utils/useCoalescedMap.ts instead of cloning per event."
 
+# Multi-line aware (Prettier wraps long RN import lists): slurp each file
+# (-0777) and count import statements whose brace list contains a bare
+# `Image` token and whose module specifier is 'react-native'.
 rn_images=$(git ls-files 'src/**/*.tsx' \
   | grep -v '\.test\.' \
-  | xargs grep -cE "^import[^;]*[{,][[:space:]]*Image[[:space:],}][^;]*from 'react-native'" 2>/dev/null \
+  | xargs perl -0777 -ne "my \$c = () = /import[^;]*?\{[^}]*\bImage\b[^}]*\}[^;]*?from\s*'react-native'/gs; print \"\$ARGV:\$c\n\"" 2>/dev/null \
   | grep -v ':0$' || true)
 check_pattern "react-native Image import" "$rn_images" RN_IMAGE_BASELINE \
   "Use expo-image with cachePolicy=\"memory-disk\" (see docs/PERFORMANCE.adoc)."


### PR DESCRIPTION
Ben's directive: build this app to performance best practice as a standing discipline. This PR turns the discipline into repo machinery (the architecture ceiling is epic #1036):

## What

1. **CLAUDE.md → "Performance rules"** — the condensed single-JS-thread authoring rules every contributor and agent reads each session: coalesced event ingest, focus-gated single-owner subscriptions, staggered AppState resume handlers, bounded relay filters (with the NIP-59 no-`since` exception from #469), budget-gated yields, memoised rows/context values, lazy screens, no new hot-path crypto, and p50/p95 proof on perf-sensitive PRs.
2. **docs/PERFORMANCE.adoc → "Authoring best practices"** — the same rules with rationale and canonical in-repo examples, mapped 1:1 onto Stevie's 12-category audit so "clean audit" and "rules followed" are the same statement.
3. **`scripts/check-perf-antipatterns.sh` + CI job** — grep-gates the two mechanically-checkable rules, with a grandfathered per-file baseline (mirroring `check-file-size.sh`: shrink, never grow; new files start at zero):
   - per-event `new Map(prev` clones (the #554 wedge mechanism) — `useCoalescedMap.ts` itself exempt as the sanctioned home
   - bare `Image` imports from react-native (must be `expo-image` in hot lists)

## Test plan

- [x] `bash scripts/check-perf-antipatterns.sh` passes at the current baseline
- [x] Negative test: adding a `new Map(prev` to a clean file fails the gate with a `::error` annotation, and passes again after revert
- [x] `bash scripts/check-file-size.sh` still passes (docs/CLAUDE.md changes don't affect it)
- [x] CI job wired beside the file-size job in ci.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6Z2rpoHvJeiXw5beozBUa