### PR TITLE
fix(i18n): add missing uk conversationScreen.typing — unbreaks TypeScript on main

### DIFF
--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -287,7 +287,8 @@
     "zapUnavailable": "Надіслати zap (недоступно — у співрозмовника немає адреси Lightning)",
     "closeFullscreenGif": "Закрити повноекранний GIF",
     "shareContactTitle": "Поділитися контактом з {{name}}",
-    "shareContactSubtitle": "Вони побачать це як картку профілю Nostr, яку можна відкрити."
+    "shareContactSubtitle": "Вони побачать це як картку профілю Nostr, яку можна відкрити.",
+    "typing": "друкує…"
   },
   "courseDetailScreen": {
     "courseNotFound": "Курс не знайдено",


### PR DESCRIPTION
Closes #992's follow-up gap: the typing-indicator PR added `conversationScreen.typing` to `en.json` and `es.json` but not `uk.json`, so the locale type check fails on main's own HEAD and blocks CI on every open PR.

One line: `"typing": "друкує…"` mirroring the en/es placement.

## Test plan

- [x] `npx tsc --noEmit` passes locally with the key added (fails without it)
- [x] `uk.json` parses as valid JSON; Prettier clean