### PR TITLE
chore(release): v1.3.17

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -17,7 +17,7 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 - **App language is now its own setting.** Account → **Language** (moved out of Appearance) — switch between System / English / Español / Українська.
 - **"Typing…" in chats.** You'll see when the other person is typing in a 1:1 message thread.
 - **Tabbed leaderboard.** Explore → Geo-caches → Leaderboard now has **Top hiders** / **Top finders** tabs instead of one long list.
-- **The Geo-caches map scrolls with the page**, and Nearby merchants is a horizontal rail — the map no longer takes up a fixed chunk of the screen.
+- **The Geo-caches map scrolls with the page**, and Nearby merchants now show in a horizontal rail — the map no longer takes up a fixed chunk of the screen.
 - **Experimental (testers): native crypto.** Account → Nostr → **Experimental** has a "Native crypto (rust-nostr)" switch. Turning it on (Android only, restart to apply) runs message encryption and signature checks through a native module instead of JavaScript — much faster on busy inboxes. Watch for anything odd in messaging and turn it back off if so. Off by default; the row shows "Unavailable on this device" where it can't run.
 
 ### Improved

--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -14,20 +14,20 @@ See docs/DEPLOYMENT.adoc → "TestFlight 'What to Test' automation".
 
 ### New
 
-- **Hunt community sections.** The Geo-caches screen now shows "Recently added" and "Recently found" rails, plus a Leaderboard page (top hiders and top finders) — Explore → Geo-caches → scroll down.
-- **Cover-flow card picker.** Wallet Settings → Card Design is now a swipeable cover-flow of all card themes.
-- **AI Robot wallet card.** A new chrome-and-green robot design in the card picker.
+- **App language is now its own setting.** Account → **Language** (moved out of Appearance) — switch between System / English / Español / Українська.
+- **"Typing…" in chats.** You'll see when the other person is typing in a 1:1 message thread.
+- **Tabbed leaderboard.** Explore → Geo-caches → Leaderboard now has **Top hiders** / **Top finders** tabs instead of one long list.
+- **The Geo-caches map scrolls with the page**, and Nearby merchants is a horizontal rail — the map no longer takes up a fixed chunk of the screen.
+- **Experimental (testers): native crypto.** Account → Nostr → **Experimental** has a "Native crypto (rust-nostr)" switch. Turning it on (Android only, restart to apply) runs message encryption and signature checks through a native module instead of JavaScript — much faster on busy inboxes. Watch for anything odd in messaging and turn it back off if so. Off by default; the row shows "Unavailable on this device" where it can't run.
 
 ### Improved
 
-- Settings screens (Security, On-chain, Nearby merchants) now use white section icons and brand-pink toggles and selected rows.
-- Home feels snappier — wallet refreshes that change nothing no longer rebuild the transaction list.
-- Explore map pans more smoothly (marker layers no longer re-render on every GPS fix).
-- Group messages appear in the thread instantly when you hit send.
+- **Group messages appear the instant you hit send** — no waiting for encryption to finish first.
+- **Snappier taps after the app wakes up** from a long time in the background.
+- **Sending is faster** — the app no longer re-reads your key from secure storage on every message.
+- **Geo-cache pages are smoother** as recently-added / recently-found and their icons stream in.
 
 ### Fixed
 
-- Tapping a sent group message no longer shows a false "Send failed" dialog — delivered messages now read "Message sent".
-- Geo-caches hidden in Lightning Piggy now always show the Piglet icon and pink map pin, even when they have no prize attached (existing caches fix themselves, no republish needed).
-- The app responds to taps immediately after waking from a long background pause.
-- Messages sent while the app was asleep now appear as soon as it reconnects, not just when you open the Messages tab.
+- **Messages sent while your app was asleep now arrive as soon as it reconnects**, instead of only when you open the Messages tab.
+- Ukrainian: the "typing…" label is now translated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-piggy-app",
-      "version": "1.3.16",
+      "version": "1.3.17",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-piggy-app",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "main": "index.ts",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Release prep for v1.3.17: version bump (1.3.16 → 1.3.17) + What-to-Test notes.

Ships everything merged since v1.3.16 (17 PRs): the full native crypto pipeline behind default-off flags (module #1054, engine #1062, tester toggle #1061), Language moved to its own section (#1060), tabbed leaderboard (#1043), map-scroll + Nearby rail on Geo-caches (#1044, #1050), typing indicator (#992), and the perf batch (group optimistic bubble #1040, receive-yields + reconnect #1039, resume stagger #1031, memoised send key #1037, found-log coalescing #1032, leaderboard data reuse #1030).

Native crypto/engine are **off by default** (`EXPO_PUBLIC_NATIVE_CRYPTO` / `EXPO_PUBLIC_NATIVE_ENGINE` unset) — production behaviour is unchanged; testers opt in via the new Settings toggle.

No linked issue — release chore (matches #1027, #1000).

## Test plan

N/A — release chore (version bump + What-to-Test notes). App changes were tested in their own PRs; the release workflow validates the tag → package.json flow.